### PR TITLE
chore: dogfood backend_overrides.auto_merge

### DIFF
--- a/.claude/skills/DOCTRINE.md
+++ b/.claude/skills/DOCTRINE.md
@@ -1,4 +1,4 @@
-<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=4f69a7c8fbd9 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=6913f5e9b053 — managed by the-cycle; edit the template, not this file -->
 # Pipeline doctrine (shared)
 
 Single source of truth for the rules the the-cycle work-loop skills share. A skill that says
@@ -123,19 +123,22 @@ The pipeline pushes + opens PRs. **Auto-merge SAFE stories** (none of §5's alwa
 AND green CI); **a judgment-call story's PR is left open for Brandon's manual merge** —
 report "ready for your merge: <url>" + *why* it's gated.
 
-**This repo has no server-side enforcement**, so the **poll-then-merge guard IS the enforcement**.
-Never use a fire-and-forget auto-merge flag here — `--auto` merges when the repo's merge
-*requirements* are met, and with no branch protection there are none, so it fires immediately with
-nothing to wait on. Run the guard in the **background** (the poll takes minutes; a foreground
-`sleep` is harness-blocked):
+**Server-side auto-merge is enabled here**, and the forge enforces the required checks — so queue
+the merge and let it do the waiting:
 
 ```bash
-(until gh pr checks "<pr>" >/dev/null 2>&1; do sleep 30; done; gh pr checks "<pr>" --watch --interval 30 --fail-fast && gh pr merge "<pr>" --squash --delete-branch) &
+gh pr merge "<pr>" --auto --squash
 ```
 
-The guard is a client-side *simulation* of branch protection, with a simulation's weaknesses: it
-dies with the session, costs polling quota, and the harness can refuse to run it. If this repo ever
-gains protection, set `backend_overrides.auto_merge` and delete the guard.
+It cannot merge early: `--auto` waits until the repo's merge requirements are satisfied, and with
+required status checks configured those requirements *are* the checks. Prefer this to a
+client-side poll — enforcement survives a killed session, a crashed harness, or a denied background
+command, and it costs no polling quota.
+
+If it errors `Auto merge is not allowed for this repository`, the forge setting was turned off:
+the declaration in `.cycle/config.jsonc` is now a lie. Re-enable it, or drop
+`backend_overrides.auto_merge` and fall back to the poll guard. `cycle check --verify-forge`
+catches that drift before it bites.
 
 Closing rides on the PR body's `Closes #<n>` keyword — GitHub fires it anywhere in the body
 regardless of surrounding prose (§8), so a multi-phase PR must never place that token next to an

--- a/.claude/skills/done/SKILL.md
+++ b/.claude/skills/done/SKILL.md
@@ -2,7 +2,7 @@
 name: done
 description: Ship a the-cycle story — commit the reviewed work, push, open a PR that Closes #<n>, and (for a safe story) merge it via the background poll-then-merge guard; a judgment-call story's PR is left for Brandon's manual merge. Done = the issue closes on merge. Plan-first. Usage `/done #<n>`. Use after /review (+ /patch) pass clean.
 ---
-<!-- cycle:rendered template=skills/done.md.tmpl hash=aaac1924ab00 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/done.md.tmpl hash=4ec3b11ed433 — managed by the-cycle; edit the template, not this file -->
 
 # /done #<n> — ship a story
 
@@ -38,13 +38,16 @@ mechanics, §8 Commit & PR conventions, §9 Branch policy. The procedure below i
    Conventional-Commit subject as title.
 10. **Post a one-line issue comment** linking the PR: `gh issue comment "<n>" --body "<text>"`
 11. **Land it — the auto-merge decision (§5 + §6):**
-    - **Safe story** — none of §5's always-brake classes (auth / tokens / secrets, schema / data migration, anything destructive or irreversible) **and** green CI →
-      run the **poll-then-merge guard in the background** (§6):
+    - **Safe story** — none of §5's always-brake classes (auth / tokens / secrets, schema / data migration, anything destructive or irreversible) → **queue the
+      server-side merge** (§6). No polling, no background job: the forge holds it until the
+      required checks pass.
       ```bash
-      (until gh pr checks "<pr>" >/dev/null 2>&1; do sleep 30; done; gh pr checks "<pr>" --watch --interval 30 --fail-fast && gh pr merge "<pr>" --squash --delete-branch) &
+      gh pr merge "<pr>" --auto --squash
       ```
