### PR TITLE
chore(cli): gate self-render drift in CI; unify JSONC parsing

### DIFF
--- a/.claude/skills/DOCTRINE.md
+++ b/.claude/skills/DOCTRINE.md
@@ -1,4 +1,4 @@
-<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=6913f5e9b053 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=0dca555ec9cd — managed by the-cycle; edit the template, not this file -->
 # Pipeline doctrine (shared)
 
 Single source of truth for the rules the the-cycle work-loop skills share. A skill that says
@@ -81,6 +81,7 @@ Local, before handing to `/review` or `/done` (never proceed over a red gate):
 
 ```
 npm test
+node bin/cycle.mjs check
 ```
 
 ## §5 Judgment calls & autonomy
@@ -259,8 +260,21 @@ file* — neither fixes, branches, or merges.
    - **Unsure → no status label.** It lands in the untriaged pile (§1) for a human look — the
      filing-time twin of §5's "when unsure, exclude and surface."
 
-   A finding that touches a §5 brake surface is **never** deterministic, however certain the fix
-   looks — certainty and safety are different axes, and pickable requires both.
+   On a §5 brake surface, test the **direction of the change, not the surface it touches**. A
+   finding there is deterministic only when it *tightens* — more validation, more redaction,
+   stricter gates, fewer accepted inputs — **and** §4's gates can demonstrate both the tightening
+   and that nothing legitimate was lost. Anything that loosens, exempts, widens, or re-opens is
+   **never** deterministic, however small the diff: certainty and safety are different axes, and
+   pickable requires both.
+
+   The second half of that test is load-bearing, because tightening is not automatically safe. A
+   redaction rule greedy enough to eat the evidence a validator needs, or a gate strict enough to
+   reject legitimate traffic, fails *closed* — which is the quiet direction, and the one that
+   hides. Pickable means the gates prove both halves; if they can only prove the tightening, it is
+   interpretive.
+
+   A brake entry describing an **irreversible action** rather than a code change — running a
+   destructive verb, writing to production — has no direction to test and never becomes pickable.
 6. **Budget.** Filing zero is a success. A sweep that files 20 low-grade issues has made the queue
    worse, not better. Cap a focused pass at **3–5** findings; a multi-lens sweep caps *per lens* and
    stays in single digits overall. Rank by (impact × how-actionable) and file only the top ones —

--- a/.claude/skills/dep-update/SKILL.md
+++ b/.claude/skills/dep-update/SKILL.md
@@ -2,7 +2,7 @@
 name: dep-update
 description: Routine dependency hygiene for the-cycle — survey what's outdated, plan the bump, update, run the gates, and land one lockfile commit. Distinguishes a stale test expectation from a real regression. Never uses `audit fix --force`; never auto-pushes. Plan-first. Usage `/dep-update` (or `/dep-update <package>`).
 ---
-<!-- cycle:rendered template=skills/dep-update.md.tmpl hash=b491f8fb56b8 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/dep-update.md.tmpl hash=58c6bd2d36a2 — managed by the-cycle; edit the template, not this file -->
 
 # /dep-update — dependency hygiene
 
@@ -30,6 +30,7 @@ Goal: keep dependencies current without turning a routine bump into an outage.
 7. **Run the gates** (§4):
    ```
    npm test
+   node bin/cycle.mjs check
    ```
    **A red gate here is one of two things, and they need opposite responses:**
    - **A stale expectation** — the dependency legitimately changed its output, and the test

--- a/.claude/skills/done/SKILL.md
+++ b/.claude/skills/done/SKILL.md
@@ -2,7 +2,7 @@
 name: done
 description: Ship a the-cycle story — commit the reviewed work, push, open a PR that Closes #<n>, and (for a safe story) merge it via the background poll-then-merge guard; a judgment-call story's PR is left for Brandon's manual merge. Done = the issue closes on merge. Plan-first. Usage `/done #<n>`. Use after /review (+ /patch) pass clean.
 ---
-<!-- cycle:rendered template=skills/done.md.tmpl hash=4ec3b11ed433 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/done.md.tmpl hash=d83ffbfc6a79 — managed by the-cycle; edit the template, not this file -->
 
 # /done #<n> — ship a story
 
