### PR TITLE
feat(backend): per-repo backend_overrides, and a real auto-merge path

### DIFF
--- a/.claude/skills/DOCTRINE.md
+++ b/.claude/skills/DOCTRINE.md
@@ -1,4 +1,4 @@
-<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=92a91e20db54 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=4f69a7c8fbd9 — managed by the-cycle; edit the template, not this file -->
 # Pipeline doctrine (shared)
 
 Single source of truth for the rules the the-cycle work-loop skills share. A skill that says
@@ -123,14 +123,19 @@ The pipeline pushes + opens PRs. **Auto-merge SAFE stories** (none of §5's alwa
 AND green CI); **a judgment-call story's PR is left open for Brandon's manual merge** —
 report "ready for your merge: <url>" + *why* it's gated.
 
-There is **no server-side auto-merge-on-green** here, so the **poll-then-merge guard IS the
-enforcement**. Never use a fire-and-forget auto-merge flag — with nothing to wait on it merges
-immediately. Run the guard in the **background** (the poll takes minutes; a foreground `sleep` is
-harness-blocked):
+**This repo has no server-side enforcement**, so the **poll-then-merge guard IS the enforcement**.
+Never use a fire-and-forget auto-merge flag here — `--auto` merges when the repo's merge
+*requirements* are met, and with no branch protection there are none, so it fires immediately with
+nothing to wait on. Run the guard in the **background** (the poll takes minutes; a foreground
+`sleep` is harness-blocked):
 
 ```bash
 (until gh pr checks "<pr>" >/dev/null 2>&1; do sleep 30; done; gh pr checks "<pr>" --watch --interval 30 --fail-fast && gh pr merge "<pr>" --squash --delete-branch) &
 ```
+
+The guard is a client-side *simulation* of branch protection, with a simulation's weaknesses: it
+dies with the session, costs polling quota, and the harness can refuse to run it. If this repo ever
+gains protection, set `backend_overrides.auto_merge` and delete the guard.
 
 Closing rides on the PR body's `Closes #<n>` keyword — GitHub fires it anywhere in the body
 regardless of surrounding prose (§8), so a multi-phase PR must never place that token next to an

--- a/.claude/skills/done/SKILL.md
+++ b/.claude/skills/done/SKILL.md
@@ -2,7 +2,7 @@
 name: done
 description: Ship a the-cycle story — commit the reviewed work, push, open a PR that Closes #<n>, and (for a safe story) merge it via the background poll-then-merge guard; a judgment-call story's PR is left for Brandon's manual merge. Done = the issue closes on merge. Plan-first. Usage `/done #<n>`. Use after /review (+ /patch) pass clean.
 ---
-<!-- cycle:rendered template=skills/done.md.tmpl hash=d61c4ea7b120 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/done.md.tmpl hash=aaac1924ab00 — managed by the-cycle; edit the template, not this file -->
 
 # /done #<n> — ship a story
 
@@ -39,7 +39,7 @@ mechanics, §8 Commit & PR conventions, §9 Branch policy. The procedure below i
 10. **Post a one-line issue comment** linking the PR: `gh issue comment "<n>" --body "<text>"`
 11. **Land it — the auto-merge decision (§5 + §6):**
     - **Safe story** — none of §5's always-brake classes (auth / tokens / secrets, schema / data migration, anything destructive or irreversible) **and** green CI →
-      run the **poll-then-merge guard in the background**:
+      run the **poll-then-merge guard in the background** (§6):
       ```bash
       (until gh pr checks "<pr>" >/dev/null 2>&1; do sleep 30; done; gh pr checks "<pr>" --watch --interval 30 --fail-fast && gh pr merge "<pr>" --squash --delete-branch) &
       ```

