### PR TITLE
fix(cli): support non-interactive install bindings

### DIFF
--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -806,7 +806,32 @@ const DEFAULT_STATUSES = {
  * defensible defaults for everything it couldn't. Shared by the interview and by
  * `--plan`, so a guided setup and a manual one begin from exactly the same draft.
  */
-export function draftConfig(root, { backend: wanted, profile } = {}) {
+function applyConfigSets(cfg, sets = []) {
+    for (const assignment of sets) {
+        const equals = assignment.indexOf('=');
+        const path = equals < 1 ? '' : assignment.slice(0, equals);
+        if (!path || equals === assignment.length - 1) {
+            fail(`invalid --set value "${assignment}"`, 'use `--set path=value`');
+        }
+        const keys = path.split('.');
+        let parent = cfg;
+        for (const key of keys.slice(0, -1)) {
+            if (!parent || typeof parent !== 'object' || !Object.hasOwn(parent, key)) {
+                fail(`unknown config path "${path}"`, 'use a dotted path from the install draft');
+            }
+            parent = parent[key];
+        }
+        const leaf = keys.at(-1);
+        if (!parent || typeof parent !== 'object' || !Object.hasOwn(parent, leaf)) {
+            fail(`unknown config path "${path}"`, 'use a dotted path from the install draft');
+        }
+        const raw = assignment.slice(equals + 1);
+        try { parent[leaf] = JSON.parse(raw); } catch { parent[leaf] = raw; }
+    }
+    return cfg;
+}
+
+export function draftConfig(root, { backend: wanted, profile, set } = {}) {
     const d = detect(root);
     const backend = wanted ?? d.backend;
     const cfg = {
@@ -847,7 +872,7 @@ export function draftConfig(root, { backend: wanted, profile } = {}) {
         commit: { coauthor: 'Claude Opus 5 <noreply@anthropic.com>' },
         deploy: d.deploy ?? { test: '', prod: '' },
     };
-    return { cfg, detected: d };
+    return { cfg: applyConfigSets(cfg, set), detected: d };
 }
 
 async function cmdInstall(args) {
@@ -857,6 +882,7 @@ async function cmdInstall(args) {
         options: {
             profile: { type: 'string' },
             backend: { type: 'string' },
+            set: { type: 'string', multiple: true },
             yes: { type: 'boolean', short: 'y' },
             plan: { type: 'boolean' },
         },
@@ -869,7 +895,7 @@ async function cmdInstall(args) {
         fail('this repo already has .cycle/config.jsonc', 'use `cycle update` to re-render, or pass --yes to overwrite');
     }
 
-    const { cfg } = draftConfig(root, { backend: values.backend, profile: values.profile });
+    const { cfg } = draftConfig(root, { backend: values.backend, profile: values.profile, set: values.set });
 
     if (!values.yes) {
         const rl = createInterface({ input: process.stdin, output: process.stdout });
@@ -930,7 +956,7 @@ async function cmdInstall(args) {
  * It writes nothing, so running it is always safe.
  */
 function cmdPlan(root, values) {
-    const { cfg, detected } = draftConfig(root, { backend: values.backend, profile: values.profile });
+    const { cfg, detected } = draftConfig(root, { backend: values.backend, profile: values.profile, set: values.set });
     const backend = loadBackend(cfg.backend);
     const profiles = readdirSync(join(CYCLE_HOME, 'profiles'))
         .filter((f) => f.endsWith('.jsonc'))
@@ -1180,7 +1206,7 @@ function cmdRender(args) {
 
 const USAGE = `${bold('cycle')} — render the-cycle's work pipeline into a repo
 
-  ${bold('cycle install')} [--profile lean|standard|full] [--backend github] [-y]
+  ${bold('cycle install')} [--profile lean|standard|full] [--backend github] [--set path=value]... [-y]
       Interview, write .cycle/config.jsonc, render the skills.
 
   ${bold('cycle install --plan')}

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -49,12 +49,6 @@ const cycleRaw = (dir, args) => {
     return { status: r.status, out: `${r.stdout ?? ''}${r.stderr ?? ''}` };
 };
 
-/** GitHub needs a board number before it can render; supply one the way a user would. */
-function setProject(dir) {
-    const p = join(dir, '.cycle', 'config.jsonc');
-    writeFileSync(p, readFileSync(p, 'utf8').replace('"project": null', '"project": 4'));
-}
-
 const dirs = [];
 after(() => dirs.forEach((d) => rmSync(d, { recursive: true, force: true })));
 
@@ -67,13 +61,7 @@ for (const backend of BACKENDS) {
             before(() => {
                 dir = scratchRepo(backend);
                 dirs.push(dir);
-                try {
-                    cycle(dir, ['install', '--profile', profile, '--backend', backend, '-y']);
-                } catch {
-                    // github stops on the missing board number by design; supply and retry.
-                    setProject(dir);
-                    cycle(dir, ['update']);
-                }
+                cycle(dir, ['install', '--profile', profile, '--backend', backend, '--set', 'tracker.project=4', '-y']);
                 skills = readdirSync(join(dir, '.claude', 'skills'), { withFileTypes: true })
                     .filter((e) => e.isDirectory())
                     .map((e) => e.name);
@@ -230,8 +218,8 @@ describe('install --plan', () => {
         const { draft, write } = planOf(dir);
 
         mkdirSync(join(dir, '.cycle'), { recursive: true });
+        draft.tracker.project = 4;
         writeFileSync(join(dir, '.cycle', 'config.jsonc'), JSON.stringify(draft, null, 2));
-        setProject(dir); // github needs a board number before it can render
         assert.equal(write.then, 'cycle update');
         cycle(dir, ['update']);
         assert.match(cycle(dir, ['check']), /clean/);
@@ -240,13 +228,18 @@ describe('install --plan', () => {
     test('reports an existing install rather than pretending to be a first run', () => {
         const dir = scratchRepo('github');
         dirs.push(dir);
-        try {
-            cycle(dir, ['install', '--profile', 'lean', '-y']);
-        } catch {
-            // github stops on the missing board number by design; config.jsonc is
-            // written before that check runs, which is all this test needs.
-        }
+        cycle(dir, ['install', '--profile', 'lean', '--set', 'tracker.project=4', '-y']);
         assert.equal(planOf(dir).existing_config, '.cycle/config.jsonc');
+    });
+
+    test('--set rejects malformed and unknown config paths', () => {
+        for (const assignment of ['tracker.project', 'tracker.nope=4', 'tracker.project=null']) {
+            const dir = scratchRepo('github');
+            dirs.push(dir);
+            const result = cycleRaw(dir, ['install', '--profile', 'lean', '--set', assignment, '-y']);
+            assert.equal(result.status, 1);
+            assert.match(result.out, /invalid --set|unknown config path|backend needs 1 value/);
+        }
     });
 });
 
@@ -257,12 +250,7 @@ describe('shim resolution', () => {
     test('CYCLE_HOME overrides the path baked in at render time', () => {
         const dir = scratchRepo('github');
         dirs.push(dir);
-        try {
-            cycle(dir, ['install', '--profile', 'lean', '-y']);
-        } catch {
-            setProject(dir);
-            cycle(dir, ['update']);
-        }
+        cycle(dir, ['install', '--profile', 'lean', '--set', 'tracker.project=4', '-y']);
 
         const elsewhere = mkdtempSync(join(tmpdir(), 'cycle-elsewhere-'));
         dirs.push(elsewhere);
@@ -287,12 +275,7 @@ describe('shim resolution', () => {
     test('an exported value beats the baked-in binding', () => {
         const dir = scratchRepo('github');
         dirs.push(dir);
-        try {
-            cycle(dir, ['install', '--profile', 'lean', '-y']);
-        } catch {
-            setProject(dir);
-            cycle(dir, ['update']);
-        }
+        cycle(dir, ['install', '--profile', 'lean', '--set', 'tracker.project=4', '-y']);
 
         const elsewhere = mkdtempSync(join(tmpdir(), 'cycle-elsewhere-'));
         dirs.push(elsewhere);
@@ -317,12 +300,7 @@ describe('multi-harness render', () => {
     before(() => {
         dir = scratchRepo('github');
         dirs.push(dir);
-        try {
-            cycle(dir, ['install', '--profile', 'standard', '-y']);
-        } catch {
-            setProject(dir);
-            cycle(dir, ['update']);
-        }
+        cycle(dir, ['install', '--profile', 'standard', '--set', 'tracker.project=4', '-y']);
         const p = join(dir, '.cycle', 'config.jsonc');
         writeFileSync(p, readFileSync(p, 'utf8').replace(
             '"harnesses": [\n    "claude"\n  ],',
@@ -400,12 +378,7 @@ describe('drift detection', () => {
     before(() => {
         dir = scratchRepo('github');
         dirs.push(dir);
-        try {
-            cycle(dir, ['install', '--profile', 'lean', '-y']);
-        } catch {
-            setProject(dir);
-            cycle(dir, ['update']);
-        }
+        cycle(dir, ['install', '--profile', 'lean', '--set', 'tracker.project=4', '-y']);
     });
 
     test('a hand edit is reported and update refuses to clobber it', () => {
@@ -453,12 +426,7 @@ describe('version stamp — no .git in CYCLE_HOME (an npm/npx install)', () => {
     test('a render from a gitless copy stamps state.json with the package version', () => {
         const dir = scratchRepo('github');
         dirs.push(dir);
-        try {
-            gitlessCli(dir, ['install', '--profile', 'lean', '-y']);
-        } catch {
-            setProject(dir);
-            gitlessCli(dir, ['update']);
-        }
+        gitlessCli(dir, ['install', '--profile', 'lean', '--set', 'tracker.project=4', '-y']);
         const state = JSON.parse(readFileSync(join(dir, '.cycle', 'state.json'), 'utf8'));
         assert.equal(state.upstream, expectedVersion);
     });
@@ -466,12 +434,7 @@ describe('version stamp — no .git in CYCLE_HOME (an npm/npx install)', () => {
     test('a shim rendered from a gitless copy never bakes in the ephemeral package dir', () => {
         const dir = scratchRepo('github');
         dirs.push(dir);
-        try {
-            gitlessCli(dir, ['install', '--profile', 'lean', '-y']);
-        } catch {
-            setProject(dir);
-            gitlessCli(dir, ['update']);
-        }
+        gitlessCli(dir, ['install', '--profile', 'lean', '--set', 'tracker.project=4', '-y']);
         const shim = readFileSync(join(dir, 'scripts', 'gh-project.mjs'), 'utf8');
         assert.ok(!shim.includes(gitlessHome), 'the baked path must not point into the npx-style cache dir');
         assert.match(shim, /['"].*[/\\]code[/\\]the-cycle['"]/, 'expected the conventional clone location baked in instead');
@@ -480,10 +443,9 @@ describe('version stamp — no .git in CYCLE_HOME (an npm/npx install)', () => {
     test('gitless `cycle install` points at the durable clone for cycle update/check and the setup skills', async () => {
         const dir = scratchRepo('github');
         dirs.push(dir);
-        // -y would skip straight past what github additionally requires with no way to
-        // supply it, so answer the interview for real here instead: accept every
-        // detected default except the board number, which github has none to detect —
-        // type one, the way a real user would.
+        // Exercise the interactive path separately: accept every detected default except
+        // the board number, which github has none to detect — type one, the way a real
+        // user would.
         const child = spawn(process.execPath, [join(gitlessHome, 'bin', 'cycle.mjs'), 'install', '--profile', 'lean'], {
             cwd: dir,
             env: { ...process.env, NO_COLOR: '1' },


### PR DESCRIPTION
## What shipped

- Add repeatable --set path=value overrides to cycle install and --plan.
- Parse JSON scalars, reject malformed or unknown config paths, and preserve validateConfig's loud missing-value failure.
- Replace the render-test install catch/retry workaround with direct successful installs.

## Findings actioned

Inline review found no correctness or design findings.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)