@@ -23,6 +23,7 @@ mechanics, §8 Commit & PR conventions, §9 Branch policy. The procedure below i
 2. **Confirm gates green** (§4) — never `/done` over a red build:
    ```
    npm test
+   node bin/cycle.mjs check
    ```
 3. **Confirm findings were actioned, not parked** (§5) — `/patch` fixed every real finding, or
    each was an explicit escalation to a `finding` issue. Never a silent defer.

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -2,7 +2,7 @@
 name: implement
 description: Implement a single the-cycle work story from its issue. Reads the spec from the issue body (Why / Touches / Acceptance), picks the executor (orchestrator-inline by default; a parallel agent only for independent mechanical work across several files), moves it to status:in-progress, and presents a plan before building. Plan-first. Usage `/implement #<n>`.
 ---
-<!-- cycle:rendered template=skills/implement.md.tmpl hash=d01840ec8b68 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/implement.md.tmpl hash=ec9c0164c37d — managed by the-cycle; edit the template, not this file -->
 
 # /implement #<n> — ship a single story
 
@@ -51,6 +51,7 @@ claims), §4 Gates, §9 Branch policy. The procedure below is just the ordering.
 9. **Independently re-verify** when an agent was spawned (§3) — re-run the gates **yourself**:
    ```
    npm test
+   node bin/cycle.mjs check
    ```
    The agent's "green" is a claim, not proof; a spawned "all green" has failed in a clean shell.
    A subagent reporting "completed" is likewise evidence of *intent*, not that its writes landed —

--- a/.claude/skills/patch/SKILL.md
+++ b/.claude/skills/patch/SKILL.md
@@ -2,7 +2,7 @@
 name: patch
 description: Address /review findings on the uncommitted the-cycle diff. Reads the most-recent review output from context, triages (fix-now is the DEFAULT for any finding about this diff — P0/P1/bounded-P2; escalate to Brandon if it needs a decision or is too big), presents a fix plan, then patches inline — no agent spawn, the orchestrator already holds the diff + findings. Re-runs the gates after. Use after /review, before /done. Plan-first.
 ---
-<!-- cycle:rendered template=skills/patch.md.tmpl hash=ce0e7c9f32f5 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/patch.md.tmpl hash=69279047fb66 — managed by the-cycle; edit the template, not this file -->
 
 # /patch — address reviewer findings
 
@@ -38,6 +38,7 @@ stays in progress.
 5. **Re-run gates** (§4):
    ```
    npm test
+   node bin/cycle.mjs check
    ```
    Re-spawn a specific reviewer if the patch landed in their lane. If a Fix-now patch fails a gate,
    stop and surface — don't pile on.

