### PR TITLE
refactor(templates): collapse the backend branching

### DIFF
--- a/.claude/skills/DOCTRINE.md
+++ b/.claude/skills/DOCTRINE.md
@@ -1,4 +1,4 @@
-<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=86b5739b0514 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=f1e26579efc6 — managed by the-cycle; edit the template, not this file -->
 # Pipeline doctrine (shared)
 
 Single source of truth for the rules the the-cycle work-loop skills share. A skill that says
@@ -26,7 +26,8 @@ Why / Touches / Acceptance; routing lives on the board (§3). **Milestones = epi
 
 **Ranking pickable work** (`/next`): **milestone first** (a real numbered epic beats no milestone), then **issue number** (lower first).
 
-**A closed issue is "done."** `Closes #<n>` closes the issue on merge. If the board has no closed→Done automation, set Status explicitly after the merge lands. The pipeline doesn't argue with the
+**A closed issue is "done."** `Closes #<n>` closes the issue on merge. If the board has no
+closed→Done automation, set Status explicitly after the merge lands. The pipeline doesn't argue with the
 close; it lets the close speak.
 
 **A stale-*open* issue may already be shipped.** An umbrella/parent issue's slices often ship
@@ -122,7 +123,9 @@ harness-blocked):
 (until gh pr checks "<pr>" >/dev/null 2>&1; do sleep 5; done; gh pr checks "<pr>" --watch --fail-fast && gh pr merge "<pr>" --squash --delete-branch) &
 ```
 
-Closing rides on the PR body's `Closes #<n>` keyword — GitHub fires it anywhere in the body regardless of surrounding prose (§8), so a multi-phase PR must never place that token next to an issue number it shouldn't close.
+Closing rides on the PR body's `Closes #<n>` keyword — GitHub fires it anywhere in the body
+regardless of surrounding prose (§8), so a multi-phase PR must never place that token next to an
+issue number it shouldn't close.
 
 **Reading a red gate.** Logs come from `gh run view "<run>" --log`.
 `gh run view "<run>" --log-failed`
@@ -143,7 +146,11 @@ other workarounds.
 
 ## §7 Tracker mechanics
 
-Routing values are Project fields on the board item, not labels. `gh project item-list` returns `content` (`.number`, `.title`, `.url`, `.body`) alongside `status` and any custom fields. item-list carries no open/closed state, so intersect with `gh issue list --state open` on `number` — a closed item can linger on the board until archived, and this also catches an open issue not yet added to the board.
+Routing values are Project fields on the board item, not labels. `gh project item-list 1 --owner brndnsh-labs --format json` returns
+`content` (`.number`, `.title`, `.url`, `.body`) alongside `status` and any custom fields. It
+carries no open/closed state, so intersect with `gh issue list --state open --json number,title,labels,milestone,url` on `number` — a closed item can
+linger on the board until archived, and this also catches an open issue not yet added to the
+board.
 
 - **Read the tracker:** `gh issue list --state open --json number,title,labels,milestone,url`
 - **Read one issue:** `gh issue view "<n>" --json number,title,state,url,labels,milestone,body`

--- a/.claude/skills/intake/SKILL.md
+++ b/.claude/skills/intake/SKILL.md
@@ -2,7 +2,7 @@
 name: intake
 description: The front door to the backlog — turn a plain-English idea into an actionable the-cycle issue. Interviews Brandon ONE question at a time until the issue is genuinely implementable, then drafts it, classifies it, and files it. Plan-first — always shows the shaped issue before writing. Shares /scout's filing mechanics (DOCTRINE §10). Usage `/intake <the idea>` (or bare, and it'll ask).
 ---
-<!-- cycle:rendered template=skills/intake.md.tmpl hash=abb524bfb6ac — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/intake.md.tmpl hash=c4f1720bf172 — managed by the-cycle; edit the template, not this file -->
 
 # /intake — turn an idea into an actionable issue
 
@@ -63,7 +63,7 @@ options, recommendation first) — never to fire several at once.
 
 5. **File it** (§7): `gh issue create --title "<title>" --body "<body>" --label "<label>"` — the label is a §2 workflow
    label describing *what kind of work it is* (`bug` and the `area:*` set), never a routing value:
-   §10.5 leaves routing to the picking skill. No fitting label is fine; file it bare., then
+   §10.5 leaves routing to the picking skill. No fitting label is fine; file it bare, then
    add it to the board and set Status: `node scripts/gh-project.mjs status "<n>" "Ready"`.
    Batch the field writes into one call (§7).
 

--- a/.cycle/state.json
+++ b/.cycle/state.json
@@ -1,14 +1,14 @@
 {
-  "upstream": "fa88bbf-dirty",
+  "upstream": "0f642f0-dirty",
   "files": {
-    ".claude/skills/DOCTRINE.md": "86b5739b0514",
+    ".claude/skills/DOCTRINE.md": "f1e26579efc6",
     ".claude/skills/cycle/SKILL.md": "7df092de0d13",
     ".claude/skills/implement/SKILL.md": "b69023538a4f",
     ".claude/skills/review/SKILL.md": "8fe508eb864d",
     ".claude/skills/patch/SKILL.md": "9e6d8f48e728",
     ".claude/skills/done/SKILL.md": "bd458933c244",
     ".claude/skills/next/SKILL.md": "cb66d479235e",
-    ".claude/skills/intake/SKILL.md": "abb524bfb6ac",
+    ".claude/skills/intake/SKILL.md": "c4f1720bf172",
     ".claude/skills/scout/SKILL.md": "c6bda433419b",
     ".claude/skills/burndown/SKILL.md": "78bcf07bafb2",
     ".claude/skills/dep-update/SKILL.md": "b491f8fb56b8",

--- a/backends/github.jsonc
+++ b/backends/github.jsonc
@@ -8,16 +8,11 @@
   "name": "github",
 
   "semantics": {
-    // There IS a board, and an issue must be added to it to carry field values.
-    "has_board": true,
-    // `gh run view --log` works; no wrapper needed.
-    "job_logs": "api",
-    // `gh run view --log-failed` shows the failed steps of ONE run — it does not search
-    // back for the most recent failing run. Skills must list runs first and pass an id.
-    "job_logs_search": false,
     // `gh pr merge --auto` is correct ONLY with branch protection — without it the
     // merge fires immediately with nothing to wait on. Repos without protection use
-    // the poll-then-merge guard below instead.
+    // the poll-then-merge guard below instead. This is a per-repo branch-protection
+    // fact rather than a backend fact, but relocating it onto that axis is a separate
+    // follow-up — for now it's the one semantic flag still declared here.
     "auto_merge": false
   },
 
@@ -81,12 +76,5 @@
     "ci_runs": "gh run list",
     "ci_log": "gh run view $1 --log",
     "ci_log_failed": "gh run view $1 --log-failed"
-  },
-
-  "notes": {
-    "merge_guard": "Closing rides on the PR body's `Closes #<n>` keyword — GitHub fires it anywhere in the body regardless of surrounding prose (§8), so a multi-phase PR must never place that token next to an issue number it shouldn't close.",
-    "routing_read": "Routing values are Project fields on the board item, not labels. `gh project item-list` returns `content` (`.number`, `.title`, `.url`, `.body`) alongside `status` and any custom fields. item-list carries no open/closed state, so intersect with `gh issue list --state open` on `number` — a closed item can linger on the board until archived, and this also catches an open issue not yet added to the board.",
-    "unreachable": "`gh` unauthenticated or offline: say so and stop. Never guess board state.",
-    "done_means": "`Closes #<n>` closes the issue on merge. If the board has no closed→Done automation, set Status explicitly after the merge lands."
   }
 }

--- a/bin/lint.mjs
+++ b/bin/lint.mjs
@@ -8,7 +8,8 @@
 // Each check exists because the corresponding mistake was made, or is one edit away:
 //
 //   citations      §N is a plain string; nothing links it to DOCTRINE's headings.
-//   verbs          a typo'd {{@verb}} only fails on the backend that lacks it.
+//   verbs          a typo'd {{@verb}} renders as an unresolved tag instead of failing
+//                  the build loudly.
 //   shims          `shims` was declared and consumed nowhere — every rendered skill
 //                  called a helper script into a repo that had no such file. Verbs
 //                  and shim declarations must agree.