--- a/.cycle/state.json
+++ b/.cycle/state.json
@@ -1,12 +1,12 @@
 {
-  "upstream": "11184ac-dirty",
+  "upstream": "493e3ad-dirty",
   "files": {
-    ".claude/skills/DOCTRINE.md": "92a91e20db54",
+    ".claude/skills/DOCTRINE.md": "4f69a7c8fbd9",
     ".claude/skills/cycle/SKILL.md": "7df092de0d13",
     ".claude/skills/implement/SKILL.md": "d01840ec8b68",
     ".claude/skills/review/SKILL.md": "7480fa810fb6",
     ".claude/skills/patch/SKILL.md": "ce0e7c9f32f5",
-    ".claude/skills/done/SKILL.md": "d61c4ea7b120",
+    ".claude/skills/done/SKILL.md": "aaac1924ab00",
     ".claude/skills/next/SKILL.md": "0afc40565e46",
     ".claude/skills/intake/SKILL.md": "7fb751ead121",
     ".claude/skills/scout/SKILL.md": "bbfa6de5fa2e",

--- a/backends/github.jsonc
+++ b/backends/github.jsonc
@@ -14,9 +14,18 @@
   "semantics": {
     // `gh pr merge --auto` is correct ONLY with branch protection — without it the
     // merge fires immediately with nothing to wait on. Repos without protection use
-    // the poll-then-merge guard below instead. This is a per-repo branch-protection
-    // fact rather than a backend fact, but relocating it onto that axis is a separate
-    // follow-up — for now it's the one semantic flag still declared here.
+    // the poll-then-merge guard below instead.
+    //
+    // This is a per-repo branch-protection fact, not a backend fact, so the value here
+    // is only the safe DEFAULT: a repo that genuinely has protection overrides it with
+    // `backend_overrides: { "auto_merge": true }` in its own `.cycle/config.jsonc`
+    // (see docs/BACKENDS.md). It stays false here because protection is not guaranteed
+    // to exist — and on GitHub it is not even always purchasable: a public repo on a
+    // Free org can be protected, while a private one on the same org cannot be, by
+    // either classic rules or rulesets. Same forge, same owner, opposite correct answer.
+    //
+    // Never flip this default to true to save a repo the override. That would hand
+    // every unprotected repo a merge with nothing gating it.
     "auto_merge": false
   },
 
@@ -45,6 +54,13 @@
     // any run exists, so wait for registration first. The && is the guard — merge only
     // happens if every check passed.
     "merge_guard": "(until gh pr checks $1 >/dev/null 2>&1; do sleep 30; done; gh pr checks $1 --watch --interval 30 --fail-fast && gh pr merge $1 --squash --delete-branch) &",
+
+    // The protected-repo counterpart to merge_guard: one foreground call, no polling.
+    // Only rendered when `auto_merge` is true, because without required status checks
+    // this merges on the spot. `--delete-branch` is omitted deliberately — a repo that
+    // has protection configured usually has `delete_branch_on_merge` set too, and the
+    // flag is redundant there; pass it explicitly if that isn't the case.
+    "merge_auto": "gh pr merge $1 --auto --squash",
 
     // One call, and idempotent: clearing every status label before adding the target
     // keeps the set mutually exclusive without a read first. Both halves are safe —

--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -520,7 +520,19 @@ function buildContext(cfg, backend) {
             // Pre-formatted for prose: the join filter can't wrap each item in backticks.
             manifests_md: (cfg.deps?.manifests ?? []).map((m) => `\`${m}\``).join(', '),
         },
-        backend: { name: cfg.backend, ...(backend.semantics ?? {}), notes: backend.notes ?? {} },
+        // `backend_overrides` lets one repo correct a backend-wide default that is
+        // really a per-repo fact. `auto_merge` is the motivating case: it is a
+        // branch-protection property, not a forge property, and the two disagree
+        // across repos on the same backend (a public repo on a Free org can be
+        // protected; a private one cannot be protected at all). Backend defaults stay
+        // safe-by-default, and a repo opts in only when the forge genuinely enforces
+        // it — `cycle check --verify-forge` is what stops that claim from drifting.
+        backend: {
+            name: cfg.backend,
+            ...(backend.semantics ?? {}),
+            ...(cfg.backend_overrides ?? {}),
+            notes: backend.notes ?? {},
+        },
         profile: { name: cfg.profile, ...(cfg.profileFlags ?? {}) },
     };
 }