--- a/.cycle/config.jsonc
+++ b/.cycle/config.jsonc
@@ -68,7 +68,11 @@
     "executor_default": "orchestrator-inline"
   },
   "gates": {
-    "test": "npm test"
+    "test": "npm test",
+    // The dogfood's self-consistency gate: a template edit that skips `cycle update`
+    // leaves this repo's own rendered copy behind, and nothing else notices. Offline
+    // and deterministic by design, so CI runs it too (.github/workflows/ci.yml).
+    "check": "node bin/cycle.mjs check"
   },
   "deps": {
     "outdated": "npm outdated",

--- a/.cycle/state.json
+++ b/.cycle/state.json
@@ -1,17 +1,17 @@
 {
-  "upstream": "1c92f78-dirty",
+  "upstream": "2aa9504-dirty",
   "files": {
-    ".claude/skills/DOCTRINE.md": "6913f5e9b053",
+    ".claude/skills/DOCTRINE.md": "0dca555ec9cd",
     ".claude/skills/cycle/SKILL.md": "7df092de0d13",
-    ".claude/skills/implement/SKILL.md": "d01840ec8b68",
+    ".claude/skills/implement/SKILL.md": "ec9c0164c37d",
     ".claude/skills/review/SKILL.md": "7480fa810fb6",
-    ".claude/skills/patch/SKILL.md": "ce0e7c9f32f5",
-    ".claude/skills/done/SKILL.md": "4ec3b11ed433",
+    ".claude/skills/patch/SKILL.md": "69279047fb66",
+    ".claude/skills/done/SKILL.md": "d83ffbfc6a79",
     ".claude/skills/next/SKILL.md": "0afc40565e46",
     ".claude/skills/intake/SKILL.md": "7fb751ead121",
     ".claude/skills/scout/SKILL.md": "bbfa6de5fa2e",
     ".claude/skills/burndown/SKILL.md": "2a7af6f01608",
-    ".claude/skills/dep-update/SKILL.md": "b491f8fb56b8",
+    ".claude/skills/dep-update/SKILL.md": "58c6bd2d36a2",
     ".claude/skills/deploy-test/SKILL.md": "8a0cf4447165",
     ".claude/skills/deploy-prod/SKILL.md": "41ad9d2f17db"
   }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
-# the-cycle has one gate: `npm test` (node --test, zero dependencies — no install
-# step needed). The poll-then-merge guard watches this check and only merges a PR
-# once it's green; main is branch-protected with `gates` as the required context.
+# the-cycle's gates: `npm test` (node --test, zero dependencies — no install step
+# needed) and `cycle check` (this repo dogfoods its own render; a template commit
+# that forgot `cycle update` would otherwise merge green with the rendered copy
+# stale). Auto-merge waits on this check; main is branch-protected with `gates`
+# as the required context.
 # GitHub's context is the bare job name — NOT a scoped form like
 # "CI / gates (pull_request)" — so keep it in sync with the job name below.
 #
@@ -36,3 +38,7 @@ jobs:
         with:
           node-version: '22'
       - run: npm test
+      # Offline + deterministic (network probes are behind --verify-forge), so it is
+      # CI-safe. Fails if a template moved without `cycle update` re-rendering this
+      # repo's own copy — the drift the tool exists to catch, caught on itself.
+      - run: node bin/cycle.mjs check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,9 @@ and risk surfaces. It replaces three hand-copied, silently-diverged pipelines wi
 source; `cycle update` propagates improvements outward, `cycle check` makes drift visible. Full
 rationale and diagram: `README.md`.
 
-Zero dependencies, Node ESM, `>=20`. The entire CLI is `bin/cycle.mjs` (one file, on purpose — it's
-installed via symlink, so no module resolution games).
+Zero dependencies, Node ESM, `>=20`. The CLI is `bin/cycle.mjs` plus two lazily-imported siblings
+(`bin/adopt.mjs`, `bin/lint.mjs`) — it's installed via symlink, and relative sibling imports
+resolve through that with no module resolution games.
 
 ## This repo dogfoods itself
 
@@ -34,7 +35,9 @@ Every file under `.claude/skills/` carries a provenance comment and must never b
 ## Commands
 
 ```sh
-npm test                                    # the only gate — node --test test/*.test.mjs
+npm test                                    # node --test test/*.test.mjs
+cycle check                                 # the other gate — this repo's own rendered
+                                             #   copy must match the templates (dogfood)
 node --test test/render.test.mjs            # a single test file
 node --test --test-name-pattern="drift"     # a single test by name, across files
 cycle lint                                  # internal consistency: §N citations, verb bindings,
@@ -97,8 +100,8 @@ into the template or config, don't force over it.
 
 ## CI
 
-`.github/workflows/ci.yml` — one `gates` job, `npm test`, on `ubuntu-latest`, no install step
-(zero dependencies). GitHub-hosted rather than ghrunner01 because this repo is public and the org's
+`.github/workflows/ci.yml` — one `gates` job (`npm test` + `node bin/cycle.mjs check`), on
+`ubuntu-latest`, no install step (zero dependencies). GitHub-hosted rather than ghrunner01 because this repo is public and the org's
 runner group refuses public repos. `main` is branch-protected on the bare context name `gates` (not
 a scoped `CI / gates (pull_request)` form); PRs merge via the backend's poll-then-merge guard once
 CI is green, not a server-side auto-merge.

--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 // cycle — render the-cycle's work pipeline into a repo, and keep it honest.
 //
-// Zero dependencies, Node ESM. The whole CLI lives in this file on purpose: it is
-// installed via a symlink from ~/.local/bin (see install.sh), so a single file with
-// no resolution games is the shape that survives.
+// Zero dependencies, Node ESM. The CLI is this file plus two lazily-imported
+// siblings (adopt.mjs, lint.mjs), resolved relative to this file — it is installed
+// via a symlink from ~/.local/bin (see install.sh), and relative sibling imports
+// survive that with no module-resolution games.
 //
 // Commands: install · update · check · adopt · eject · render (debug)
 //
@@ -689,8 +690,7 @@ const upstreamSha = () => {
 function writeState(root, plan) {
     const files = {};
     for (const f of plan) files[f.rel] = readProvenance(f.content)?.hash ?? '';
-    const state = { upstream: upstreamSha(), profile: undefined, files };
-    delete state.profile;
+    const state = { upstream: upstreamSha(), files };
     writeFileSync(statePath(root), `${JSON.stringify(state, null, 2)}\n`);
 }
 

--- a/bin/lint.mjs
+++ b/bin/lint.mjs
@@ -26,6 +26,8 @@
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
+import { readJsonc } from './cycle.mjs';
+
 const ERROR = 'error';
 const WARN = 'warn';
 
@@ -382,16 +384,6 @@ export function lint({ CYCLE_HOME }) {
     }
 
     return findings;
-}
-
-/** Local copy so lint can run standalone; same stripper the CLI uses. */
-function readJsonc(path) {
-    const text = readFileSync(path, 'utf8');
-    return JSON.parse(
-        text
-            .replace(/"(?:[^"\\]|\\.)*"|\/\/[^\n]*|\/\*[\s\S]*?\*\//g, (m) => (m.startsWith('"') ? m : ''))
-            .replace(/,(\s*[}\]])/g, '$1'),
-    );
 }
 
 export function cmdLint(args, { CYCLE_HOME, bold, dim, red, yellow, green }) {

--- a/templates/DOCTRINE.md.tmpl
+++ b/templates/DOCTRINE.md.tmpl
@@ -295,8 +295,21 @@ file* — neither fixes, branches, or merges.
    - **Unsure → no status label.** It lands in the untriaged pile (§1) for a human look — the
      filing-time twin of §5's "when unsure, exclude and surface."
 
-   A finding that touches a §5 brake surface is **never** deterministic, however certain the fix
-   looks — certainty and safety are different axes, and pickable requires both.
+   On a §5 brake surface, test the **direction of the change, not the surface it touches**. A
+   finding there is deterministic only when it *tightens* — more validation, more redaction,
+   stricter gates, fewer accepted inputs — **and** §4's gates can demonstrate both the tightening
+   and that nothing legitimate was lost. Anything that loosens, exempts, widens, or re-opens is
+   **never** deterministic, however small the diff: certainty and safety are different axes, and
+   pickable requires both.
+
+   The second half of that test is load-bearing, because tightening is not automatically safe. A
+   redaction rule greedy enough to eat the evidence a validator needs, or a gate strict enough to
+   reject legitimate traffic, fails *closed* — which is the quiet direction, and the one that
+   hides. Pickable means the gates prove both halves; if they can only prove the tightening, it is
+   interpretive.
+
+   A brake entry describing an **irreversible action** rather than a code change — running a
+   destructive verb, writing to production — has no direction to test and never becomes pickable.
 6. **Budget.** Filing zero is a success. A sweep that files 20 low-grade issues has made the queue
    worse, not better. Cap a focused pass at **3–5** findings; a multi-lens sweep caps *per lens* and
    stays in single digits overall. Rank by (impact × how-actionable) and file only the top ones —


### PR DESCRIPTION
Four small fixes from a codebase review. Stacked on #17 (the §10.5 doctrine cherry-pick) — the diff shrinks to just this PR's changes once #17 merges.

**What shipped:**

- **CI + this repo's §4 gates now run `node bin/cycle.mjs check`.** The motivating failure is live in the history: the §10.5 doctrine commit changed the template without re-rendering this repo's own copy, and nothing caught it — the exact drift the tool exists to detect, invisible on the tool's own repo. `check` is offline and deterministic by design, so it is CI-safe. The owed re-render (DOCTRINE + the four skills that print the gates block) is included.
- **One JSONC parser, not two.** `lint.mjs` now imports `readJsonc` from `cycle.mjs` instead of carrying its own untested regex-based stripper that could disagree on an edge case.
- **Retired the stale "one file, on purpose" claim** in the `cycle.mjs` header and CLAUDE.md — the CLI is three files with lazy sibling imports, and the symlink rationale survives that fine.
- **Dropped a dead `profile: undefined` + `delete` pair** in `writeState`.

Gates: npm test 101/101 · cycle lint clean · cycle check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)