-      After it lands, sync local main and prune the branch, then set
-      Status explicitly: `gh issue edit "<n>" --remove-label "status:ready,status:in-progress,status:in-review,status:needs-decision,status:blocked" --add-label "status:in-review"`.
+      This returns immediately with the merge *queued*, so the PR is normally still open when
+      you look — that is success, not a pending failure. Set Status explicitly right away:
+      `gh issue edit "<n>" --remove-label "status:ready,status:in-progress,status:in-review,status:needs-decision,status:blocked" --add-label "status:in-review"`. Sync local main and prune on the next
+      run that needs it, rather than waiting around for the merge to land.
     - **Judgment-call story** → **leave the PR open**, report "ready for your merge: <url>" + *why*
       it's gated. Do NOT auto-merge.
 12. **Suggest next:** `/deploy-test`, `/next`, or `/cycle` continues.

--- a/.cycle/config.jsonc
+++ b/.cycle/config.jsonc
@@ -10,6 +10,15 @@
   },
   "profile": "lean",
   "backend": "github",
+  // the-cycle is PUBLIC, so a Free org can branch-protect it, and `main` requires the
+  // `gates` context — so `gh pr merge --auto` genuinely waits instead of firing on the
+  // spot. Enabled on the repo 2026-08-07 alongside `delete_branch_on_merge` (which is
+  // why the `merge_auto` verb omits `--delete-branch`).
+  //
+  // This is also the dogfood: the backend default stays false, and this repo proves the
+  // override path it ships. Consuming repos WITHOUT protection must not copy this.
+  // `cycle check --verify-forge` fails if this and the live repo ever disagree.
+  "backend_overrides": { "auto_merge": true },
   "tracker": {
     // Routing lives in `status:*` labels on the issue. Each name below is a real
     // label that must exist in the repo — `gh` fails loudly on one that doesn't,

--- a/.cycle/state.json
+++ b/.cycle/state.json
@@ -1,12 +1,12 @@
 {
-  "upstream": "493e3ad-dirty",
+  "upstream": "1c92f78-dirty",
   "files": {
-    ".claude/skills/DOCTRINE.md": "4f69a7c8fbd9",
+    ".claude/skills/DOCTRINE.md": "6913f5e9b053",
     ".claude/skills/cycle/SKILL.md": "7df092de0d13",
     ".claude/skills/implement/SKILL.md": "d01840ec8b68",
     ".claude/skills/review/SKILL.md": "7480fa810fb6",
     ".claude/skills/patch/SKILL.md": "ce0e7c9f32f5",
-    ".claude/skills/done/SKILL.md": "aaac1924ab00",
+    ".claude/skills/done/SKILL.md": "4ec3b11ed433",
     ".claude/skills/next/SKILL.md": "0afc40565e46",
     ".claude/skills/intake/SKILL.md": "7fb751ead121",
     ".claude/skills/scout/SKILL.md": "bbfa6de5fa2e",


### PR DESCRIPTION
Follow-up to #15, which added the override mechanism.

`the-cycle` is public with `main` requiring the `gates` context, so it qualifies for the override it ships. `allow_auto_merge` and `delete_branch_on_merge` are now enabled on the repo, and `.cycle/config.jsonc` declares the override.

This makes the repo the live proof of the override path — the same role it already plays for the github backend generally. `/done` and DOCTRINE §6 here now render `gh pr merge --auto --squash` instead of the background poll loop.

The backend default stays `false`. A consuming repo without branch protection must **not** copy the block, and the config comment says so explicitly — `--auto` with no required checks merges on the spot.

## Verification

- `npm test` 101/101 · `cycle lint` clean
- `cycle check --verify-forge` → `✓ forge matches the declared config`
- Rendered output confirmed: both `DOCTRINE.md` and `done/SKILL.md` now carry `gh pr merge --auto --squash`
- Merged via `--auto` itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)