@@ -1050,9 +1062,90 @@ ${JSON.stringify(cfg, null, 2)}
 `;
 }
 
+/**
+ * Verify forge-facts declared in config against the live forge.
+ *
+ * Opt-in, and deliberately NOT part of a plain `cycle check`: rendering and drift
+ * detection stay offline and deterministic, so they work on a plane and produce the
+ * same answer for everyone. This is the one place the tool looks outward.
+ *
+ * Returns a list of human-readable mismatches. A probe that cannot run (no `gh`, not
+ * authenticated, no network) is reported as a skip, never as a mismatch — an
+ * unanswerable question must not read as a failed answer.
+ */
+function verifyForge(cfg) {
+    const problems = [];
+    const slug = cfg.repo?.slug;
+    if (cfg.backend !== 'github') return { problems, skipped: `backend ${cfg.backend} has no forge probe` };
+    if (!slug) return { problems, skipped: 'repo.slug not set in .cycle/config.jsonc' };
+
+    let repoJson;
+    try {
+        repoJson = JSON.parse(
+            execFileSync('gh', ['api', `repos/${slug}`, '--jq', '{allow_auto_merge,delete_branch_on_merge}'], {
+                encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+            }),
+        );
+    } catch {
+        return { problems, skipped: `could not query ${slug} (gh missing, unauthenticated, or offline)` };
+    }
+
+    const declared = Boolean(cfg.backend_overrides?.auto_merge ?? false);
+    const live = Boolean(repoJson.allow_auto_merge);
+
+    if (declared && !live) {
+        problems.push(
+            `auto_merge declared true but ${slug} has allow_auto_merge=false — ` +
+            'the rendered doctrine tells agents to use `gh pr merge --auto`, which will error. ' +
+            'Re-enable it on the repo, or drop backend_overrides.auto_merge.',
+        );
+    } else if (!declared && live) {
+        problems.push(
+            `${slug} allows auto-merge but config does not declare it — agents are running a ` +
+            'polling merge guard for a job the forge would do server-side. Set ' +
+            'backend_overrides.auto_merge to true (only if branch protection is configured).',
+        );
+    }
+
+    // auto_merge is only SAFE with required status checks: with none, `--auto` merges
+    // on the spot. Declaring it without protection is the dangerous direction, so probe
+    // it specifically rather than trusting the repo flag alone.
+    if (declared) {
+        try {
+            const contexts = JSON.parse(
+                execFileSync('gh', ['api', `repos/${slug}/branches/main/protection`, '--jq', '.required_status_checks.contexts'], {
+                    encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
+                }),
+            );
+            if (!Array.isArray(contexts) || contexts.length === 0) {
+                problems.push(
+                    `auto_merge declared true but ${slug}'s main has no required status checks — ` +
+                    '`--auto` would merge immediately with nothing to wait on. Configure required ' +
+                    'checks, or drop backend_overrides.auto_merge.',
+                );
+            }
+        } catch {
+            problems.push(
+                `auto_merge declared true but branch protection on ${slug} could not be read ` +
+                '(often means it is not configured, or the plan does not allow it). Unverified — ' +
+                'confirm before relying on it.',
+            );
+        }
+    }
+
+    return { problems, skipped: null };
+}
+
 function cmdCheck(args) {
     const root = findRepoRoot();
-    const { values } = parseArgs({ args, options: { quiet: { type: 'boolean', short: 'q' } }, allowPositionals: true });
+    const { values } = parseArgs({
+        args,
+        options: {
+            quiet: { type: 'boolean', short: 'q' },
+            'verify-forge': { type: 'boolean' },
+        },
+        allowPositionals: true,
+    });
     const cfg = loadConfig(root);
     const plan = planRender(root, cfg);
     const state = readState(root);
@@ -1105,7 +1198,24 @@ function cmdCheck(args) {
         console.log(green('✓ clean — every managed file matches its template'));
     }
 
-    process.exitCode = missing.length || local.length || upstream.length ? 1 : 0;
+    // Forge verification is opt-in: a plain `cycle check` stays offline so it is
+    // deterministic and works unauthenticated. File drift and forge drift are separate
+    // failures and are reported separately, but either one fails the command.
+    let forgeProblems = [];
+    if (values['verify-forge']) {
+        const { problems, skipped } = verifyForge(cfg);
+        forgeProblems = problems;
+        if (skipped) {
+            console.log(dim(`· forge check skipped — ${skipped}`));
+        } else if (problems.length) {
+            console.log(red(`✗ ${problems.length} forge fact(s) disagree with .cycle/config.jsonc`));
+            for (const p of problems) console.log(`    ${p}`);
+        } else {
+            console.log(green('✓ forge matches the declared config'));
+        }
+    }
+
+    process.exitCode = missing.length || local.length || upstream.length || forgeProblems.length ? 1 : 0;
 }
 
 function cmdUpdate(args) {
@@ -1218,9 +1328,12 @@ const USAGE = `${bold('cycle')} — render the-cycle's work pipeline into a repo
       and why each matters, every overlay point — as JSON, and write nothing.
       This is what /cycle-setup reads; useful on its own to see the shape.
 
-  ${bold('cycle check')} [-q]
+  ${bold('cycle check')} [-q] [--verify-forge]
       Report drift on two axes: locally edited files, and files a re-render
       would change. Exits non-zero on any drift.
+      --verify-forge additionally checks facts this repo *declares* about its
+      forge (backend_overrides.auto_merge) against the live repo. Opt-in
+      because it needs network + auth; without it, check stays offline.
 
   ${bold('cycle update')} [--dry-run] [--force]
       Re-render. Shows a diff; refuses to clobber hand-edited files without --force.

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -59,9 +59,40 @@ GitHub's block:
 | `auto_merge` | `false` | branch protection isn't guaranteed to exist — see below |
 
 **On `auto_merge`:** a fire-and-forget auto-merge flag is only safe when the forge enforces
-required checks. Without branch protection, `gh pr merge --auto` merges *immediately* — there is
-nothing for it to wait on. The backend therefore defaults to the background poll-then-merge guard.
-Set `auto_merge: true` only for a repo that actually has protection configured.
+required checks. `gh pr merge --auto` does not mean "merge when checks are green" — it means
+"merge when the repo's merge *requirements* are satisfied." With required status checks configured
+that is the same thing; without branch protection there are no requirements, so it merges
+*immediately*, possibly before CI starts. The backend therefore defaults to the background
+poll-then-merge guard.
+
+### Overriding a backend default per repo
+
+`auto_merge` is really a **per-repo branch-protection fact wearing a backend flag's clothing**. Two
+repos on the same backend, in the same org, can need opposite values — on GitHub a *public* repo on
+a Free org can be branch-protected while a *private* one cannot be protected at all (classic rules
+and rulesets both 403). So the backend value is only a safe default; a repo corrects it in its own
+`.cycle/config.jsonc`:
+
+```jsonc
+{
+  "backend": "github",
+  "backend_overrides": {
+    // Only set this if the forge REALLY enforces required checks on main.
+    "auto_merge": true
+  }
+}
+```
+
+Keys in `backend_overrides` are merged over the backend's `semantics` block, so this works for any
+semantic flag, not just `auto_merge`. It cannot override *verbs* — those are backend mechanics, not
+repo policy.
+
+**Verify the claim rather than trusting it.** A declared forge fact drifts the moment someone
+changes a repo setting, and a stale declaration is worse than none: the rendered doctrine confidently
+instructs agents to use a merge path that errors. `cycle check --verify-forge` compares the
+declaration against the live repo — including whether required status checks actually exist, since
+`auto_merge: true` without them is the genuinely dangerous combination. It is opt-in because it
+needs network and auth; a plain `cycle check` stays offline and deterministic.
 
 ## Reading routing values
 

--- a/templates/DOCTRINE.md.tmpl
+++ b/templates/DOCTRINE.md.tmpl
@@ -134,19 +134,42 @@ AND green CI); **a judgment-call story's PR is left open for {{repo.human}}'s ma
 report "ready for your merge: <url>" + *why* it's gated.
 
 {{#unless backend.auto_merge}}
-There is **no server-side auto-merge-on-green** here, so the **poll-then-merge guard IS the
-enforcement**. Never use a fire-and-forget auto-merge flag — with nothing to wait on it merges
-immediately. Run the guard in the **background** (the poll takes minutes; a foreground `sleep` is
-harness-blocked):
+**This repo has no server-side enforcement**, so the **poll-then-merge guard IS the enforcement**.
+Never use a fire-and-forget auto-merge flag here — `--auto` merges when the repo's merge
+*requirements* are met, and with no branch protection there are none, so it fires immediately with
+nothing to wait on. Run the guard in the **background** (the poll takes minutes; a foreground
+`sleep` is harness-blocked):
 
 ```bash
 {{@merge_guard "<pr>" "<n>"}}
 ```
 
+The guard is a client-side *simulation* of branch protection, with a simulation's weaknesses: it
+dies with the session, costs polling quota, and the harness can refuse to run it. If this repo ever
+gains protection, set `backend_overrides.auto_merge` and delete the guard.
+{{/unless}}
+{{#if backend.auto_merge}}
+**Server-side auto-merge is enabled here**, and the forge enforces the required checks — so queue
+the merge and let it do the waiting:
+
+```bash
+{{@merge_auto "<pr>"}}
+```
+
+It cannot merge early: `--auto` waits until the repo's merge requirements are satisfied, and with
+required status checks configured those requirements *are* the checks. Prefer this to a
+client-side poll — enforcement survives a killed session, a crashed harness, or a denied background
+command, and it costs no polling quota.
+
+If it errors `Auto merge is not allowed for this repository`, the forge setting was turned off:
+the declaration in `.cycle/config.jsonc` is now a lie. Re-enable it, or drop
+`backend_overrides.auto_merge` and fall back to the poll guard. `cycle check --verify-forge`
+catches that drift before it bites.
+{{/if}}
+
 Closing rides on the PR body's `Closes #<n>` keyword — GitHub fires it anywhere in the body
 regardless of surrounding prose (§8), so a multi-phase PR must never place that token next to an
 issue number it shouldn't close.
-{{/unless}}
 
 **Reading a red gate.** Logs come from `{{@ci_log "<run>"}}`.
 `{{@ci_log_failed "<run>"}}`

--- a/templates/skills/done.md.tmpl
+++ b/templates/skills/done.md.tmpl
@@ -37,13 +37,27 @@ mechanics, §8 Commit & PR conventions, §9 Branch policy. The procedure below i
    Conventional-Commit subject as title.
 10. **Post a one-line issue comment** linking the PR: `{{@issue_comment "<n>" "<text>"}}`
 11. **Land it — the auto-merge decision (§5 + §6):**
+{{#unless backend.auto_merge}}
     - **Safe story** — none of §5's always-brake classes ({{brakes|join:, }}) **and** green CI →
-      run the **poll-then-merge guard in the background**:
+      run the **poll-then-merge guard in the background** (§6):
       ```bash
       {{@merge_guard "<pr>" "<n>"}}
       ```
       After it lands, sync local main and prune the branch, then set
       Status explicitly: `{{@set_status "<n>" "{{tracker.status.done}}"}}`.
+{{/unless}}
+{{#if backend.auto_merge}}
+    - **Safe story** — none of §5's always-brake classes ({{brakes|join:, }}) → **queue the
+      server-side merge** (§6). No polling, no background job: the forge holds it until the
+      required checks pass.
+      ```bash
+      {{@merge_auto "<pr>"}}
+      ```
+      This returns immediately with the merge *queued*, so the PR is normally still open when
+      you look — that is success, not a pending failure. Set Status explicitly right away:
+      `{{@set_status "<n>" "{{tracker.status.done}}"}}`. Sync local main and prune on the next
+      run that needs it, rather than waiting around for the merge to land.
+{{/if}}
     - **Judgment-call story** → **leave the PR open**, report "ready for your merge: <url>" + *why*
       it's gated. Do NOT auto-merge.
 12. **Suggest next:** `/deploy-test`, `/next`, or `/cycle` continues.

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -498,3 +498,72 @@ describe('version stamp — no .git in CYCLE_HOME (an npm/npx install)', () => {
         assert.match(out, /cycle-setup/);
     });
 });
+
+// ---------------------------------------------------------------------------
+// backend_overrides — a per-repo correction to a backend-wide default.
+//
+// `auto_merge` is the motivating case and the dangerous one: it is a
+// branch-protection fact, not a forge fact, so two repos on the same backend can
+// need opposite values. Both directions are asserted — that the override actually
+// changes the rendered merge path, AND that the default still renders the guard —
+// because a conditional that silently renders nothing is exactly the bug this
+// replaced (§6 previously had an {{#unless}} with no counterpart).
+// ---------------------------------------------------------------------------
+describe('backend_overrides.auto_merge', () => {
+    let guardDir;
+    let autoDir;
+
+    before(() => {
+        guardDir = scratchRepo('github');
+        dirs.push(guardDir);
+        cycle(guardDir, ['install', '--profile', 'full', '--backend', 'github', '-y']);
+
+        autoDir = scratchRepo('github');
+        dirs.push(autoDir);
+        cycle(autoDir, ['install', '--profile', 'full', '--backend', 'github', '-y']);
+        const cfgPath = join(autoDir, '.cycle', 'config.jsonc');
+        const cfg = readFileSync(cfgPath, 'utf8');
+        assert.match(cfg, /"backend":\s*"github"/, 'fixture expects a plain string backend');
+        writeFileSync(
+            cfgPath,
+            cfg.replace(/"backend":\s*"github",/, '"backend": "github",\n  "backend_overrides": { "auto_merge": true },'),
+        );
+        cycle(autoDir, ['update']);
+    });
+
+    const doctrine = (d) => readFileSync(join(d, '.claude', 'skills', 'DOCTRINE.md'), 'utf8');
+    const done = (d) => readFileSync(join(d, '.claude', 'skills', 'done', 'SKILL.md'), 'utf8');
+
+    test('default renders the poll-then-merge guard, not --auto', () => {
+        const src = doctrine(guardDir);
+        assert.match(src, /gh pr checks .* --watch/, 'expected the poll guard');
+        assert.doesNotMatch(src, /gh pr merge .*--auto/, 'must not offer --auto without protection');
+    });
+
+    test('the override swaps the merge path to server-side --auto', () => {
+        const src = doctrine(autoDir);
+        assert.match(src, /gh pr merge .*--auto/, 'expected the server-side merge');
+        assert.doesNotMatch(src, /until gh pr checks/, 'the poll guard must be gone');
+    });
+
+    test('/done follows the same switch, so the flag is not doctrine-only', () => {
+        assert.match(done(guardDir), /until gh pr checks/);
+        assert.doesNotMatch(done(guardDir), /gh pr merge .*--auto/);
+        assert.match(done(autoDir), /gh pr merge .*--auto/);
+        assert.doesNotMatch(done(autoDir), /until gh pr checks/);
+    });
+
+    // The regression this change exists to prevent: `Closes #<n>` used to live INSIDE
+    // the {{#unless auto_merge}} block, so a protected repo silently lost the one rule
+    // that makes issue-closing work at all.
+    test('Closes #<n> survives in BOTH modes', () => {
+        assert.match(doctrine(guardDir), /Closes #<n>/);
+        assert.match(doctrine(autoDir), /Closes #<n>/);
+    });
+
+    test('an overridden repo still renders clean and re-renders byte-identically', () => {
+        const { status, out } = cycleRaw(autoDir, ['check']);
+        assert.equal(status, 0, out);
+        assert.match(out, /clean/);
+    });
+});


### PR DESCRIPTION
## Why

`auto_merge` lives in `backends/github.jsonc` as a backend-wide default, but it is really a **per-repo branch-protection fact**. The file's own comment already flagged this:

> This is a per-repo branch-protection fact rather than a backend fact, but relocating it onto that axis is a separate follow-up.

This is that follow-up. Two repos on the same backend, same org, can need opposite values — verified today:

| Repo | Visibility | Protection | Correct `auto_merge` |
|---|---|---|---|
| `Ensemble` | public | ✅ `checks` + `e2e-tests` | `true` |
| `songsiknow` | private | ❌ classic **and** rulesets both 403 | `false` |

`gh api repos/brndnsh-labs/songsiknow/branches/main/protection` → `403 Upgrade to GitHub Pro or make this repository public`. Same for `/rulesets`. So a private repo on a Free org has no server-side enforcement available at any price short of Pro — the backend default must stay `false`.

## What changed

- **`backend_overrides`** in `.cycle/config.jsonc` merges over the backend's `semantics`. Additive, so no existing config needs touching. Verbs are deliberately not overridable — those are backend mechanics, not repo policy.
- **DOCTRINE §6 gains the counterpart branch.** It had an `{{#unless auto_merge}}` with no partner, so a repo with the flag set rendered §6 with **no merge instruction at all**. Worse, the `Closes #<n>` rule was trapped inside that block and vanished with it — hoisted out, since it's true either way. The engine has no `{{else}}`, so this is paired `#unless`/`#if`.
- **`done.md.tmpl` branches on the same flag.** Without this the flag was doctrine-only — `/done` hardcoded `{{@merge_guard}}`, so flipping it changed nothing in practice.
- **`merge_auto` verb** added; backend default stays `false`.
- **`cycle check --verify-forge`** compares the declared fact against the live repo — including whether required status checks actually *exist*, because `auto_merge: true` without them is the genuinely dangerous case (`--auto` merges when merge *requirements* are met; with no protection there are none, so it fires immediately). Opt-in, because it needs network + auth; a plain `cycle check` stays offline and deterministic.

## Verification

- `npm test` — **101/101** (5 new)
- `cycle lint` — clean
- self-render — clean, and an overridden repo re-renders byte-identically

**Mutation-checked, not just green:** removing the `backend_overrides` spread fails exactly the two tests that assert the override works, while the three default-path tests correctly stay green. The `Closes #<n>` test covers both modes specifically because that regression is what motivated hoisting it.

## Note

`the-cycle` itself is public with branch protection (required context `gates`) but has `allow_auto_merge: false`, so it renders the poll guard here. It qualifies for the override whenever you want to flip the repo setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)