### PR TITLE
docs(doctrine): route §10.5 by direction of change, not surface touched

### DIFF
--- a/templates/DOCTRINE.md.tmpl
+++ b/templates/DOCTRINE.md.tmpl
@@ -295,8 +295,21 @@ file* — neither fixes, branches, or merges.
    - **Unsure → no status label.** It lands in the untriaged pile (§1) for a human look — the
      filing-time twin of §5's "when unsure, exclude and surface."
 
-   A finding that touches a §5 brake surface is **never** deterministic, however certain the fix
-   looks — certainty and safety are different axes, and pickable requires both.
+   On a §5 brake surface, test the **direction of the change, not the surface it touches**. A
+   finding there is deterministic only when it *tightens* — more validation, more redaction,
+   stricter gates, fewer accepted inputs — **and** §4's gates can demonstrate both the tightening
+   and that nothing legitimate was lost. Anything that loosens, exempts, widens, or re-opens is
+   **never** deterministic, however small the diff: certainty and safety are different axes, and
+   pickable requires both.
+
+   The second half of that test is load-bearing, because tightening is not automatically safe. A
+   redaction rule greedy enough to eat the evidence a validator needs, or a gate strict enough to
+   reject legitimate traffic, fails *closed* — which is the quiet direction, and the one that
+   hides. Pickable means the gates prove both halves; if they can only prove the tightening, it is
+   interpretive.
+
+   A brake entry describing an **irreversible action** rather than a code change — running a
+   destructive verb, writing to production — has no direction to test and never becomes pickable.
 6. **Budget.** Filing zero is a success. A sweep that files 20 low-grade issues has made the queue
    worse, not better. Cap a focused pass at **3–5** findings; a multi-lens sweep caps *per lens* and
    stays in single digits overall. Rank by (impact × how-actionable) and file only the top ones —


### PR DESCRIPTION
The old rule — "a finding that touches a §5 brake surface is never
deterministic" — collapsed tightening and loosening into one test. A change
that makes a redaction rule stricter got braked identically to one that
exempts model output from validation, so filing-time triage parked safe,
net-tightening fixes on the human's decision queue and made them the
bottleneck for their own hardening work.

Test direction instead: tightening is pickable when the gates can prove both
the tightening and that nothing legitimate was lost; loosening never is. The
second half is load-bearing — a redaction rule greedy enough to eat a
validator's evidence fails closed, which is the quiet direction.

Brake entries naming an irreversible action rather than a code change have no
direction to test and stay unpickable.

Cherry-picked from a local-main commit that could not be pushed directly (main is branch-protected); folding it into the follow-up PR's squash would have cost it its own commit identity (§9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)