@@ -99,23 +100,20 @@ export function lint({ CYCLE_HOME }) {
     }
 
     // --- verbs -------------------------------------------------------------
-    // A verb missing from one backend is legitimate when the call sits inside a
-    // {{#if backend.…}} branch — that is how a backend with no board (Forgejo, before
-    // it was retired) could skip board-only verbs like {{@board_list}}. Outside such a
-    // branch it is a render failure waiting for whichever repo happens to use the
-    // other tracker — a check that still holds even while only one backend exists.
-    const called = new Map(); // verb → [{rel, line, guarded}]
+    // A verb call {{@verb}} that no backend binds is a render failure waiting to
+    // happen — this is the one part of the verb story still worth catching now that
+    // github is the only backend. (This used to also track {{#if backend.…}} guards,
+    // so a verb legitimate on one backend but missing on another — e.g. {{@board_list}}
+    // guarded for the since-retired label-only Forgejo backend, which had no board —
+    // wouldn't false-positive; and it warned on a verb only one backend bound that no
+    // template called. Both were about *divergence between backends*, which cannot
+    // exist with a single one — re-add them if a second backend ever returns.)
+    const called = new Map(); // verb → [{rel, line}]
     for (const [rel, text] of templates) {
-        let guard = 0;
         text.split('\n').forEach((line, i) => {
-            for (const m of line.matchAll(/\{\{[#/](if|unless)\s*([^}\s]*)/g)) {
-                if (m[0].startsWith('{{/')) guard = Math.max(0, guard - 1);
-                else if (m[2].startsWith('backend.')) guard += 1;
-                else guard += 0; // a non-backend conditional does not excuse a missing verb
-            }
             for (const m of line.matchAll(/\{\{@([a-z_]+)/g)) {
                 if (!called.has(m[1])) called.set(m[1], []);
-                called.get(m[1]).push({ rel, line: i + 1, guarded: guard > 0 });
+                called.get(m[1]).push({ rel, line: i + 1 });
             }
         });
     }
@@ -123,30 +121,6 @@ export function lint({ CYCLE_HOME }) {
         const lacking = [...backends].filter(([, b]) => !(b.verbs ?? {})[verb]).map(([n]) => n);
         if (lacking.length === backends.size) {
             add(ERROR, 'verbs', `{{@${verb}}} is bound by no backend`, sites[0] && `${sites[0].rel}:${sites[0].line}`);
-            continue;
-        }
-        for (const site of sites) {
-            if (lacking.length && !site.guarded) {
-                add(
-                    ERROR,
-                    'verbs',
-                    `{{@${verb}}} is unbound on ${lacking.join(', ')} and this call is not inside a {{#if backend.…}}`,
-                    `${site.rel}:${site.line}`,
-                );
-            }
-        }
-    }
-    // An uncalled verb is not itself a problem — the vocabulary in docs/BACKENDS.md is
-    // deliberately complete, so adding a skill never means editing a backend. What IS
-    // worth seeing is an uncalled verb only *one* backend binds: either the other
-    // backend is missing it, or it was written for a skill that never materialized.
-    for (const [name, b] of backends) {
-        for (const verb of Object.keys(b.verbs ?? {})) {
-            if (called.has(verb)) continue;
-            const others = [...backends].filter(([n]) => n !== name);
-            if (others.length && others.every(([, o]) => !(o.verbs ?? {})[verb])) {
-                add(WARN, 'verbs', `only ${name} binds "${verb}", and no template calls it`, `backends/${name}.jsonc`);
-            }
         }
     }
 

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -52,9 +52,6 @@ GitHub's block:
 
 | Flag | Value | Why |
 | --- | --- | --- |
-| `has_board` | `true` | an issue must be added to the board to carry its Projects v2 field values |
-| `job_logs` | `api` | `gh run view --log` |
-| `job_logs_search` | `false` | `--log-failed` narrows one run; it never searches back for a failure |
 | `auto_merge` | `false` | branch protection isn't guaranteed to exist — see below |
 
 **On `auto_merge`:** a fire-and-forget auto-merge flag is only safe when the forge enforces
@@ -122,8 +119,14 @@ path alone would pass every test and fail on the other laptop.
    hard error at render time, so nothing is silently missing.
 3. Set every semantic flag honestly. Getting `auto_merge` wrong is the one that can actually
    lose work.
-4. Fill in `notes.routing_read`, `notes.unreachable`, and `notes.done_means` — these splice into
-   DOCTRINE §1/§7 where a backend's *prose* has to differ, not just its commands.
+4. **Check whether the new backend's tracker mechanics actually match GitHub's.** DOCTRINE's §1
+   ("closed issue is done") and §7 (tracker-mechanics opening, "unreachable → stop") currently read
+   as GitHub-specific prose, hardcoded directly into the template rather than spliced from a
+   per-backend note — that's correct only because GitHub is the sole backend today. If the new
+   backend's board semantics, close-on-merge behavior, or unreachable condition genuinely differ,
+   those sections need real `{{#if backend.…}}` branches again, the way `has_board` used to fork
+   §1's board-vs-labels paragraph before the label-only Forgejo backend was retired (#5/#6). Don't
+   silently reuse GitHub's prose for a backend it doesn't describe.
 5. Put any executable it needs in `helpers/` and declare a shim for it. Every `scripts/*` path a
    verb mentions must have one; `cycle lint` fails the build if it doesn't.
 6. `npm test` renders every profile against every backend in `backends/`, runs each shim, and

--- a/templates/DOCTRINE.md.tmpl
+++ b/templates/DOCTRINE.md.tmpl
@@ -14,11 +14,7 @@ restate it. The skills hold only their *unique* procedure.
 ## §1 Tracker & readiness
 
 The tracker is {{tracker.description}}. A **story = an issue**: its **body** holds
-Why / Touches / Acceptance; {{#if backend.has_board}}routing lives on the board (§3){{/if}}{{#unless backend.has_board}}its **labels** hold routing (§3){{/unless}}. **Milestones = epics.**
-
-{{#unless backend.has_board}}
-**Labels are the source of truth**; any board/project *view* is eyes-only — no skill writes it.
-{{/unless}}
+Why / Touches / Acceptance; routing lives on the board (§3). **Milestones = epics.**
 
 | Status | Meaning | Pipeline action |
 | --- | --- | --- |
@@ -27,7 +23,8 @@ Why / Touches / Acceptance; {{#if backend.has_board}}routing lives on the board 
 
 **Ranking pickable work** (`/next`): {{tracker.ranking}}.
 
-**A closed issue is "done."** {{backend.notes.done_means}} The pipeline doesn't argue with the
+**A closed issue is "done."** `Closes #<n>` closes the issue on merge. If the board has no
+closed→Done automation, set Status explicitly after the merge lands. The pipeline doesn't argue with the
 close; it lets the close speak.
 
 **A stale-*open* issue may already be shipped.** An umbrella/parent issue's slices often ship
@@ -137,14 +134,15 @@ harness-blocked):
 {{@merge_guard "<pr>" "<n>"}}
 ```
 
-{{backend.notes.merge_guard}}
+Closing rides on the PR body's `Closes #<n>` keyword — GitHub fires it anywhere in the body
+regardless of surrounding prose (§8), so a multi-phase PR must never place that token next to an
+issue number it shouldn't close.
 {{/unless}}
 
-**Reading a red gate.** {{#if backend.job_logs}}Logs come from `{{@ci_log "<run>"}}`.
-{{#if backend.job_logs_search}}The most recent *failing* run is `{{@ci_log_failed}}` — it scans
-back through the run list.{{/if}}{{#unless backend.job_logs_search}}`{{@ci_log_failed "<run>"}}`
+**Reading a red gate.** Logs come from `{{@ci_log "<run>"}}`.
+`{{@ci_log_failed "<run>"}}`
 narrows one run to its failed steps, but it does **not** search backwards: list the runs first
-(`{{@ci_runs}}`) and pass the id of the one that actually failed.{{/unless}}{{/if}} A red CI is diagnosable, so **"retry and see" is not
+(`{{@ci_runs}}`) and pass the id of the one that actually failed. A red CI is diagnosable, so **"retry and see" is not
 an acceptable first move** — read the log, then decide transient-vs-real. §5 still makes an
 unexplained red a hard stop.
 
@@ -162,7 +160,11 @@ other workarounds.
 
 ## §7 Tracker mechanics
 
-{{backend.notes.routing_read}}
+Routing values are Project fields on the board item, not labels. `{{@board_list}}` returns
+`content` (`.number`, `.title`, `.url`, `.body`) alongside `status` and any custom fields. It
+carries no open/closed state, so intersect with `{{@issue_list}}` on `number` — a closed item can
+linger on the board until archived, and this also catches an open issue not yet added to the
+board.
 
 - **Read the tracker:** `{{@issue_list}}`
 - **Read one issue:** `{{@issue_view "<n>"}}`
@@ -172,7 +174,7 @@ other workarounds.
 - **Issue/PR ops:** `{{@issue_create "<title>" "<body>" "<label>"}}` · `{{@issue_comment "<n>" "<text>"}}` ·
   `{{@issue_close "<n>"}}` · `{{@pr_create "<branch>" "<title>" "<body>"}}`
 
-**Unreachable → STOP.** {{backend.notes.unreachable}}
+**Unreachable → STOP.** `gh` unauthenticated or offline: say so and stop. Never guess board state.
 
 {{> overlay?:doctrine-tracker-mechanics}}
 

--- a/templates/skills/done.md.tmpl
+++ b/templates/skills/done.md.tmpl
@@ -42,8 +42,8 @@ mechanics, §8 Commit & PR conventions, §9 Branch policy. The procedure below i
       ```bash
       {{@merge_guard "<pr>" "<n>"}}
       ```
-      After it lands, sync local main and prune the branch{{#if backend.has_board}}, then set
-      Status explicitly: `{{@set_status "<n>" "{{tracker.status.done}}"}}`{{/if}}.
+      After it lands, sync local main and prune the branch, then set
+      Status explicitly: `{{@set_status "<n>" "{{tracker.status.done}}"}}`.
     - **Judgment-call story** → **leave the PR open**, report "ready for your merge: <url>" + *why*
       it's gated. Do NOT auto-merge.
 12. **Suggest next:** `/deploy-test`, `/next`, or `/cycle` continues.

--- a/templates/skills/intake.md.tmpl
+++ b/templates/skills/intake.md.tmpl
@@ -64,8 +64,8 @@ leading with a recommendation, and wait for the reply.{{/unless}}
 
 5. **File it** (§7): `{{@issue_create "<title>" "<body>" "<label>"}}` — the label is a §2 workflow
    label describing *what kind of work it is* (`bug` and the `area:*` set), never a routing value:
-   §10.5 leaves routing to the picking skill. No fitting label is fine; file it bare.{{#if backend.has_board}}, then
-   add it to the board and set Status: `{{@set_status "<n>" "{{tracker.status.pickable}}"}}`{{/if}}.
+   §10.5 leaves routing to the picking skill. No fitting label is fine; file it bare, then
+   add it to the board and set Status: `{{@set_status "<n>" "{{tracker.status.pickable}}"}}`.
    Batch the field writes into one call (§7).
 
 6. **Report** the issue number and URL, and suggest `/cycle #<n>` if it's ready to build now.

--- a/templates/skills/next.md.tmpl
+++ b/templates/skills/next.md.tmpl
@@ -21,15 +21,15 @@ mechanics, including the "unreachable → stop" rule). Don't restate them; apply
 ## Data sources (§7)
 
 - **The open set** — `{{@issue_list}}`
-{{#if backend.has_board}}- **The board** — `{{@board_list}}`. `item-list` carries no open/closed state, so **intersect on
+- **The board** — `{{@board_list}}`. `item-list` carries no open/closed state, so **intersect on
   `number`** to keep only open issues — a closed item can linger on the board until archived, and
   this also catches an open issue not yet on the board.
-{{/if}}- **Unreachable → stop** (§7). Say so plainly; never guess tracker state or fall back to a cached
+- **Unreachable → stop** (§7). Say so plainly; never guess tracker state or fall back to a cached
   list.
 
 ## Workflow
 
-1. **Pull the open set**{{#if backend.has_board}} and the board; join by issue `number`{{/if}}.
+1. **Pull the open set** and the board; join by issue `number`.
 2. **Partition by Status** (§1): pickable · in flight (note, don't re-pick) · done/closed (ignore) ·
    the `finding` pile (review debt — count and sample, don't pick) · **unrouted** (no Status at all).
    Unrouted is not an empty bucket: §10 has `/intake` and `/scout` file without routing on purpose,
@@ -71,6 +71,6 @@ recently (`{{@issue_list_closed}}` — the open set won't tell you), anything bl
 - **No pickable issues:** say so plainly — the queue is drained. List anything in flight (a merge
   may be pending, §6) and the `finding` count. Suggest scoping the next epic, or a `/scout` sweep.
 - **All issues shipped/closed:** say so; suggest scoping the next milestone's stories.
-{{#if backend.has_board}}- **An open issue not on the board:** surface it; note it should be added during triage.
-{{/if}}- **A pickable issue that's really a design call:** `/next` still surfaces it (it *is* pickable),
+- **An open issue not on the board:** surface it; note it should be added during triage.
+- **A pickable issue that's really a design call:** `/next` still surfaces it (it *is* pickable),
   but flag in the body read that it lands on a §5 always-brake surface — `/cycle` will pause there.

--- a/templates/skills/scout.md.tmpl
+++ b/templates/skills/scout.md.tmpl
@@ -86,12 +86,12 @@ call — file it with the options sketched and flag it as needing a decision, no
 6. **Present the slate** — each finding with its lens, `file:line`, the drafted issue body
    **including its drafted fix**, and whether it lands on a §5 brake. **This is the checkpoint**;
    nothing is written before it.
-7. **File** (§7): `{{@issue_create "<title>" "<body>" "scout"}}`{{#if backend.has_board}}, then set
+7. **File** (§7): `{{@issue_create "<title>" "<body>" "scout"}}`, then set
    Status for **all of them in one batch** — never a loop:
    ```
    {{@batch "<file.json>"}}
    ```
-{{/if}}   Tracker unreachable → say so and stop; don't pretend it filed.
+   Tracker unreachable → say so and stop; don't pretend it filed.
 8. **Report.** What was filed (links, labels, which ones flag a §5 brake for later), what was found
    but not filed (dups, below-the-cut, "clean on this lens"), and point at `/next`.
 

--- a/test/lint.test.mjs
+++ b/test/lint.test.mjs
@@ -38,22 +38,6 @@ const edit = (dir, rel, fn) => {
 const errors = (dir) => lint({ CYCLE_HOME: dir }).filter((f) => f.severity === 'error');
 const checksHit = (dir) => new Set(errors(dir).map((f) => f.check));
 
-/**
- * A second backend that mirrors github but omits board_list — exactly how the
- * since-retired Forgejo backend (label routing only, no board) omitted it.
- *
- * With the-cycle down to one real backend, the verbs check's "lacking" list is always
- * empty and its guard-tracking (bin/lint.mjs:107-115) can never be exercised either
- * way — a genuine gap only a fabricated second backend can close.
- */
-function addSyntheticBackend(dir) {
-    const other = readFileSync(join(dir, 'backends', 'github.jsonc'), 'utf8')
-        .replace(/[ \t]*"board_list":[^\n]*\n/, '\n')
-        .replace('"has_board": true,', '"has_board": false,')
-        .replace('"name": "github",', '"name": "other",');
-    writeFileSync(join(dir, 'backends', 'other.jsonc'), other);
-}
-
 describe('lint', () => {
     test('the tree is consistent', () => {
         const findings = lint({ CYCLE_HOME });
@@ -152,7 +136,7 @@ describe('lint', () => {
     // expecting the prose to follow, and nothing moves.
     test('catches a semantic flag no template branches on', () => {
         const dir = sandbox();
-        edit(dir, 'backends/github.jsonc', (t) => t.replace('"has_board": true,', '"has_board": true,\n    "invented_flag": true,'));
+        edit(dir, 'backends/github.jsonc', (t) => t.replace('"auto_merge": false', '"auto_merge": false,\n    "invented_flag": true'));
         assert.ok(errors(dir).some((f) => f.check === 'semantics' && /invented_flag/.test(f.message)));
     });
 
@@ -162,27 +146,6 @@ describe('lint', () => {
         const dir = sandbox();
         edit(dir, 'templates/skills/done.md.tmpl', (t) => `${t}\n{{#if backend.never_declared}}x{{/if}}\n`);
         assert.ok(errors(dir).some((f) => f.check === 'semantics' && /never_declared/.test(f.message)));
-    });
-
-    // A verb only one backend binds is fine inside a {{#if backend.…}} branch — that
-    // is how board reads stayed guarded on the since-retired Forgejo backend, which
-    // had no board. Outside one it is a render failure waiting for whichever repo
-    // uses the other tracker.
-    test('allows a one-backend verb inside a backend conditional', () => {
-        const dir = sandbox();
-        addSyntheticBackend(dir);
-        // next.md.tmpl already calls {{@board_list}} inside {{#if backend.has_board}} —
-        // exactly the guarded shape this check exists to allow. Left unguarded (or with
-        // guard-tracking itself broken), this would false-positive on real, shipped
-        // template content.
-        assert.ok(!errors(dir).some((f) => /board_list/.test(f.message)));
-    });
-
-    test('catches a one-backend verb called unconditionally', () => {
-        const dir = sandbox();
-        addSyntheticBackend(dir);
-        edit(dir, 'templates/skills/burndown.md.tmpl', (t) => `${t}\n\nRead the board: {{@board_list}}\n`);
-        assert.ok(errors(dir).some((f) => f.check === 'verbs' && /board_list/.test(f.message)));
     });
 
     // harness.* is engine-computed, so unlike backend.semantics a typo can't be caught


### PR DESCRIPTION
## What shipped

Phase 2 of the GitHub-primary work. With `github` the only backend (#5), every `{{#if backend.*}}`
fork had a dead arm, and the `backend.notes.*` splices existed purely so DOCTRINE could say
different sentences per forge — indirection with nothing on the other side.

Removed the semantics flags that only expressed a Forgejo-vs-GitHub difference (`has_board`,
`job_logs`, `job_logs_search`) and inlined the four note splices (`done_means`, `routing_read`,
`unreachable`, `merge_guard`) as direct prose.

**The verb vocabulary stays.** This removes the branching, not the abstraction.

## `auto_merge` deliberately stays

It's modeled as a backend semantic but it's a **per-repo branch-protection fact**, and the repos
genuinely split — verified against the live API:

| repo | protection |
| --- | --- |
| the-cycle | ✅ `gates` |
| Ensemble | ✅ `checks,e2e-tests` |
| mend · songsiknow · TwistOS | ❌ private on a free plan — **cannot** have protection |

So `gh pr merge --auto` is available to two repos and impossible for three. Relocating this to
config is its own change, not a side effect of this one.

## Rendered output

Prose-only, and small: three re-wraps, one command expanded to its verb macro, and **one genuine
bugfix** — `/intake` rendered `file it bare., then` because a board conditional opened mid-sentence
with a leading comma. `next` / `done` / `scout` render **byte-identical**, since their conditionals
already evaluated this way with the sole backend.

The §1 prose seam that bit last time (a `notes.*` splice duplicating the template's own lead-in,
shipped to every consuming repo) was checked by reading the assembled DOCTRINE, not just the gates.
Clean.

## Lint

Kept the checks that still have teeth, **each verified by mutation**:
- a `{{@verb}}` bound by no backend → still errors on a typo
- a template branching on a flag the backend doesn't declare → still errors
- a backend declaring a flag no template branches on → still errors (this is what keeps `auto_merge` honest)

Removed the two that needed a second backend to divide by, plus the guard-tracking machinery only
they read. **Test count drops 97 → 95** accordingly — that's the removed checks' own tests, not lost coverage.

## Worth knowing for the next inline

Pasting `notes.routing_read`'s literal `gh project item-list` into the template tripped `cycle lint`'s
own inlining check. Backend notes lived outside `templates/` and were exempt from that scan; inlined
prose is not. It had to be re-expressed through the verb macro — which is the rule working as designed.

## Gates

- `npm test` → **95/95**, and **0/5 failures under CPU saturation**
- `cycle lint` → clean · `cycle check` → clean
- `rg 'backend\.' templates/` → one hit, `{{#unless backend.auto_merge}}`, as intended

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)