### PR TITLE
feat(tooling): improve agent development environment

### DIFF
--- a/.agents/skills/DOCTRINE.md
+++ b/.agents/skills/DOCTRINE.md
@@ -1,4 +1,4 @@
-<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=0a060e228db8 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=53ecb293e2c7 — managed by the-cycle; edit the template, not this file -->
 # Pipeline doctrine (shared)
 
 Single source of truth for the rules the the-cycle work-loop skills share. A skill that says
@@ -196,7 +196,7 @@ that isn't in the §1 table.
   **with `Closes #<n>`** (closing the issue is the done-signal), title = the Conventional-Commit
   subject. PR bodies end with:
   ```
-  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+  🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)
   ```
 - The `Closes/Fixes/Resolves #N` keyword fires **anywhere** in the body regardless of surrounding
   prose — writing "`Closes #844` is NOT set" still closes #844. When carving one item out of a

--- a/.agents/skills/burndown/SKILL.md
+++ b/.agents/skills/burndown/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: burndown
+description: Autonomously grind through the SAFE, self-contained subset of the the-cycle backlog — pre-filters out anything touching DOCTRINE §5's always-brake surfaces (auth / tokens / secrets, schema / data migration, anything destructive or irreversible) or posing an open decision, then loops `/cycle #<n>` over the rest, plus standing hygiene (`/dep-update`, a bounded dead-code sweep) when the issue queue is thin. A judgment call parks that item and the loop moves on; the run itself stops at 5 shipped items, a red gate, or a dry queue. Plan-first. Never touches prod. Usage `/burndown`.
+---
+<!-- cycle:rendered template=skills/burndown.md.tmpl hash=0ba6d12b6424 — managed by the-cycle; edit the template, not this file -->
+
+# /burndown — grind the safe backlog autonomously
+
+Goal: tick off the safe, no-judgment-call work without Brandon babysitting each one, so a
+session runs mostly unattended and the merged results get reviewed after. The curating layer on top
+of `/cycle`, not a replacement for its safety logic.
+
+**Shared rules in `.agents/skills/DOCTRINE.md` — read it if not already in context.** The safe set
+this skill lives or dies by *is* §5's always-brake list. Also leans on §1 (Status/ranking), §2
+(Labels), §6 (Merge guard — already enforced *inside* `/cycle` → `/done`; don't re-implement it
+here), §7 (tracker mechanics). **When in doubt, exclude and surface — never include.**
+
+## How this differs from `/cycle next --until-blocked`
+
+`/cycle next --until-blocked` already runs hands-off and already stops at a judgment call — most of
+the safety machinery lives there, not here. The gap it leaves: it picks by **strict rank** and
+**stops the whole chain** the moment the top-ranked item turns out to need a judgment call, even if
+three safer issues sit right behind it. `/burndown` pre-vets the queue so a known-risky issue
+doesn't block a session's throughput — it's skipped (and surfaced in the report), not a stopping
+point.
+
+Use `/cycle next --until-blocked` when you want the *next* thing in strict priority order
+regardless of risk; use `/burndown` when you want to clear as much *safe* work as possible in one
+unattended pass.
+
+## The safe filter (what /burndown MAY queue)
+
+Qualifies only if **all** hold — read the issue body; don't just pattern-match the labels:
+
+- **Labeled `status:ready`** — pickable, not already in flight.
+- **Doesn't pose an open decision.** An issue framed "decide one of: A / B" is a human `/cycle`
+  candidate regardless of how small the eventual diff is — a decision is a judgment call by
+  construction.
+- **Doesn't touch a §5 always-brake surface** (auth / tokens / secrets, schema / data migration, anything destructive or irreversible). Labels are a first-pass signal,
+  **not the filter**: a clean dependency CVE bump under a `security` label can be perfectly safe,
+  and an unlabeled issue can still be risky. **Read the body and the touched area before
+  deciding.**
+- **Well-specified and bounded** — clear acceptance, single area, no "TBD" scope.
+- **Gate-verifiable** (§4) — not something whose correctness needs a live or manual glance.
+
+If an item *almost* qualifies but has one catch, it's **out** — leave it for a human `/cycle #<n>`.
+
+## What's in scope
+
+1. **Safe-filtered pickable issues** (above), ordered by §1's ranking within the filtered set.
+2. **Standing hygiene**, when the filtered queue is thin or dry:
+   - **`/dep-update`** — run its workflow inline.
+   - **A bounded dead-code / type-safety sweep** — mirrors `/scout`'s hygiene lens. **Verify the
+     gap is real first** (read the code, don't assume); keep each sweep single-area and small.
+     Skip if nothing concrete turns up — don't invent a change.
+
+## Workflow
+
+1. **Build the safe queue.** Pull the open set (§7); partition to pickable; apply the safe filter
+   to each; order the survivors by §1 rank. Note (but don't queue) anything excluded, with a
+   one-line reason.
+2. **Present the curated queue** (plan-first): the ordered list, one line each on *why it's safe*,
+   the excluded set + why, and the hygiene fallback if the queue's thin. This is the only
+   checkpoint — then it runs unattended.
+3. **Work each item: `/cycle #<n>`** (run its workflow inline — don't re-derive it). `/cycle`'s own
+   judgment-call detection is the real backstop. If a pre-vetted item still trips one mid-cycle,
+   that's the filter being wrong on this one, not a bug in the loop — **stop that item** (leave its
+   PR open, per `/cycle`'s own behavior) **and continue to the next queued item**.
+4. **When the issue queue is dry, run the hygiene fallback.** Re-verify gates yourself after each —
+   never trust a spawned "green" (§3).
+5. **Stop — and report — when ANY of:**
+   - **5 items shipped** this run (issues + hygiene combined) → check in (runaway guard).
+   - **Gates or CI red**, and not a trivial retry.
+   - **The safe queue AND the hygiene fallback are both dry.**
+   - Interrupt.
+6. **Report:** what shipped (issue/PR links), what was excluded and why (so Brandon can
+   `/cycle #<n>` those himself), and anything left running or blocked.
+
+## Safety
+
+- **The filter is conservative by design.** Excluding a safe-ish item costs a bit of throughput;
+  including an unsafe one costs trust in the whole queue. **Exclude when unsure.**
+- **Auto-merge is entirely `/cycle`/`/done`'s job** (§6) — `/burndown` never merges directly.
+- **Prod deploy is never part of `/burndown`** — always Brandon's explicit `/deploy-prod`.
+- Honor `/cycle`'s own >30-min-per-cycle guard.
+
+## Edge cases
+
+- **Nothing safe to do:** say so plainly — the backlog is all blocked, sensitive, or design-shaped.
+  Point at `/scout` to refill the queue, or suggest a human `/cycle #<n>` on the judgment-call
+  pile. **Don't manufacture busywork.**
+- **A hygiene pass has no real work:** skip it, say so, don't invent a change.
+- **An item looked safe but the diff turned sensitive mid-cycle:** that's `/cycle`'s own brake
+  doing its job — treat it as informative for next run's filter, not as a failure.
+
+## How it fits the pipeline
+
+- **`/scout`** = code → candidate issues (feeds this queue).
+- **`/burndown`** = grind the safe subset of that queue, unattended, plus hygiene backfill.
+- **`/cycle #<n>`** = the human-in-the-loop path for anything `/burndown` excludes, and the engine
+  `/burndown` calls under the hood.

--- a/.agents/skills/cycle/SKILL.md
+++ b/.agents/skills/cycle/SKILL.md
@@ -2,14 +2,14 @@
 name: cycle
 description: Run the full the-cycle story loop on one issue or a chain — composes /implement → /review → /patch → /done (→ optional /deploy-test), interrupting only on a judgment call. Usage `/cycle #<n>` · `/cycle next` · `/cycle next --until-blocked` · add `--deploy`.
 ---
-<!-- cycle:rendered template=skills/cycle.md.tmpl hash=c5fa85661a41 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/cycle.md.tmpl hash=260b386a0a4c — managed by the-cycle; edit the template, not this file -->
 
 # /cycle — full loop on one story or a chain
 
 Goal: collapse the routine `/implement → /review → /patch → /done` rhythm into one invocation.
 Plan-first.
 
-**Shared rules in `.claude/skills/DOCTRINE.md` — read it if not already in context.** This skill is
+**Shared rules in `.agents/skills/DOCTRINE.md` — read it if not already in context.** This skill is
 the orchestrator of the others, so it leans on nearly all of it: §1 readiness, §3 routing, §4
 Gates, **§5 Judgment calls & autonomy (the governing rule below IS §5)**, §6 Merge guard, §8/§9
 commit and branch policy. The phases invoke `/implement`, `/review`, `/patch`, `/done` — run their

--- a/.agents/skills/dep-update/SKILL.md
+++ b/.agents/skills/dep-update/SKILL.md
@@ -2,13 +2,13 @@
 name: dep-update
 description: Routine dependency hygiene for the-cycle — survey what's outdated, plan the bump, update, run the gates, and land one dependency-metadata commit. Distinguishes a stale test expectation from a real regression. Never uses `audit fix --force`; never auto-pushes. Plan-first. Usage `/dep-update` (or `/dep-update <package>`).
 ---
-<!-- cycle:rendered template=skills/dep-update.md.tmpl hash=b5d36ac6dff1 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/dep-update.md.tmpl hash=70677227a33a — managed by the-cycle; edit the template, not this file -->
 
 # /dep-update — dependency hygiene
 
 Goal: keep dependencies current without turning a routine bump into an outage.
 
-**Shared rules in `.claude/skills/DOCTRINE.md` — read it if not already in context.** Leans on §4
+**Shared rules in `.agents/skills/DOCTRINE.md` — read it if not already in context.** Leans on §4
 (Gates), §8 (commit conventions — explicit paths), §9 (branch policy).
 
 ## Workflow

--- a/.agents/skills/deploy-prod/SKILL.md
+++ b/.agents/skills/deploy-prod/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: deploy-prod
+description: Deploy the-cycle to production — the gated ritual. Preflight (clean pushed main, what's actually shipping, any migration plan), then STOP for Brandon's explicit go, then deploy, then independently verify the public origin. Includes the rollback path. Never runs unattended. Usage `/deploy-prod`.
+---
+<!-- cycle:rendered template=skills/deploy-prod.md.tmpl hash=1d59d46239ff — managed by the-cycle; edit the template, not this file -->
+
+# /deploy-prod — ship to production
+
+Goal: make the safe path automatic — **not** the decision to ship.
+
+**Shared rules in `.agents/skills/DOCTRINE.md` — read it if not already in context.** This is the
+one skill with a hard human gate. `/burndown`, `/cycle` and every unattended path are forbidden
+from invoking it.
+
+## 1. Preflight (read-only)
+
+- **Clean tree, on `main`, pushed.** A dirty or unpushed tree means the thing you're about to ship
+  isn't the thing in the repo. Refuse.
+- **Gates green** (§4).
+- **Show exactly what's shipping.** Diff against what's *live*, not against the last tag or a
+  stored ref — a stored deploy ref drifts silently and will happily lie to you. Read the live
+  revision from the running origin and `git log <live>..HEAD`.
+- **Any data migration in the pending set → surface it before the gate**, with what it does and
+  whether it's reversible. A migration is a §5 always-brake surface in its own right.
+
+## 2. THE GATE
+
+Present the preflight and **stop.** Wait for one explicit "go" from Brandon in this turn.
+
+Not a go: general enthusiasm, approval of the *code*, a merged PR, or an earlier "ship it" about
+something else. Approval of the work is not approval of the deploy. If you're unsure whether you
+have a go, you don't.
+
+## 3. Deploy
+
+**`deploy.prod` is not set in `.cycle/config.jsonc`** — stop and say so.
+There is no deploy command to run, and prod is the last place to improvise one.
+
+## 4. Verify independently
+
+Don't trust the deploy script's own success report — check the **public origin** yourself:
+
+- It responds (and with the right status).
+- The served build **is the one you just deployed** — compare the revision, don't assume.
+- Spot-check one surface that actually changed in this deploy.
+
+Report green only if all of those hold. "The script said OK" is not verification.
+
+## 5. Report + rollback
+
+State what shipped, the live revision, and the verification results.
+
+**Rollback = roll forward.** `git revert` → PR → green → deploy again. Reverting the deploy in
+place leaves the repo and the box disagreeing about reality, which is worse than the bug you're
+rolling back.
+
+## Why this one is gated
+
+Everything else in this pipeline is auto-merged on green because a wrong merge is cheap to walk
+back. Prod is different: it's the one place where a mistake is visible to real users on someone
+else's schedule. The gate isn't distrust of the pipeline — it's an acknowledgment that the *cost
+function* changes here, and the person who owns the consequences should be the one who says go.
+
+## Edge cases
+
+- **Preflight fails:** stop, report which check. Never "deploy anyway."
+- **Deploy fails partway:** say exactly which step, and whether a migration ran. Do not retry
+  blindly — a half-applied migration needs a decision, not a rerun.
+- **Verification disagrees with the deploy script:** trust the origin. Report as a failure.
+- **Asked to deploy unattended** (from `/burndown`, an overnight lane, or a chained skill):
+  **refuse.** Report that prod needs an explicit invocation.

--- a/.agents/skills/deploy-test/SKILL.md
+++ b/.agents/skills/deploy-test/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: deploy-test
+description: the-cycle has no separate test environment — a stub that redirects to /deploy-prod's gate rather than letting an ungated deploy reach production. Usage `/deploy-test`.
+---
+<!-- cycle:rendered template=skills/deploy-test.md.tmpl hash=8a0cf4447165 — managed by the-cycle; edit the template, not this file -->
+
+# /deploy-test — not applicable here
+
+**`deploy.test` is not set in `.cycle/config.jsonc`.** the-cycle has no lower-stakes target to
+preview a branch or a dirty tree on, so there is nothing for this skill to deploy to.
+
+**Do not substitute the production deploy.** The test flow is deliberately ungated — *no gate, no
+explicit go* — because a test box is cheap to get wrong. Pointing that ceremony at the only
+environment there is would turn a low-ceremony preview into an unreviewed production release.
+That inversion is the exact mistake this stub exists to prevent.
+
+## If you were asked to preview something
+
+1. **Say plainly there is no test environment here** — don't improvise one, and don't reach for
+   the production deploy command.
+2. **If it genuinely needs to ship,** hand off to `/deploy-prod`, which carries the explicit-go
+   gate a real deploy requires.
+3. **If it only needs looking at,** run it locally instead.

--- a/.agents/skills/done/SKILL.md
+++ b/.agents/skills/done/SKILL.md
@@ -2,7 +2,7 @@
 name: done
 description: Ship a the-cycle story — commit the reviewed work, push, open a PR that Closes #<n>, and (for a safe story) queue server-side auto-merge; a judgment-call story's PR is left for Brandon's manual merge. Done = the issue closes on merge. Plan-first. Usage `/done #<n>`. Use after /review (+ /patch) pass clean.
 ---
-<!-- cycle:rendered template=skills/done.md.tmpl hash=9a77f154a49f — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/done.md.tmpl hash=76b4130435ca — managed by the-cycle; edit the template, not this file -->
 
 # /done #<n> — ship a story
 
@@ -10,7 +10,7 @@ Goal: commit the reviewed work, push, open a PR that closes the issue, and land 
 queueing a safe story for CI-gated server-side auto-merge, or leaving a
 judgment-call PR for Brandon.
 
-**Shared rules in `.claude/skills/DOCTRINE.md` — read it if not already in context.** This skill
+**Shared rules in `.agents/skills/DOCTRINE.md` — read it if not already in context.** This skill
 leans on §4 Gates, §5 Judgment calls (the safe-vs-brake split), §6 Merge guard, §7 Tracker
 mechanics, §8 Commit & PR conventions, §9 Branch policy. The procedure below is just the ordering.
 

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: implement
+description: Implement a single the-cycle work story from its issue. Reads the spec from the issue body (Why / Touches / Acceptance), picks the executor (orchestrator-inline by default; a parallel agent only for independent mechanical work across several files), moves it to status:in-progress, and presents a plan before building. Plan-first. Usage `/implement #<n>`.
+---
+<!-- cycle:rendered template=skills/implement.md.tmpl hash=ed230d275141 — managed by the-cycle; edit the template, not this file -->
+
+# /implement #<n> — ship a single story
+
+Goal: load one issue's context, present a plan, build, report.
+
+**Shared rules in `.agents/skills/DOCTRINE.md` — read it if not already in context.** This skill
+leans on §1 Tracker & readiness (pickability), §3 Routing (executor choice; re-verify agent
+claims), §4 Gates, §9 Branch policy. The procedure below is just the ordering.
+
+## Workflow
+
+1. **Parse the issue ref** — `#<n>` (or a bare number).
+2. **Read the issue:**
+   - `gh issue view "<n>" --json number,title,state,url,labels,milestone,body` — Why / Touches / Acceptance (body), labels (§2), epic (milestone).
+   - Its current Status (§1).
+   - The relevant docs + `CLAUDE.md`.
+3. **Check it's pickable** (§1). `status:ready` → pick. `status:in-progress` →
+   likely mid-flight; confirm before re-building. No status label → warn it's untriaged; proceed only if
+   genuinely scoped (the write below promotes it).
+4. **Pick the executor** (§3) — **`orchestrator-inline` by default**: the main thread
+   builds, keeping accumulated context (right for small diffs, and for the surfaces where a cold
+   agent re-derives brittle detail and ships latent bugs). **Spawn a parallel agent only for
+   independent mechanical work** (the same change across several files); keep shared-file edits
+   (indexes, schema) and the §4 gates on the main thread.
+5. **Mark it `status:in-progress`:** `gh issue edit "<n>" --remove-label "status:ready,status:in-progress,status:in-review,status:needs-decision,status:blocked" --add-label "status:in-progress"`
+6. **Branch check** (§9) — if on `main`, branch first (`git checkout -b <short-slug>`); reuse an
+   epic branch if one exists. Never build on `main`.
+7. **Present the plan** (a status update, not a gate — §5):
+
+   ```
+   ## Plan: #<n> — <title>
+
+   **Issue:** #<n>  ( <milestone> )   **Status:** status:in-progress
+   **Executor:** orchestrator-inline | parallel agent   **Branch:** <branch>
+   **Files I expect to touch:** <from Touches in the body>
+   **Acceptance gates:** §4
+   **Approach:** <2–4 bullets>
+   ```
+
+8. **Build immediately** in the same turn — no "Proceed?" wait, unless step 3 or 10 already
+   surfaced a judgment call.
+   - **Inline (default):** the orchestrator edits directly.
+   - **Spawn (mechanical fan-out only):** the prompt cites the **issue #** + acceptance, the files
+     it owns (no others), the §4 gates, and asks for a `## Result` block.
+   - Run the §4 gates either way.
+9. **Independently re-verify** when an agent was spawned (§3) — re-run the gates **yourself**:
+   ```
+   npm test
+   node bin/cycle.mjs check
+   ```
+   The agent's "green" is a claim, not proof; a spawned "all green" has failed in a clean shell.
+   A subagent reporting "completed" is likewise evidence of *intent*, not that its writes landed —
+   confirm the files actually changed before trusting the report.
+10. **Always-brake check** (§5) — if the diff lands on auth / tokens / secrets, schema / data migration, anything destructive or irreversible, flag it now; `/review`
+    will route a `/security-review`.
+11. **Report** the `## Result` (or inline summary) + the *re-verified* gate status. **Don't run
+    reviewers** (`/review`). **Don't commit / push / merge** (`/done`).
+12. **Suggest next:** `/review` → `/patch` → `/done`.
+
+## Edge cases
+
+- **Issue is a judgment call** (§5, or ambiguous with no obvious default): surface options + a
+  recommendation; don't guess.
+- **No Status (untriaged idea):** warn it's not a scoped story; proceed only if genuinely scoped.
+- **Agent returns Blocked:** present the blocker; don't auto-retry. Common causes: the spec no
+  longer matches the code (refresh the issue body), or the acceptance criterion can't be measured.
+- **Gates red:** report; don't hand off to `/review` against a broken build.
+- **Build abandoned** (not handed to `/review`): roll the label back to `status:ready`
+  (`gh issue edit "<n>" --remove-label "status:ready,status:in-progress,status:in-review,status:needs-decision,status:blocked" --add-label "status:ready"`) so nothing is stranded mid-flight.

--- a/.agents/skills/intake/SKILL.md
+++ b/.agents/skills/intake/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: intake
+description: The front door to the backlog — turn a plain-English idea into an actionable the-cycle issue. Interviews Brandon ONE question at a time until the issue is genuinely implementable, then drafts it, classifies it, and files it. Plan-first — always shows the shaped issue before writing. Shares /scout's filing mechanics (DOCTRINE §10). Usage `/intake <the idea>` (or bare, and it'll ask).
+---
+<!-- cycle:rendered template=skills/intake.md.tmpl hash=3db22c6ab9ad — managed by the-cycle; edit the template, not this file -->
+
+# /intake — turn an idea into an actionable issue
+
+Goal: stop a good idea from evaporating, or from landing as a vague one-liner that blocks later
+work. Every other pipeline skill *reads* the tracker (`/next` picks, `/cycle` builds, `/burndown`
+grinds); this one *writes* a well-formed issue into it from a plain-English idea.
+
+**Shared rules in `.agents/skills/DOCTRINE.md` — read it if not already in context.** The filing
+mechanics — dedup, the actionable bar, body format, budget — are **§10**; don't restate them,
+apply them. Classification maps onto §2 (Labels) and §1 (Status). The write step uses §7.
+
+**The bar is "actionable"** (§10). A filed issue must be implementable from its own text —
+`/implement` or `/cycle` should know exactly what "done" looks like without asking again. If the
+idea isn't there yet, **interview it up to that bar** before filing. A vague issue is worse than no
+issue: it defers the thinking to a moment with *less* context than right now.
+
+## The one rule that makes this skill itself: interview ONE question at a time
+
+Brandon will describe the idea in good faith; your job is sharpening it to actionable —
+proposing the shape, filling obvious gaps yourself, asking only where the answer genuinely changes
+the issue. So:
+
+- Ask **one focused question, then wait.** No batched multi-question forms.
+- **Reflect each answer back** in a sentence, so drift gets caught early.
+- Ask only about what's **genuinely missing for the issue to be actionable** — infer the rest.
+- **Lead with a recommendation** on every judgment-call question. *"I'd scope this to the
+  operator-side fix, not both stacks — sound right?"* beats *"what's the scope?"*
+- **Stop the moment it's actionable.** Three crisp exchanges is great; ten is a slog.
+
+This harness has no structured menu tool — ask each question directly in chat, one at a time,
+leading with a recommendation, and wait for the reply.
+
+## Workflow
+
+1. **Hear the idea.** If invoked bare, ask what's on Brandon's mind. If it carried text, restate it in
+   one plain sentence to confirm alignment before digging.
+
+2. **Dedup first** (§10, read-only): search open issues on the idea's keywords and skim titles. If
+   a likely twin exists, surface it — *"We already have #N for this — extend that, or is yours
+   different?"* Extending is often the right move; never file a duplicate.
+
+3. **Interview to actionable — one question at a time.** Ask about the highest-value *gap* first,
+   skipping anything already clear:
+   - **The symptom / why** — what's actually going wrong or missing, concretely. This usually
+     arrives up front; reflect it back rather than re-asking.
+   - **Acceptance — the load-bearing one.** What does "done" look like, verifiably? If that's
+     fuzzy, this is the question to ask.
+   - **Scope boundary** — what's explicitly *not* in this? Keeps it small and stops creep.
+   - **Does it touch a §5 always-brake surface** (auth / tokens / secrets, schema / data migration, anything destructive or irreversible)? If so, say so plainly in the
+     drafted body — it still files normally, but `/cycle` will pause there for a human call
+     regardless of how the issue reads.
+   - **Is it actually a decision, not a task** (no work happens until a direction is picked)? If
+     so, write the options into the body ("decide one of: A / B") rather than picking one.
+
+4. **Draft and show the shaped issue** — title, body in §10's Why / Touches / Acceptance format,
+   and the classification you'd apply. **This is the checkpoint**: nothing is written until it's
+   seen it.
+
+5. **File it** (§7): `gh issue create --title "<title>" --body "<body>" --label "<label>"` — the label is a §2 workflow
+   label describing *what kind of work it is* (`bug` and the `area:*` set); no fitting label is
+   fine. Then route it by §10.5's certainty call — which the interview already made: an idea that
+   reached the actionable bar is pickable, `gh issue edit "<n>" --remove-label "status:ready,status:in-progress,status:in-review,status:needs-decision,status:blocked" --add-label "status:ready"`;
+   one that's really a decision (step 3) gets `gh issue edit "<n>" --remove-label "status:ready,status:in-progress,status:in-review,status:needs-decision,status:blocked" --add-label "status:needs-decision"`
+   instead. There is nothing to add it *to* — an open issue is already in the queue; the status
+   label is the only write.
+
+6. **Report** the issue number and URL, and suggest `/cycle #<n>` if it's ready to build now.
+
+## Batch mode
+
+Given several ideas at once, interview them **one at a time** to actionable, draft them all,
+show the set together, then file with a **single batched field write** (§7).
+
+## Guardrails
+
+- **Actionable, or don't file** (§10). If the interview stalls short of that bar, say so and stop —
+  a placeholder issue is debt, not capture.
+- **Read-only until Brandon confirms the draft.** No issue is created mid-interview.
+- **Route honestly** (§10.5) — pickable only when the interview genuinely reached actionable; a
+  decision-shaped idea files as `status:needs-decision`, never as pickable-with-caveats.
+- **Don't fix anything.** `/intake` files; `/cycle` builds. Even a one-line fix goes through the
+  pipeline.
+
+## Edge cases
+
+- **The idea is already an open issue:** extend or comment on it; report which, don't file a twin.
+- **The idea is really several:** say so, and split it — several small actionable issues beat one
+  umbrella nobody can pick up.
+- **The idea is a decision, not work:** file it *as* a decision with the options written out.
+- **Tracker unreachable (§7):** stop. Don't lose the idea — echo the drafted issue in the reply so
+  it can be filed by hand.

--- a/.agents/skills/next/SKILL.md
+++ b/.agents/skills/next/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: next
+description: Pick up the next the-cycle work story. Finds the highest-priority pickable issue, the in-flight work, and the finding pile, and lays out enough to choose /implement (one issue) vs /cycle (full loop). Add `--board` for the whole-queue orientation view instead of a single pick. Plan-first — read-only, no spawn, no edit. Use at session start or whenever deciding what to pick up.
+---
+<!-- cycle:rendered template=skills/next.md.tmpl hash=f49c75d042fd — managed by the-cycle; edit the template, not this file -->
+
+# /next — surface the next work story
+
+Goal: say what to work on next, with enough context to choose `/implement #<n>` vs `/cycle #<n>`.
+
+**Shared rules in `.agents/skills/DOCTRINE.md` — read it if not already in context.** This skill is
+all §1 (Tracker & readiness — the Status model, the ranking), §2 (Labels) and §7 (tracker
+mechanics, including the "unreachable → stop" rule). Don't restate them; apply them.
+
+## Forms
+
+- **`/next`** — the single best pick, with enough context to start. The default.
+- **`/next --board`** — orientation instead of a pick: the whole queue tallied by status label and
+  milestone, what's in flight, what's blocked on Brandon, and the idea pile. Readable in 20
+  seconds. **This is not a planner, a reviewer, or a writer** — it reports, then stops.
+
+## Data sources (§7)
+
+- **The open set** — `gh issue list --state open --json number,title,labels,milestone,url`. This is the whole queue: status is a `status:*` label in
+  each issue's `labels`, so one call returns the work *and* its routing, already scoped to this
+  repo and already limited to open issues. There is no second source to reconcile.
+- **Unreachable → stop** (§7). Say so plainly; never guess tracker state or fall back to a cached
+  list.
+
+## Workflow
+
+1. **Pull the open set** — one call, no join.
+2. **Partition by status label** (§1): pickable · in flight (note, don't re-pick) ·
+   the `finding` pile (review debt — count and sample, don't pick) · **unrouted** (no `status:*` label).
+   Unrouted is not an empty bucket: it's everything still waiting on a §10.5 certainty call —
+   review-carved observations (§2), and findings their filer couldn't confidently route. Never
+   silently drop it — count it, and surface the top candidates under **Untriaged** so it can be
+   promoted.
+3. **Rank the pickable issues** by the §1 rule: **milestone first** (a real numbered epic beats no milestone), then **issue number** (lower first).
+4. **Read the top pick's body** — Why / Touches / Acceptance.
+5. **Check it hasn't already shipped** (§1) — an umbrella issue's slices often land under
+   sibling-numbered PRs that never reference its number. If the body describes behavior that looks
+   familiar, trace it in live code before recommending it.
+6. **Present** (below).
+7. **Stop.** Read-only — no spawn, no edit, no Status or issue changes.
+
+## Presentation
+
+```
+## Next: #<n> — <title>   ( <milestone> )
+
+**Status:** status:ready   **Executor:** orchestrator-inline (default, §3)
+**Reviewer:** inline pass<, + /security-review if the diff touches an always-brake surface (§3)>
+
+**Why / Touches / Acceptance:** <from the issue body>
+
+**Suggested next:**
+- `/implement #<n>` — ship it (plan-first)
+- `/cycle #<n>` — full loop (implement → review → patch → done → PR → CI-gated merge)
+
+**In flight:** #<…>, if any.
+**Findings (review debt — not scheduled):** N issues.
+```
+
+With `--board` — the whole open queue, which is what "the board" means here — replace the single
+pick with: tallies by status label and milestone, what closed
+recently (`gh issue list --state closed --limit 20 --json number,title,closedAt,url` — the open set won't tell you), anything blocked on
+Brandon, the untriaged pile, and `git status` in-flight work — then a one-line
+**Suggested entry point**.
+
+## Edge cases
+
+- **No pickable issues:** say so plainly — the queue is drained. List anything in flight (a merge
+  may be pending, §6) and the `finding` count. Suggest scoping the next epic, or a `/scout` sweep.
+- **All issues shipped/closed:** say so; suggest scoping the next milestone's stories.
+- **An open issue with no `status:*` label:** that's the untriaged pile, not an error — surface it
+  under **Untriaged** so it can be routed. Nothing can be "missing from" the queue any more.
+- **A pickable issue that's really a design call:** `/next` still surfaces it (it *is* pickable),
+  but flag in the body read that it lands on a §5 always-brake surface — `/cycle` will pause there.

--- a/.agents/skills/patch/SKILL.md
+++ b/.agents/skills/patch/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: patch
+description: Address /review findings on the uncommitted the-cycle diff. Reads the most-recent review output from context, triages (fix-now is the DEFAULT for any finding about this diff — P0/P1/bounded-P2; escalate to Brandon if it needs a decision or is too big), presents a fix plan, then patches inline — no agent spawn, the orchestrator already holds the diff + findings. Re-runs the gates after. Use after /review, before /done. Plan-first.
+---
+<!-- cycle:rendered template=skills/patch.md.tmpl hash=21b0fc67d17f — managed by the-cycle; edit the template, not this file -->
+
+# /patch — address reviewer findings
+
+Goal: close the review→done seam — sort `/review`'s findings and apply inline fixes.
+
+**Shared rules in `.agents/skills/DOCTRINE.md` — read it if not already in context.** The triage
+below applies §5 (findings get actioned not parked — the `finding` issue set trends to empty) and
+§2 (the `finding` label); the re-run gates are §4. **Patch does not change Status** — the story
+stays in progress.
+
+## Workflow
+
+1. **Load findings** from the most-recent `/review` output in context (severity, `file:line`,
+   verbatim quote, suggested direction). If not in context (new session), ask Brandon to
+   re-run `/review`.
+2. **Triage:**
+
+   | Triage | Criteria | Action |
+   |---|---|---|
+   | **Fix now (DEFAULT)** | Any finding about the diff under review — P0, P1, **or a bounded P2** (mechanical, or a small/localized change). This is the default, not the exception. | patch inline this turn |
+   | **Escalate to Brandon** | A real finding that (a) needs a design call (§5 — auth / tokens / secrets, schema / data migration, anything destructive or irreversible, or any genuinely ambiguous call), or (b) is large / cross-cutting / would balloon the diff | stop; surface it; **on Brandon's nod** open a `finding` issue (`gh issue create --title "<title>" --body "<body>" --label "finding"`) and/or recommend `/implement #<n>` with a fix-focused prompt — **never silently shelve a real finding** |
+   | **New idea** | A genuinely *new* idea/feature surfaced during review — not a flaw in this code | **note it to Brandon**; don't open an issue unprompted |
+
+   **Bias to fix now.** Deferring a real finding to a list is the thing we're eliminating — the
+   open `finding` issues should trend to *empty* (§2). A fix that's genuinely too big to do
+   in-cycle is an **escalation** (with Brandon's nod), not a silent defer.
+3. **Present the patch plan** (Fix-now / Escalate, each with
+   `file:line` + a fix sketch + the §4 gates) — a status update, not a gate (§5).
+4. **Patch inline immediately** in the same turn, with Edit/Write — no "Apply?" wait, unless a
+   finding needed escalation (§5). **No spawn**: the orchestrator's context already holds the diff
+   and the findings; a subagent would re-derive both and get them subtly wrong. Add a `**Why:**`
+   comment at any non-obvious fix site.
+5. **Re-run gates** (§4):
+   ```
+   npm test
+   node bin/cycle.mjs check
+   ```
+   Re-spawn a specific reviewer if the patch landed in their lane. If a Fix-now patch fails a gate,
+   stop and surface — don't pile on.
+6. **Report:** a table of patches applied (finding → fix), any **escalated** findings, and gate
+   status. The default expectation is that real findings were *fixed*, not parked — call out
+   anything that wasn't, and why. Then suggest `/done` (if green) or `/review` again (if the
+   patches were substantive).
+
+## Safety
+
+- Never patch a file the most-recent `/review` didn't flag — that's scope creep.
+- Never silently downgrade a P0 to avoid escalation; if you think it's overblown, say so and let
+  Brandon decide.
+- Don't run reviewers here — that's `/review`'s job.
+
+## Edge cases
+
+- **No findings:** report; suggest `/done` directly.
+- **All findings are P0 design calls:** patch none; surface the questions; recommend
+  `/implement #<n>`.
+- **Findings conflict** (one says tighten, one says loosen the same threshold): present both; ask —
+  don't auto-pick.
+- **Cited line has moved** (the diff was edited since `/review`): re-Read, relocate by content
+  match, and note the drift.
+- **A finding contradicts a project memory note:** this is a §5 always-brake — **escalate, don't
+  resolve it here.** The memory usually wins, but "usually" is not a license to drop a finding
+  silently: surface both, say which you'd keep and why, and let Brandon call it.

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: review
+description: Review the current uncommitted the-cycle diff. Inspects git status + diff --stat to route reviewers — an inline correctness pass for any non-trivial change, plus `/security-review` whenever the diff touches an always-brake surface (auth / tokens / secrets, schema / data migration, anything destructive or irreversible), and optionally a second-model angle on a meaty diff. Presents the reviewer plan before running. Does NOT change Status — review happens within status:in-progress. Use after /implement, before /done.
+---
+<!-- cycle:rendered template=skills/review.md.tmpl hash=131f0ccfb7cf — managed by the-cycle; edit the template, not this file -->
+
+# /review — review the uncommitted tree
+
+Goal: pick the right reviewers for what changed, run them, present consolidated findings.
+
+**Shared rules in `.agents/skills/DOCTRINE.md` — read it if not already in context.** This skill is
+the detailed expansion of §3 (Reviewers) and routes on §5's always-brake surfaces. The routing
+table below is review's own, more-specific version of §3. **Review does not change Status** — the
+story stays `status:in-progress` through review and patch.
+
+## Workflow
+
+1. **Survey the diff.** `git status` + `git diff --stat`. If the diff is empty, say so and stop.
+2. **Route reviewers.** Rows are **additive** — union the reviewers and run each once.
+
+   | If the diff touches... | Run |
+   | :- | :- |
+   | Any non-trivial code change | the **inline correctness pass** — the orchestrator reviews the diff itself, across the angles a heavyweight reviewer would cover (logic, edges, error paths, contracts, invariants). Match depth to risk. Tests **alongside** prod code stay supporting cast — review the behavior change; the prod diff is the subject. |
+   | **auth / tokens / secrets** | **`/security-review`** *in addition* — non-optional here (§5). Reason about this flow's specific threat model, not just generic categories. |
+   | **schema / data migration** | **`/security-review`** *in addition* — non-optional here (§5). Reason about this flow's specific threat model, not just generic categories. |
+   | **anything destructive or irreversible** | **`/security-review`** *in addition* — non-optional here (§5). Reason about this flow's specific threat model, not just generic categories. |
+   | A **test-only** diff | the **test-quality lens** (below) — the tests *are* the deliverable. |
+   | A meaty diff built by the default model | optionally a **second-model angle** (below). |
+   | Docs only (`*.md`) and no code | None — report "docs-only, skipping review." |
+
+   **`/code-review` is human-triggered, not a loop step.** The heavyweight multi-angle cloud review
+   exists, but only Brandon can invoke it — no skill can run it, and a routing table that
+   names it as the baseline just teaches the loop to skip that row. The loop's baseline is the
+   inline pass + the second-model angle; when a diff is large or risky enough to deserve the
+   heavyweight pass, *say so* in the findings ("worth a human `/code-review`") and leave the call
+   to Brandon.
+
+   ### Second-model angle (cheap, orthogonal)
+
+   A reviewer with a **different model than the implementer** shares fewer blind spots — a
+   different prior catches what same-model review lets slide. Spawn a reviewer on the other tier
+   for a meaty diff, alongside the inline pass. Prompt it for correctness bugs *and* anything that
+   "feels off" — the different weighting is the point, so don't over-constrain it. It's cheap; run
+   it freely on a substantial diff.
+
+   ### Test-quality lens
+
+   When the tests *are* the deliverable, review them as the subject, not as supporting cast:
+   - **Coverage gaps** — which behaviors of the unit under test are still unasserted?
+   - **Intent vs implementation** — does the test assert the *contract*, or merely restate what the
+     code currently does? The second kind passes forever and catches nothing.
+   - **Vacuous asserts** — assertions that cannot fail (a tautology, a threshold below the
+     no-op baseline, an assert on a value the test itself just set).
+   - **Brittle verbatim** — snapshots and exact-string matches that will break on an unrelated
+     change and teach everyone to re-bless them without reading.
+   - If a test appears to **codify a bug** — the behavior is wrong but the test enshrines it —
+     **flag it as a finding**; never bless it because it passes.
+
+3. **Present the plan** (a status update, not a gate — §5):
+
+   ```
+   ## Review plan
+   **Diff:** <N files, +<n>/-<m>>
+   **Files:** <key files + scope>
+   **Reviewers:** <those firing> — <why each>
+   ```
+
+4. **Run them immediately** in the same turn — no "Run them?" wait.
+5. **Present consolidated findings,** each with severity (P0/P1/P2) + `file:line` + a **verbatim
+   quote** of the offending line, then a recommendation:
+
+   ```
+   ### Recommendation
+   - ✅ Clean → /done
+   - ⚠️ Mechanical findings → /patch, then /done
+   - ❌ Design-level findings → /implement #<n> with a fix-focused prompt
+   - 🛑 A finding contradicts a project memory note → memory wins by default; surface it
+   ```
+
+6. **Suggest the next step** from the recommendation.
+
+## Safety
+
+- **A finding is a hypothesis with a citation, not a fact.** Before reporting one, read the cited
+  line — grep the *assignment*, not just a textual match. Roughly one in three "X exists at line N"
+  claims is a misread, and a confidently wrong finding costs more than a missed one.
+- **Empty findings is a valid clean result; *missing* findings is a failure.** If a reviewer times
+  out or errors, report that — never fabricate "clean" from an absent answer.
+
+## Edge cases
+
+- **Empty diff:** report; suggest `/next`. Don't run reviewers.
+- **Diff mixes story work + unrelated drift:** flag the drift; ask whether to revert before
+  reviewing.
+- **Finding contradicts a memory note** (an architecture rule, an invariant): the memory wins
+  unless Brandon overrides; surface it prominently rather than silently dropping either one.

--- a/.agents/skills/scout/SKILL.md
+++ b/.agents/skills/scout/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: scout
+description: Discovery-driven finder for the-cycle — fans out read-only agents across security · performance · hygiene · context · a11y lenses, verifies each finding against the real code, dedupes against open issues, and files the worth-keeping candidates as actionable issues. Read-only over code: it FINDS and FILES, it never fixes, branches, or merges. Usage `/scout` (all lenses, tightly capped) or `/scout <lens>` (one focused lens, higher cap).
+---
+<!-- cycle:rendered template=skills/scout.md.tmpl hash=4f7ce9d369b1 — managed by the-cycle; edit the template, not this file -->
+
+# /scout — find the-cycle's next work, on demand
+
+Goal: surface maintenance and hardening work the code itself is hiding — before it becomes an
+incident — and land it in the same tracker every other skill already reads. Every other pipeline
+skill *consumes* the queue (`/next` picks, `/cycle` builds); `/scout` *generates* candidates from
+the code.
+
+**Shared rules in `.agents/skills/DOCTRINE.md` — read it if not already in context.** Scout files
+issues, so the filing mechanics are **§10** — dedup, the actionable bar, the body format, the
+budget. Don't restate them; apply them. Also leans on §1 (Status), §2 (the `scout` provenance
+stamp), §5 (a finding that touches an always-brake surface still gets filed, just clearly flagged),
+and §7 (the batch-write rule).
+
+## The cardinal rule: scout finds and files. It never fixes, branches, or merges.
+
+The surfaces scout is best at spotting — auth / tokens / secrets, schema / data migration, anything destructive or irreversible — are exactly §5's always-brake class.
+Auto-merging a speculative fix there is how a real incident happens. Discovery is cheap and
+reversible; a shipped-without-review "fix" isn't. Scout's job stops at a well-specified issue.
+
+## Lenses
+
+Run **all lenses in one capped sweep** by default; pass a lens name for a focused, deeper pass.
+
+- **`security`** — the trust boundary, secrets handling, authn/authz surfaces, dependency CVEs.
+- **`performance`** — payload weight, render/hydration cost, query and index patterns, polling
+  cadence, work done that didn't need doing.
+- **`hygiene`** — type-safety erosion (`any`, unchecked casts, `@ts-expect-error`, non-null `!`),
+  dead code, and drift between near-duplicate modules.
+- **`context`** — **does the map still match the territory?** Do `CLAUDE.md`, the docs, and inline
+  comments still describe the code as it is? A stale claim here misleads the next cold reader
+  worse than no claim at all. Every finding in this lens must name **both** the wrong inference a
+  cold reader would draw **and** the concrete in-tree artifact that fixes it.
+- **`a11y`** — semantic HTML, focus management, touch-target size, reduced-motion, and anything
+  that encodes meaning in color alone.
+
+## The budget — quality over flood (load-bearing)
+
+Within §10.6's budget: **all-lenses run** — ~2 findings per lens, single digits overall;
+**single-lens run** — the top 3–5.
+
+**Filing zero because a lens is clean is a success, not a failure** — say so and stop. A flood of
+marginal issues is worse than a missed one: it burns trust in the whole queue.
+
+## Verify before filing (non-negotiable)
+
+Every finding is a **hypothesis with a citation** until you've read the cited code. Open the file,
+read the actual line, and confirm the claim — grep the *assignment*, not just a textual match. A
+finding that turns out to be a misread costs more than the one you didn't file, because it teaches
+Brandon to distrust the rest of the slate.
+
+## File the fix already drafted (the fleshing-out rule)
+
+A diagnosis-only issue hands Brandon homework; a drafted fix hands them a decision
+(§10.3). Scout has already done the reading — it knows the file, the line, and what right looks
+like — so the body carries that knowledge instead of describing where someone else might find
+it. Every filed issue includes:
+
+- **Evidence** — `file:line` plus a **verbatim quote** of the offending code, and, where one
+  exists, the in-repo pattern that already does it right (the strongest possible spec: "make it
+  match its sibling").
+- **The failure scenario** — the concrete inputs/state → wrong outcome, and why it matters here.
+- **The drafted fix** — the concrete change: a diff block, or the exact edit stated precisely
+  enough to apply without re-deriving the analysis. The decision becomes *"ship this? y/n"*, and
+  the eventual builder starts from the draft instead of from zero.
+- **Acceptance** a gate or a look can actually verify.
+
+A finding you can't draft a fix for usually isn't actionable enough to file — put it in the
+report as an observation instead. The one exception: a genuine defect whose fix needs a design
+call — file it with the options sketched and route it `status:needs-decision` (§10.5),
+never pickable.
+
+## Workflow
+
+1. **Pick the lenses** (all, or the named one).
+2. **Sweep, read-only.** Fan out across the lenses; each returns candidate findings with
+   `file:line` citations.
+3. **Verify each candidate against the real file.** Drop anything that doesn't survive.
+4. **Dedup** (§10.1) — open *and* recently-closed issues. A closed-unfixed twin is a rejection
+   with memory: report it, don't re-file it.
+5. **Rank and cut to budget.**
+6. **Present the slate** — each finding with its lens, `file:line`, the drafted issue body
+   **including its drafted fix**, its §10.5 certainty call with one line of why, and whether it
+   lands on a §5 brake. This is a §5 plan — shown for visibility, then acted on in the same turn;
+   an unattended run's standing go folds it into the report.
+7. **File** (§7): `gh issue create --title "<title>" --body "<body>" --label "scout"` per finding, then route each by
+   its certainty call (§10.5) — deterministic → `gh issue edit "<n>" --remove-label "status:ready,status:in-progress,status:in-review,status:needs-decision,status:blocked" --add-label "status:ready"`,
+   interpretive → `gh issue edit "<n>" --remove-label "status:ready,status:in-progress,status:in-review,status:needs-decision,status:blocked" --add-label "status:needs-decision"`, unsure → no status write —
+   plus anything this repo's lens table adds. A plain loop is correct here; these are REST calls,
+   and there is nothing to batch around. Tracker unreachable → say so and stop; don't pretend it
+   filed.
+8. **Report.** What was filed (links, labels, which ones flag a §5 brake for later), what was found
+   but not filed (dups, below-the-cut, "clean on this lens"), and point at `/next`.
+
+## Guardrails
+
+- **Find and file only — never fix, branch, or merge.** If it's tempting to "just fix this one,"
+  file it instead and let `/cycle` do it with a human watching.
+- **Verify every finding against the real file before it reaches the slate.** Non-negotiable.
+- **Respect the budget.** Fewer, sharper issues beat a flood; zero is a fine outcome.
+- **Dedup is not optional.**
+- **Read-only until the step-6 slate is shown.** Presenting it is a §5 plan, not a "Proceed?"
+  prompt — but nothing is created before it exists.
+- **Always-brake findings still get filed** — just clearly labeled as needing `/security-review` at
+  build time, never framed as a quick auto-mergeable patch.
+
+## How it fits the pipeline
+
+- **`/scout`** = code → candidate issues (the discovery front door).
+- **`/next`** = ranks and picks. A scout-filed issue arrives already routed by §10.5's certainty
+  call: deterministic findings are pickable on arrival, interpretive ones sit on Brandon's
+  decision queue with the fix pre-drafted, and only the genuinely unsure land under **Untriaged**.
+- **`/implement` / `/cycle`** = build a picked issue; §5 still brakes regardless of who filed it.
+- **`/burndown`** = curates the believed-safe subset and loops `/cycle` over it.

--- a/.cycle/config.jsonc
+++ b/.cycle/config.jsonc
@@ -1,5 +1,5 @@
 // the-cycle bindings for this repo.
-// Everything repo-specific lives here; the skills in .claude/skills are rendered
+// Everything repo-specific lives here; the skills in configured harness trees are rendered
 // from shared templates and should not be hand-edited (`cycle check` will tell you
 // if they have been). Re-render with `cycle update` after changing this file.
 {
@@ -10,6 +10,8 @@
   },
   "profile": "lean",
   "backend": "github",
+  // Dogfood both supported render targets so their dialects cannot drift unnoticed.
+  "harnesses": ["claude", "codex"],
   // the-cycle is PUBLIC, so a Free org can branch-protect it, and `main` requires the
   // `gates` context — so `gh pr merge --auto` genuinely waits instead of firing on the
   // spot. Enabled on the repo 2026-08-07 alongside `delete_branch_on_merge` (which is
@@ -64,7 +66,7 @@
     "milestones": []
   },
   "routing": {
-    "model": "**opus for everything** (spawned agents included).",
+    "model": "Use the active harness's default model unless the task explicitly requires another.",
     "executor_default": "orchestrator-inline"
   },
   "gates": {
@@ -76,13 +78,14 @@
   },
   "deps": {
     "outdated": "npm outdated",
-    "audit": "npm audit",
-    "audit_fix": "npm audit fix",
-    "update": "npm update",
-    "install": "npm install",
+    // This package intentionally has no dependency lockfile. `npm audit` fails with ENOLOCK,
+    // so don't teach agents to run a gate the repository cannot satisfy.
+    "audit": "",
+    "audit_fix": "",
+    "update": "npm update --package-lock=false",
+    "install": "npm install --package-lock=false",
     "manifests": [
-      "package.json",
-      "package-lock.json"
+      "package.json"
     ]
   },
   "brakes": [
@@ -98,7 +101,8 @@
     "minor_edits_direct": false
   },
   "commit": {
-    "coauthor": "Claude Opus 5 <noreply@anthropic.com>"
+    // Let each harness use its real identity rather than inventing a shared one.
+    "coauthor": ""
   },
   "deploy": {
     "test": "",

--- a/.cycle/state.json
+++ b/.cycle/state.json
@@ -1,18 +1,31 @@
 {
-  "upstream": "2aa9504-dirty",
+  "upstream": "7e0cb17-dirty",
   "files": {
-    ".claude/skills/DOCTRINE.md": "0dca555ec9cd",
-    ".claude/skills/cycle/SKILL.md": "7df092de0d13",
+    ".claude/skills/DOCTRINE.md": "0a060e228db8",
+    ".claude/skills/cycle/SKILL.md": "c5fa85661a41",
     ".claude/skills/implement/SKILL.md": "ec9c0164c37d",
     ".claude/skills/review/SKILL.md": "7480fa810fb6",
     ".claude/skills/patch/SKILL.md": "69279047fb66",
-    ".claude/skills/done/SKILL.md": "d83ffbfc6a79",
+    ".claude/skills/done/SKILL.md": "9a77f154a49f",
     ".claude/skills/next/SKILL.md": "0afc40565e46",
     ".claude/skills/intake/SKILL.md": "7fb751ead121",
     ".claude/skills/scout/SKILL.md": "bbfa6de5fa2e",
     ".claude/skills/burndown/SKILL.md": "2a7af6f01608",
-    ".claude/skills/dep-update/SKILL.md": "58c6bd2d36a2",
+    ".claude/skills/dep-update/SKILL.md": "b5d36ac6dff1",
     ".claude/skills/deploy-test/SKILL.md": "8a0cf4447165",
-    ".claude/skills/deploy-prod/SKILL.md": "41ad9d2f17db"
+    ".claude/skills/deploy-prod/SKILL.md": "41ad9d2f17db",
+    ".agents/skills/DOCTRINE.md": "53ecb293e2c7",
+    ".agents/skills/cycle/SKILL.md": "260b386a0a4c",
+    ".agents/skills/implement/SKILL.md": "ed230d275141",
+    ".agents/skills/review/SKILL.md": "131f0ccfb7cf",
+    ".agents/skills/patch/SKILL.md": "21b0fc67d17f",
+    ".agents/skills/done/SKILL.md": "76b4130435ca",
+    ".agents/skills/next/SKILL.md": "f49c75d042fd",
+    ".agents/skills/intake/SKILL.md": "3db22c6ab9ad",
+    ".agents/skills/scout/SKILL.md": "4f7ce9d369b1",
+    ".agents/skills/burndown/SKILL.md": "0ba6d12b6424",
+    ".agents/skills/dep-update/SKILL.md": "70677227a33a",
+    ".agents/skills/deploy-test/SKILL.md": "8a0cf4447165",
+    ".agents/skills/deploy-prod/SKILL.md": "1d59d46239ff"
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,9 @@ jobs:
       # CI-safe. Fails if a template moved without `cycle update` re-rendering this
       # repo's own copy — the drift the tool exists to catch, caught on itself.
       - run: node bin/cycle.mjs check
+      # Exercise the exact declared floor, not merely the latest 20.x release.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.0.0'
+      - run: npm test
+      - run: node bin/cycle.mjs check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+Repository guidance for AI coding agents working on the-cycle.
+
+## Start here
+
+- Read `CLAUDE.md`. The historical filename remains, but its repository guidance applies to every
+  supported harness.
+- Read the doctrine in your rendered harness tree: `.agents/skills/DOCTRINE.md` for Codex or
+  `.claude/skills/DOCTRINE.md` for Claude Code. Both trees are generated from the same templates.
+- The normal local gates are `node bin/cycle.mjs lint`, `npm test`, and
+  `node bin/cycle.mjs check`.
+- Tests create temporary git repositories and spawn child processes. If a restricted sandbox
+  rejects those operations with `EPERM`, rerun the same gate in an environment that permits them;
+  do not weaken or skip the test.
+
+## Current documentation
+
+Use Context7 whenever work depends on current library, framework, SDK, API, CLI, or cloud-service
+documentation. Resolve the library ID first, then query one concept at a time. It is not required
+for ordinary refactoring, business-logic debugging, code review, or general programming concepts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides repository guidance to AI coding agents. `AGENTS.md` is the Codex entry point;
+this historical filename remains the detailed canonical guide.
 
 ## What this is
 
@@ -16,11 +17,11 @@ with no module resolution games.
 
 ## This repo dogfoods itself
 
-**`.claude/skills/**` in this checkout is *rendered output*, not hand-written.** the-cycle installs
+**`.claude/skills/**` and `.agents/skills/**` in this checkout are *rendered output*, not hand-written.** the-cycle installs
 its own pipeline into itself (`.cycle/config.jsonc`, profile `lean`, backend `github`) to manage its
 own backlog — issues in `brndnsh-labs/the-cycle`, routed by `status:*` labels, which also makes this repo
 the live proof that the `github` backend works.
-Every file under `.claude/skills/` carries a provenance comment and must never be hand-edited
+Every file under either harness skill tree carries a provenance comment and must never be hand-edited
 — `cycle check` will flag it as drifted.
 
 - To change pipeline **behavior/procedure**: edit `templates/DOCTRINE.md.tmpl` or
@@ -28,7 +29,7 @@ Every file under `.claude/skills/` carries a provenance comment and must never b
   eventually every other consuming repo).
 - To change **this repo's bindings** (gates, brakes, tracker fields): edit `.cycle/config.jsonc`,
   then `cycle update`.
-- Read `.claude/skills/DOCTRINE.md` once per session — it's the shared rule spine every skill here
+- Read the `DOCTRINE.md` in your harness tree once per session — it's the shared rule spine every skill here
   cites as `§N` (tracker/labels/routing/gates/autonomy/merge/commit conventions). Don't restate its
   rules; skills and this file both just point at it.
 
@@ -100,8 +101,10 @@ into the template or config, don't force over it.
 
 ## CI
 
-`.github/workflows/ci.yml` — one `gates` job (`npm test` + `node bin/cycle.mjs check`), on
-`ubuntu-latest`, no install step (zero dependencies). GitHub-hosted rather than ghrunner01 because this repo is public and the org's
+`.github/workflows/ci.yml` — the required `gates` job runs `npm test` plus
+`node bin/cycle.mjs check` first on Node 22 and then on the exact declared 20.0.0 floor, so branch
+protection cannot pass before compatibility does. It uses `ubuntu-latest` with no install step
+(zero dependencies). GitHub-hosted rather than ghrunner01 because this repo is public and the org's
 runner group refuses public repos. `main` is branch-protected on the bare context name `gates` (not
-a scoped `CI / gates (pull_request)` form); PRs merge via the backend's poll-then-merge guard once
-CI is green, not a server-side auto-merge.
+a scoped `CI / gates (pull_request)` form); safe PRs queue server-side auto-merge, which waits for
+that required context.

--- a/README.md
+++ b/README.md
@@ -39,12 +39,15 @@ Full rationale for all of the above: `docs/AUTHORING.md`.
 Bootstrap, no clone required:
 
 ```sh
-npx @brndnsh/the-cycle install       # runs the interview, renders into the current repo
+# runs the interview and renders into the current repo
+npx --yes --allow-git=root --package=github:brndnsh-labs/the-cycle cycle install
 ```
 
-npx is for a one-off first render — the fetched copy lives in npx's ephemeral cache, so `cycle
-update` / `cycle check` and the personal `/cycle-setup` skill need the durable
-clone below. `cycle install`'s own output says as much when it ran this way.
+npx is for a one-off first render directly from GitHub — the fetched copy lives in npx's
+ephemeral cache, so `cycle update` / `cycle check` and the personal `/cycle-setup` skill need the
+durable clone below. `--allow-git=root` is the narrow npm opt-in for this explicitly requested root
+package; transitive git dependencies remain disabled. `cycle install`'s own output says as much
+when it ran this way.
 
 For everyday use:
 
@@ -59,7 +62,7 @@ automatically, for machines that would rather not reach GitHub.
 
 Don't push to the Forgejo mirror directly — the next sync from GitHub overwrites it.
 
-`install.sh` also links `/cycle-setup` into `~/.claude/skills` as a personal
+`install.sh` also links `/cycle-setup` into both `~/.claude/skills` and `~/.agents/skills` as a personal
 skill — it has to work in a repo that doesn't have the-cycle yet.
 
 Then, in a repo:
@@ -117,7 +120,7 @@ picks one or more; `cycle update` renders a complete, independent skill tree per
 | | Claude Code | Codex CLI |
 | --- | --- | --- |
 | skills discovered at | `.claude/skills/<name>/SKILL.md` | `.agents/skills/<name>/SKILL.md` |
-| structured questions | `AskUserQuestion` | `ask_user_question` |
+| structured questions | `AskUserQuestion` | direct chat (`request_user_input` is Plan-mode only) |
 | parallel subagents | the Agent tool | subagents (GA 2026-03-14) |
 
 Full vocabulary, the honesty rule around capability flags, and how to add a third harness:
@@ -127,6 +130,7 @@ Full vocabulary, the honesty rule around capability flags, and how to add a thir
 
 ```
 .github/workflows/ci.yml    `npm test` on PR + push to main
+AGENTS.md               cross-harness repository entry point
 bin/
   cycle.mjs            the CLI — Node ESM, zero dependencies
 install.sh             symlink bin/cycle onto PATH
@@ -145,12 +149,13 @@ docs/
   BACKENDS.md          the verb vocabulary; adding a backend
   HARNESSES.md         the harness.* vocabulary; adding a harness
   PATTERNS.md          reviewer-agent skeleton, hooks, permissions
+  RELEASING.md         package boundary, preflight, and explicit publish gate
 ```
 
 ## Requirements
 
-Node ≥ 20, git, and bash for `install.sh`. No dependencies, no build step. `gh` authed with the
-`project` scope.
+Node ≥ 20, git, and bash for `install.sh`. No dependencies, no build step. `gh` must be
+authenticated for tracker operations; rendering, linting, and drift checks work offline.
 
 ## Adopting an existing repo
 

--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -20,7 +20,8 @@ import { createInterface } from 'node:readline/promises';
 import { execFileSync } from 'node:child_process';
 import { homedir } from 'node:os';
 import { basename, dirname, extname, join, relative, resolve } from 'node:path';
-import { parseArgs, styleText } from 'node:util';
+import { parseArgs } from 'node:util';
+import * as nodeUtil from 'node:util';
 import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 
@@ -31,7 +32,9 @@ const CYCLE_HOME = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 // ---------------------------------------------------------------------------
 
 const supportsColor = process.stdout.isTTY && process.env.NO_COLOR === undefined;
-const paint = (style, s) => (supportsColor ? styleText(style, s) : s);
+// util.styleText arrived after the initial Node 20 release. Keep the declared
+// >=20 floor honest instead of crashing during module evaluation on early 20.x.
+const paint = (style, s) => (supportsColor && nodeUtil.styleText ? nodeUtil.styleText(style, s) : s);
 const bold = (s) => paint('bold', s);
 const dim = (s) => paint('dim', s);
 const red = (s) => paint('red', s);
@@ -503,6 +506,16 @@ function buildContext(cfg, backend) {
             .filter(([, v]) => typeof v === 'string' && v.trim())
             .map(([, v]) => v);
     }
+    const dependencyManifests = cfg.deps?.manifests ?? [];
+    const knownLockfiles = new Set([
+        'pnpm-lock.yaml', 'yarn.lock', 'package-lock.json', 'Cargo.lock',
+        'go.sum', 'uv.lock', 'poetry.lock', 'Gemfile.lock',
+    ]);
+    // Configs written before deps.lockfile existed still carry the same fact in
+    // deps.manifests. Preserve their meaning on the next `cycle update`.
+    const inferredLockfile = dependencyManifests.find((path) => knownLockfiles.has(basename(path))) ?? '';
+    const hasDependencyManager = cfg.deps?.has_manager
+        ?? Boolean(cfg.deps?.outdated || dependencyManifests.length);
     return {
         ...cfg,
         gates,
@@ -516,10 +529,12 @@ function buildContext(cfg, backend) {
             status_labels: (cfg.tracker?.statuses ?? []).map((s) => s.name).join(','),
         },
         deps: {
+            has_manager: hasDependencyManager,
             outdated: '', audit: '', audit_fix: '', update: '', install: '', manifests: [],
             ...(cfg.deps ?? {}),
+            lockfile: cfg.deps?.lockfile ?? inferredLockfile,
             // Pre-formatted for prose: the join filter can't wrap each item in backticks.
-            manifests_md: (cfg.deps?.manifests ?? []).map((m) => `\`${m}\``).join(', '),
+            manifests_md: dependencyManifests.map((m) => `\`${m}\``).join(', '),
         },
         // `backend_overrides` lets one repo correct a backend-wide default that is
         // really a per-repo fact. `auto_merge` is the motivating case: it is a
@@ -553,23 +568,32 @@ const templatePath = (rel) => join(CYCLE_HOME, 'templates', rel);
  * a missing project number surfaces as "unresolved {{tracker.project}} in backend
  * verb @board_list" — technically true, useless as instruction.
  */
-function validateConfig(cfg, backend) {
+function validateConfig(root, cfg, backend) {
     const missing = Object.entries(backend.requires ?? {}).filter(([path]) => {
         const v = path.split('.').reduce((o, k) => (o == null ? o : o[k]), cfg);
         return v === undefined || v === null || v === '';
     });
-    if (!missing.length) return;
-    const lines = missing.map(([path, why]) => `  ${bold(path)} — ${why}`).join('\n');
-    fail(
-        `the ${cfg.backend} backend needs ${missing.length} value(s) set in .cycle/config.jsonc:\n${lines}`,
-        'set them, then re-run `cycle update`',
-    );
+    if (missing.length) {
+        const lines = missing.map(([path, why]) => `  ${bold(path)} — ${why}`).join('\n');
+        fail(
+            `the ${cfg.backend} backend needs ${missing.length} value(s) set in .cycle/config.jsonc:\n${lines}`,
+            'set them, then re-run `cycle update`',
+        );
+    }
+
+    const absentManifests = (cfg.deps?.manifests ?? []).filter((path) => !existsSync(join(root, path)));
+    if (absentManifests.length) {
+        fail(
+            `configured dependency manifest${absentManifests.length === 1 ? '' : 's'} missing: ${absentManifests.join(', ')}`,
+            'fix deps.manifests in .cycle/config.jsonc, or add the intended file, then re-run `cycle update`',
+        );
+    }
 }
 
 function planRender(root, cfg) {
     const backend = loadBackend(cfg.backend);
     const profile = loadProfile(cfg.profile);
-    validateConfig(cfg, backend);
+    validateConfig(root, cfg, backend);
     const ctx = buildContext(cfg, backend);
     const verbs = backend.verbs ?? {};
     const overlays = overlayDir(root);
@@ -712,37 +736,50 @@ const readState = (root) => (existsSync(statePath(root)) ? JSON.parse(readFileSy
 const ECOSYSTEMS = [
     ['pnpm-lock.yaml', {
         outdated: 'pnpm outdated', audit: 'pnpm audit', audit_fix: 'pnpm audit --fix',
-        update: 'pnpm update', install: 'pnpm install', manifests: ['package.json', 'pnpm-lock.yaml'],
+        update: 'pnpm update', install: 'pnpm install', lockfile: 'pnpm-lock.yaml', manifests: ['package.json', 'pnpm-lock.yaml'],
     }],
     ['yarn.lock', {
         outdated: 'yarn outdated', audit: 'yarn npm audit', audit_fix: '',
-        update: 'yarn up', install: 'yarn install', manifests: ['package.json', 'yarn.lock'],
+        update: 'yarn up', install: 'yarn install', lockfile: 'yarn.lock', manifests: ['package.json', 'yarn.lock'],
     }],
     ['package-lock.json', {
         outdated: 'npm outdated', audit: 'npm audit', audit_fix: 'npm audit fix',
-        update: 'npm update', install: 'npm install', manifests: ['package.json', 'package-lock.json'],
+        update: 'npm update', install: 'npm install', lockfile: 'package-lock.json', manifests: ['package.json', 'package-lock.json'],
     }],
     ['Cargo.toml', {
         outdated: 'cargo outdated', audit: 'cargo audit', audit_fix: '',
-        update: 'cargo update', install: 'cargo build', manifests: ['Cargo.toml', 'Cargo.lock'],
+        update: 'cargo update', install: 'cargo build', lockfile: 'Cargo.lock', manifests: ['Cargo.toml', 'Cargo.lock'],
     }],
     ['go.mod', {
         outdated: 'go list -u -m all', audit: 'govulncheck ./...', audit_fix: '',
-        update: 'go get -u ./...', install: 'go mod tidy', manifests: ['go.mod', 'go.sum'],
+        update: 'go get -u ./...', install: 'go mod tidy', lockfile: 'go.sum', manifests: ['go.mod', 'go.sum'],
     }],
     ['uv.lock', {
         outdated: 'uv pip list --outdated', audit: '', audit_fix: '',
-        update: 'uv lock --upgrade', install: 'uv sync', manifests: ['pyproject.toml', 'uv.lock'],
+        update: 'uv lock --upgrade', install: 'uv sync', lockfile: 'uv.lock', manifests: ['pyproject.toml', 'uv.lock'],
     }],
     ['poetry.lock', {
         outdated: 'poetry show --outdated', audit: '', audit_fix: '',
-        update: 'poetry update', install: 'poetry install', manifests: ['pyproject.toml', 'poetry.lock'],
+        update: 'poetry update', install: 'poetry install', lockfile: 'poetry.lock', manifests: ['pyproject.toml', 'poetry.lock'],
     }],
     ['Gemfile.lock', {
         outdated: 'bundle outdated', audit: 'bundle audit', audit_fix: '',
-        update: 'bundle update', install: 'bundle install', manifests: ['Gemfile', 'Gemfile.lock'],
+        update: 'bundle update', install: 'bundle install', lockfile: 'Gemfile.lock', manifests: ['Gemfile', 'Gemfile.lock'],
     }],
 ];
+
+const NPM_WITHOUT_LOCKFILE = {
+    has_manager: true,
+    outdated: 'npm outdated', audit: '', audit_fix: '',
+    update: 'npm update --package-lock=false', install: 'npm install --package-lock=false',
+    lockfile: '', manifests: ['package.json'],
+};
+
+const NO_DEPENDENCY_WORKFLOW = {
+    has_manager: false,
+    outdated: '', audit: '', audit_fix: '', update: '', install: '',
+    lockfile: '', manifests: [],
+};
 
 /** Best-effort defaults so the interview is confirmations, not data entry. */
 export function detect(root) {
@@ -779,7 +816,16 @@ export function detect(root) {
         out.deploy = { test: './scripts/deploy.sh test', prod: './scripts/deploy.sh prod' };
     }
 
-    out.deps = ECOSYSTEMS.find(([marker]) => existsSync(join(root, marker)))?.[1];
+    const ecosystem = ECOSYSTEMS.find(([marker]) => existsSync(join(root, marker)))?.[1];
+    if (ecosystem) {
+        out.deps = {
+            ...ecosystem,
+            manifests: ecosystem.manifests.filter((path) => existsSync(join(root, path))),
+            lockfile: existsSync(join(root, ecosystem.lockfile)) ? ecosystem.lockfile : '',
+        };
+    } else if (existsSync(pkgPath)) {
+        out.deps = NPM_WITHOUT_LOCKFILE;
+    }
     return out;
 }
 
@@ -864,16 +910,16 @@ export function draftConfig(root, { backend: wanted, profile, set } = {}) {
             milestones: [],
         },
         routing: {
-            model: '**opus for everything** (spawned agents included).',
+            model: "Use the active harness's default model unless the task explicitly requires another.",
             executor_default: 'orchestrator-inline',
         },
         gates: Object.keys(d.gates).length ? d.gates : { typecheck: 'npm run typecheck', test: 'npm test' },
-        // /dep-update's package-manager commands. Detected from the lockfile; blank
-        // where the ecosystem has no equivalent (plenty have no audit-fix).
-        deps: d.deps ?? ECOSYSTEMS.find(([m]) => m === 'package-lock.json')[1],
+        // /dep-update's package-manager commands. Detected from an ecosystem marker;
+        // blank where the ecosystem has no equivalent (plenty have no audit-fix).
+        deps: d.deps ?? NO_DEPENDENCY_WORKFLOW,
         brakes: ['auth / tokens / secrets', 'schema / data migration', 'anything destructive or irreversible'],
         branch: { minor_edits_direct: true },
-        commit: { coauthor: 'Claude Opus 5 <noreply@anthropic.com>' },
+        commit: { coauthor: '' },
         deploy: d.deploy ?? { test: '', prod: '' },
     };
     return { cfg: applyConfigSets(cfg, set), detected: d };
@@ -1055,7 +1101,7 @@ function cmdPlan(root, values) {
 /** config.jsonc with comments, so the file explains itself when Brandon opens it. */
 function renderConfig(cfg) {
     return `// the-cycle bindings for this repo.
-// Everything repo-specific lives here; the skills in .claude/skills are rendered
+// Everything repo-specific lives here; the skills in configured harness trees are rendered
 // from shared templates and should not be hand-edited (\`cycle check\` will tell you
 // if they have been). Re-render with \`cycle update\` after changing this file.
 ${JSON.stringify(cfg, null, 2)}
@@ -1073,7 +1119,7 @@ ${JSON.stringify(cfg, null, 2)}
  * authenticated, no network) is reported as a skip, never as a mismatch — an
  * unanswerable question must not read as a failed answer.
  */
-function verifyForge(cfg) {
+export function verifyForge(cfg, { exec = execFileSync } = {}) {
     const problems = [];
     const slug = cfg.repo?.slug;
     if (cfg.backend !== 'github') return { problems, skipped: `backend ${cfg.backend} has no forge probe` };
@@ -1082,7 +1128,7 @@ function verifyForge(cfg) {
     let repoJson;
     try {
         repoJson = JSON.parse(
-            execFileSync('gh', ['api', `repos/${slug}`, '--jq', '{allow_auto_merge,delete_branch_on_merge}'], {
+            exec('gh', ['api', `repos/${slug}`, '--jq', '{allow_auto_merge,delete_branch_on_merge}'], {
                 encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
             }),
         );
@@ -1113,7 +1159,7 @@ function verifyForge(cfg) {
     if (declared) {
         try {
             const contexts = JSON.parse(
-                execFileSync('gh', ['api', `repos/${slug}/branches/main/protection`, '--jq', '.required_status_checks.contexts'], {
+                exec('gh', ['api', `repos/${slug}/branches/main/protection`, '--jq', '.required_status_checks.contexts'], {
                     encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'],
                 }),
             );

--- a/bin/lint.mjs
+++ b/bin/lint.mjs
@@ -364,7 +364,7 @@ export function lint({ CYCLE_HOME }) {
     // every consuming repo, and the top-level docs because they are what a reader meets
     // first. Both are prose this repo owns and can hold to one dialect.
     const prose = new Map(templates);
-    for (const rel of ['README.md', 'CLAUDE.md']) {
+    for (const rel of ['README.md', 'AGENTS.md', 'CLAUDE.md']) {
         const p = join(CYCLE_HOME, rel);
         if (existsSync(p)) prose.set(rel, readFileSync(p, 'utf8'));
     }

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -192,7 +192,7 @@ below as stand-ins for "the old backend" / "the new backend" if this ever needs 
    refusal as a finding, not an obstacle: `git rm` the file and re-render.
 6. **Fix the overlays that name the tracker in prose.** Verbs are abstracted; sentences aren't.
    Grep `.cycle/overlays/` for the old forge's name — and edit the overlay, not the rendered copy
-   under `.claude/skills/`, or the next `cycle update` reverts you.
+   under a configured harness skill tree, or the next `cycle update` reverts you.
 7. **Then re-run `cycle update` and actually confirm it ran.** Editing overlays during a migration
    and never re-rendering leaves the skills — the files the agent reads — stale against their own
    source. `cycle check` reports that drift; a repo with more than one harness renders a tree per

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -37,10 +37,10 @@ executables to keep in sync.
 | `harness.display` | `Claude Code` | `Codex CLI` | human-readable, for prose |
 | `harness.root` | `.claude/skills` | `.agents/skills` | where this tree's skills land |
 | `harness.doctrine_path` | `.claude/skills/DOCTRINE.md` | `.agents/skills/DOCTRINE.md` | computed (`root/DOCTRINE.md`) — every skill's "Shared rules in `…`" line |
-| `harness.has_menus` | `true` | `true` | a structured, recommendation-first choice tool exists |
+| `harness.has_menus` | `true` | `false` | a structured choice tool is callable in normal skill execution |
 | `harness.has_subagents` | `true` | `true` | a native parallel-subagent spawn tool exists |
 | `harness.attribution` | `🤖 Generated with [Claude Code](…)` | `🤖 Generated with [Codex CLI](…)` | the §8 PR-body trailer |
-| `harness.ask` | `` `AskUserQuestion` `` | `` `ask_user_question` `` | the structured-question tool's name, backticked |
+| `harness.ask` | `` `AskUserQuestion` `` | `plain chat` | how a workflow asks a discrete question |
 
 `doctrine_path` is computed by the engine (`buildHarnessContext` in `bin/cycle.mjs`) from `root` —
 it isn't a field a harness file declares. Everything else comes straight from the `.jsonc` file.
@@ -54,15 +54,14 @@ otherwise silently falsy, not a hard error — see `bin/lint.mjs`):
 
 | | Claude Code | Codex CLI |
 | --- | --- | --- |
-| `has_menus` | `true` — `AskUserQuestion` | `true` — `ask_user_question` (GA 2026) |
+| `has_menus` | `true` — `AskUserQuestion` | `false` — `request_user_input` is Plan-mode only |
 | `has_subagents` | `true` — the Agent tool | `true` — subagents, GA 2026-03-14 |
 
-Both current harnesses happen to have both capabilities — Codex was chosen as the second target
-*because* it's nearly a structural copy of Claude Code's model (same open agent-skills format, a
-comparable menu tool, comparable subagent support). The `{{#unless harness.has_menus}}` /
-`{{#unless harness.has_subagents}}` branches exist for a **future**, less-capable harness (Opencode,
-Pi — see the harness-target follow-up issues), and are exercised by the render tests even though no
-shipped harness takes that path today.
+Both harnesses support the same open agent-skills format and native subagents. Codex's structured
+question tool is mode-scoped, however, so ordinary skill execution takes the direct-chat menu
+fallback. The `{{#unless harness.has_menus}}` / `{{#unless harness.has_subagents}}` branches are
+real shipped behavior as well as the extension seam for a future, less-capable harness (Opencode,
+Pi — see the harness-target follow-up issues).
 
 ## Verified discovery paths, not assumed
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -104,10 +104,11 @@ Broad, intentional entries (`Bash(npm run *)`, `Bash(git *)`) are worth keeping;
 literals are noise that never gets reused. `/fewer-permission-prompts` exists to replace this pile
 — run it occasionally instead of letting the file grow.
 
-## Scoped CLAUDE.md files
+## Scoped agent instruction files
 
-Invariants that only matter inside one directory belong in a `CLAUDE.md` *in that directory*, not
-in the global memory index — the index loads wholesale every session, so every line is a tax paid
-forever, while a scoped file costs nothing until someone opens that directory.
+Invariants that only matter inside one directory belong in the harness's scoped instruction file
+(`AGENTS.md` for Codex or `CLAUDE.md` for Claude Code) *in that directory*, not in the global memory
+index — the index loads wholesale every session, so every line is a tax paid forever, while a
+scoped file costs nothing until someone opens that directory.
 
 Leave a one-line pointer in the index saying the detail lives there.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,30 @@
+# Releasing the-cycle
+
+The durable installation is a clone plus `./install.sh`. The README's explicit GitHub package
+spec is the bootstrap path for a first render and does not depend on the npm registry. Its
+`--allow-git=root` flag permits only the explicitly requested root git package, not transitive git
+dependencies.
+
+The package metadata permits publication as `@brndnsh/the-cycle`, but publication is an explicit
+external release gate. Making a commit or merging a pull request does not authorize `npm publish`.
+
+## Preflight
+
+Run from a clean checkout:
+
+```sh
+npm test
+node bin/cycle.mjs lint
+node bin/cycle.mjs check
+npm pack --dry-run --json
+```
+
+Inspect the dry-run file list. It must include the CLI, templates, harness definitions, profiles,
+backends, setup skills, and documentation. It must not include this repository's `.cycle/`,
+rendered `.claude/` or `.agents/` trees, tests, or CI configuration. The automated package test
+checks the same boundary and exercises the packed artifact.
+
+## Publish gate
+
+Before publishing, obtain explicit approval for the exact version and registry. Publish using the
+normal npm authentication flow, then verify the registry package with a fresh one-off invocation.

--- a/harnesses/codex.jsonc
+++ b/harnesses/codex.jsonc
@@ -9,8 +9,10 @@
 //     repo-root path is what a rendered install writes to).
 //   - subagents: GA 2026-03-14 — parallel spawn from a single task, so /fan-out and
 //     /cover's per-unit spawn apply here too.
-//   - structured questions: `ask_user_question` — a tabbed, recommendation-first
-//     choice tool, functionally equivalent to Claude Code's AskUserQuestion.
+//   - structured questions: `request_user_input` exists in Plan mode, but repository
+//     skills normally run in Default mode. Advertise the capability as unavailable so
+//     rendered workflows use their direct-chat fallback instead of naming a tool they
+//     cannot call.
 {
   "name": "codex",
   "display": "Codex CLI",
@@ -19,12 +21,12 @@
   "skill_file": "SKILL.md",
 
   "capabilities": {
-    "has_menus": true,
+    "has_menus": false,
     "has_subagents": true
   },
 
   "notes": {
     "attribution": "🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)",
-    "ask": "`ask_user_question`"
+    "ask": "plain chat"
   }
 }

--- a/install.sh
+++ b/install.sh
@@ -11,10 +11,10 @@ set -euo pipefail
 
 CYCLE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BIN_DIR="$HOME/.local/bin"
-SKILL_DIR="$HOME/.claude/skills"
+SKILL_DIRS=("$HOME/.claude/skills" "$HOME/.agents/skills")
 PATH_LINE='export PATH="$HOME/.local/bin:$PATH"'
 
-mkdir -p "$BIN_DIR" "$SKILL_DIR"
+mkdir -p "$BIN_DIR" "${SKILL_DIRS[@]}"
 
 # Only cycle.mjs. The other files in bin/ are subcommand modules it imports on
 # demand — on PATH they would look like commands and do nothing when run.
@@ -26,12 +26,23 @@ echo
 # The setup skills are PERSONAL, not per-repo: /cycle-setup has to be available in a
 # repo that doesn't have the-cycle installed yet, which is the entire point of it.
 # Symlinked so a `git pull` here updates them without re-running this script.
-echo "Linking setup skills into $SKILL_DIR:"
-for src in "$CYCLE"/skills/*/; do
-    [ -d "$src" ] || continue
-    name="$(basename "$src")"
-    ln -sfn "${src%/}" "$SKILL_DIR/$name"
-    echo "  /$name"
+echo "Linking setup skills into personal harness skill directories:"
+for skill_dir in "${SKILL_DIRS[@]}"; do
+    echo "  $skill_dir"
+    for src in "$CYCLE"/skills/*/; do
+        [ -d "$src" ] || continue
+        name="$(basename "$src")"
+        target="$skill_dir/$name"
+        # `ln -sfn source existing-directory` nests the link inside that directory
+        # instead of replacing it. Refuse the collision so a stale hand-installed
+        # skill cannot survive behind a misleading success message.
+        if [ -e "$target" ] && [ ! -L "$target" ]; then
+            echo "error: refusing to replace existing directory or file: $target" >&2
+            exit 1
+        fi
+        ln -sfn "${src%/}" "$target"
+        echo "    /$name"
+    done
 done
 
 echo

--- a/package.json
+++ b/package.json
@@ -1,9 +1,24 @@
 {
-  "name": "the-cycle",
+  "name": "@brndnsh/the-cycle",
   "version": "0.1.0",
-  "private": true,
   "type": "module",
   "description": "An installable, self-updating work pipeline for AI coding harnesses",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/brndnsh-labs/the-cycle.git"
+  },
+  "publishConfig": { "access": "public" },
+  "files": [
+    "backends/",
+    "bin/",
+    "docs/",
+    "harnesses/",
+    "profiles/",
+    "skills/",
+    "templates/",
+    "install.sh"
+  ],
   "bin": { "cycle": "bin/cycle.mjs" },
   "scripts": {
     "test": "node --test test/*.test.mjs"

--- a/skills/cycle-setup/SKILL.md
+++ b/skills/cycle-setup/SKILL.md
@@ -10,9 +10,10 @@ irreversibly, which directories deserve which reviewer, or what "ready" means he
 reading problems, and reading is what you're for.
 
 **Your output is data, never prose that ships.** You write `.cycle/config.jsonc` and
-`.cycle/overlays/*.md`. The renderer writes the skills. Never hand-write or hand-edit a file under
-`.claude/skills/` — a rendered skill that doesn't match its template is drift, and `cycle check`
-will report it as a defect for as long as it survives.
+`.cycle/overlays/*.md`. The renderer writes every configured harness tree (for example,
+`.claude/skills/` and `.agents/skills/`). Never hand-write or hand-edit a rendered skill — one
+that doesn't match its template is drift, and `cycle check` will report it as a defect for as
+long as it survives.
 
 ## 0. Orient
 
@@ -24,7 +25,7 @@ Writes nothing. If it reports `existing_config`, this repo is already installed 
 re-setup, so read the current config before proposing changes and treat every existing value as a
 decision someone made until you find evidence otherwise.
 
-If the repo has hand-written skills in `.claude/skills/` with no `.cycle/` directory, it predates
+If the repo has hand-written skills in a supported harness root with no `.cycle/` directory, it predates
 the-cycle. **Stop and surface it** — the automated conversion path (`cycle adopt`) was retired
 after the last legacy repo converged, so reconciliation is now a deliberate manual job: extract
 the repo facts into config and overlays, then diff each hand-written skill against its rendered
@@ -56,8 +57,9 @@ to prevent.
 
 ## 2. Ask only what reading can't settle
 
-Use `AskUserQuestion` for genuine forks: a profile call that hinges on intent rather than
-evidence, a brake surface you can argue either way. Recommend one option and say why.
+Use the current harness's structured-question tool for genuine forks: a profile call that hinges
+on intent rather than evidence, a brake surface you can argue either way. Recommend one option
+and say why.
 
 Do not ask what the codebase already answers. A question you could have resolved by reading is a
 tax on the person you're supposed to be helping.
@@ -108,13 +110,13 @@ the rendered file.
 - Overlays written, and overlays deliberately skipped.
 - Anything you couldn't verify — an unreachable tracker, a gate you couldn't run, a guessed brake.
   Say it plainly; a silent guess here becomes a rule every skill enforces.
-- The suggested next step: commit `.cycle/` and `.claude/skills/` together, so config and rendered
-  output stay in sync in history.
+- The suggested next step: commit `.cycle/` and every configured harness tree together, so config
+  and rendered output stay in sync in history.
 
 ## Rules
 
-- **Never write under `.claude/skills/`.** Config and overlays are yours; skills are the
-  renderer's.
+- **Never write under a configured harness skill tree.** Config and overlays are yours; skills
+  are the renderer's.
 - **Never invent a gate command.** If you can't confirm it runs, leave it out and say so.
 - **A wrong brake is expensive in both directions** — a missing one lets an agent make an
   irreversible change alone; a spurious one stops work that should have proceeded. Argue for each

--- a/templates/DOCTRINE.md.tmpl
+++ b/templates/DOCTRINE.md.tmpl
@@ -73,8 +73,8 @@ skill at `/cycle` time, from what the diff actually touches, not at filing time.
     **human-triggered** — the loop cannot invoke it; offer it on a large or risky diff and leave
     the call to {{repo.human}}.
   - **`/security-review`** — **additionally**, whenever the diff touches {{brakes|join:, }}.
-  - A **second-model angle** (a Sonnet pass over an opus diff, or vice-versa) is a cheap way to
-    catch same-prior blind spots on a meaty diff.
+  - A **second-model angle** (a different model family or tier from the implementer) is a cheap
+    way to catch same-prior blind spots on a meaty diff.
 
 {{> overlay?:doctrine-routing}}
 
@@ -218,10 +218,11 @@ that isn't in the §1 table.
 ## §8 Commit & PR conventions
 
 - **Conventional Commit** (`feat(scope)` / `fix` / `docs` / `chore` / `test`), scoped to the area;
-  body names the story. Ends with:
+  body names the story.{{#if commit.coauthor}} Ends with:
   ```
   Co-Authored-By: {{commit.coauthor}}
-  ```
+  ```{{/if}}{{#unless commit.coauthor}} Use the harness's standard identity if it supplies one;
+  otherwise omit a co-author trailer rather than inventing an identity.{{/unless}}
 - **`git add <explicit paths>` — never `-A` / `.`**. Never `--no-verify`; never amend; never
   **force**-push.
 - **PR:** base `main`, a "what shipped + which findings were actioned" narrative as the body,

--- a/templates/skills/cycle.md.tmpl
+++ b/templates/skills/cycle.md.tmpl
@@ -56,7 +56,7 @@ unattended.
    | implement | gates green when **the orchestrator re-runs them itself** (§4) | gates red, agent Blocked, a spawned "green" that doesn't reproduce (§3), **or the diff lands on a §5 always-brake surface** |
    | review | findings all mechanical, no design call | any P0, a finding that needs a design decision, or one that contradicts a memory note (§5) |
    | patch | gates green | gates red, a fix needs a design call |
-   | done | safe story: §6 poll-then-merge → issue closed | CI red / conflict / a hook failure that isn't a trivial retry · **judgment-call class → PR left open** (not a failure — stop the chain there and report) |
+   | done | safe story: §6 {{#if backend.auto_merge}}server-side merge queued; issue closes when the forge lands it{{/if}}{{#unless backend.auto_merge}}poll-then-merge → issue closed{{/unless}} | CI red / conflict / a hook failure that isn't a trivial retry · **judgment-call class → PR left open** (not a failure — stop the chain there and report) |
    | deploy-test | deploy + verify green | deploy non-zero, or the external check fails after retries |
 
 6. **On `--until-blocked`, after `/done`** (and the optional deploy):

--- a/templates/skills/dep-update.md.tmpl
+++ b/templates/skills/dep-update.md.tmpl
@@ -1,6 +1,6 @@
 ---
 name: dep-update
-description: Routine dependency hygiene for {{repo.name}} — survey what's outdated, plan the bump, update, run the gates, and land one lockfile commit. Distinguishes a stale test expectation from a real regression. Never uses `audit fix --force`; never auto-pushes. Plan-first. Usage `/dep-update` (or `/dep-update <package>`).
+description: {{#if deps.has_manager}}Routine dependency hygiene for {{repo.name}} — survey what's outdated, plan the bump, update, run the gates, and land one dependency-metadata commit. Distinguishes a stale test expectation from a real regression. Never uses `audit fix --force`; never auto-pushes. Plan-first. Usage `/dep-update` (or `/dep-update <package>`).{{/if}}{{#unless deps.has_manager}}Dependency updates are not configured for {{repo.name}} because no supported dependency manifest was detected. Explains how to configure the workflow without inventing package-manager commands. Usage `/dep-update`.{{/unless}}
 ---
 
 # /dep-update — dependency hygiene
@@ -11,6 +11,18 @@ Goal: keep dependencies current without turning a routine bump into an outage.
 (Gates), §8 (commit conventions — explicit paths), §9 (branch policy).
 
 {{> overlay?:dep-update-landmines}}
+
+{{#unless deps.has_manager}}
+## Not configured
+
+No supported dependency manifest was detected when the-cycle was installed. Dependency updates are
+not applicable until the repository adopts a package manager or `.cycle/config.jsonc` is updated
+with real dependency commands and manifests. Do not invent a package manager, manifest, or
+lockfile merely to make this skill actionable; run `/cycle-setup` after the repository's dependency
+workflow exists.
+{{/unless}}
+
+{{#if deps.has_manager}}
 
 ## Workflow
 
@@ -48,9 +60,11 @@ Goal: keep dependencies current without turning a routine bump into an outage.
 
 ## Edge cases
 
-- **Lockfile drift with nothing outdated:** `{{deps.install}}` rewrote the lockfile without any
+- {{#if deps.lockfile}}**Lockfile drift with nothing outdated:** `{{deps.install}}` rewrote `{{deps.lockfile}}` without any
   version change (a transitive resolution moved). That's a legitimate standalone commit — say so, don't
-  bury it in an unrelated diff.
+  bury it in an unrelated diff.{{/if}}{{#unless deps.lockfile}}**This repo has no configured
+  lockfile.** Work from the configured manifests ({{deps.manifests_md}}); do not invent a lockfile
+  as an unrelated side effect.{{/unless}}
 - **A formatter or linter bumped** and now reformats files nobody touched: separate the
   reformat-everything commit from the version bump, or the diff is unreviewable.
 - **A native or compiled dependency's ABI changed**: the gates may pass locally and fail on the
@@ -58,3 +72,4 @@ Goal: keep dependencies current without turning a routine bump into an outage.
 - **A patch/override is in play:** confirm it still applies after the bump. A silently-dropped
   patch is the classic "it worked locally" failure.
 - **Nothing is outdated:** say so and stop. Don't manufacture a bump.
+{{/if}}

--- a/templates/skills/deploy-test.md.tmpl
+++ b/templates/skills/deploy-test.md.tmpl
@@ -52,9 +52,10 @@ by-eye work gets checked *before* it merges.
    `Acceptance:` line. **Derive it; don't invent it.** No generic "click around and see if it
    works" filler: only *user-visible* surfaces earn a checkbox, and each one names what changed and
    what should now be true.
-5. **Ask for a verdict** — via {{harness.ask}}, with **Works** / **Something's off** / **Haven't
-   checked**. Skip this step entirely when nothing observable shipped (a refactor, a test-only
-   change); asking for a verdict on an invisible change trains people to click through.
+5. **Ask for a verdict** — {{#if harness.has_menus}}via {{harness.ask}}, with{{/if}}{{#unless harness.has_menus}}
+   directly in chat, offering{{/unless}} **Works** / **Something's off** / **Haven't checked**.
+   Skip this step entirely when nothing observable shipped (a refactor, a test-only change);
+   asking for a verdict on an invisible change trains people to click through.
 6. **On "Something's off": capture, don't debug.** Get {{repo.human}}'s description verbatim first
    — the raw words are the evidence. Then decide whether it's a fix-now or a `finding`.
 

--- a/templates/skills/done.md.tmpl
+++ b/templates/skills/done.md.tmpl
@@ -1,13 +1,14 @@
 ---
 name: done
-description: Ship a {{repo.name}} story — commit the reviewed work, push, open a PR that Closes #<n>, and (for a safe story) merge it via the background poll-then-merge guard; a judgment-call story's PR is left for {{repo.human}}'s manual merge. Done = the issue closes on merge. Plan-first. Usage `/done #<n>`. Use after /review (+ /patch) pass clean.
+description: Ship a {{repo.name}} story — commit the reviewed work, push, open a PR that Closes #<n>, and (for a safe story) {{#if backend.auto_merge}}queue server-side auto-merge{{/if}}{{#unless backend.auto_merge}}land it through the background poll-then-merge guard{{/unless}}; a judgment-call story's PR is left for {{repo.human}}'s manual merge. Done = the issue closes on merge. Plan-first. Usage `/done #<n>`. Use after /review (+ /patch) pass clean.
 ---
 
 # /done #<n> — ship a story
 
-Goal: commit the reviewed work, push, open a PR that closes the issue, and land it — auto-merging
-a safe story (CI-gated, via the background guard) or leaving a judgment-call PR for
-{{repo.human}}.
+Goal: commit the reviewed work, push, open a PR that closes the issue, and land it —
+{{#if backend.auto_merge}}queueing a safe story for CI-gated server-side auto-merge{{/if}}{{#unless backend.auto_merge}}
+auto-merging a safe story through the CI-gated background guard{{/unless}}, or leaving a
+judgment-call PR for {{repo.human}}.
 
 **Shared rules in `{{harness.doctrine_path}}` — read it if not already in context.** This skill
 leans on §4 Gates, §5 Judgment calls (the safe-vs-brake split), §6 Merge guard, §7 Tracker
@@ -29,8 +30,10 @@ mechanics, §8 Commit & PR conventions, §9 Branch policy. The procedure below i
 5. **Branch check** (§9) — must be on a feature branch, not `main`. If on `main`, stop.
 6. **Compose the narrative** — the "what shipped + which findings were actioned + why" summary
    that becomes the **PR body**.
-7. **Commit** (§8) — Conventional Commit, explicit paths (never `-A` / `.`), the `Co-Authored-By`
-   trailer, HEREDOC body.
+7. **Commit** (§8) — Conventional Commit, explicit paths (never `-A` / `.`), HEREDOC body.{{#if commit.coauthor}}
+   Include the configured `Co-Authored-By: {{commit.coauthor}}` trailer.{{/if}}{{#unless commit.coauthor}}
+   Use the harness's standard identity if it supplies one; otherwise omit a co-author trailer
+   rather than inventing an identity.{{/unless}}
 8. **Push** — `git push -u origin <branch>`.
 9. **Open the PR** (§8) — `{{@pr_create "<branch>" "<title>" "<body>"}}` — base `main`, the
    narrative body, **`Closes #<n>`**, the attribution trailer at the end (§8), the

--- a/test/ci.test.mjs
+++ b/test/ci.test.mjs
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+test('the required gates job exercises both the default runtime and the exact Node floor', () => {
+    const workflow = readFileSync(join(ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
+    const gatesStart = workflow.indexOf('\n  gates:\n');
+    assert.notEqual(gatesStart, -1, 'CI no longer defines the branch-protected gates job');
+
+    const afterGates = workflow.slice(gatesStart + '\n  gates:\n'.length);
+    const nextJob = afterGates.search(/^  [a-zA-Z0-9_-]+:\n/m);
+    const gates = nextJob === -1 ? afterGates : afterGates.slice(0, nextJob);
+    const node22 = gates.indexOf("node-version: '22'");
+    const node20 = gates.indexOf("node-version: '20.0.0'");
+
+    assert.ok(node22 >= 0, 'gates does not exercise the default Node runtime');
+    assert.ok(node20 > node22, 'gates does not exercise Node 20.0.0 after the default runtime');
+    assert.doesNotMatch(workflow, /^  compat-node-20:/m, 'compatibility must not live in an optional job');
+});

--- a/test/engine.test.mjs
+++ b/test/engine.test.mjs
@@ -19,6 +19,7 @@ import {
     stampProvenance,
     stripJsonComments,
     stripProvenance,
+    verifyForge,
 } from '../bin/cycle.mjs';
 
 const ctx = {
@@ -211,5 +212,47 @@ describe('diff', () => {
         assert.equal(d.added, 1);
         assert.equal(d.removed, 1);
         assert.equal(lineDiff('a\nb', 'a\nb').added, 0);
+    });
+});
+
+describe('forge verification', () => {
+    const base = {
+        backend: 'github',
+        repo: { slug: 'brndnsh-labs/the-cycle' },
+        backend_overrides: { auto_merge: true },
+    };
+
+    test('skips unsupported or unqueryable forge state without inventing a mismatch', () => {
+        assert.match(verifyForge({ backend: 'other' }).skipped, /no forge probe/);
+        assert.match(verifyForge({ backend: 'github', repo: {} }).skipped, /repo.slug/);
+        const result = verifyForge(base, { exec: () => { throw new Error('offline'); } });
+        assert.deepEqual(result.problems, []);
+        assert.match(result.skipped, /could not query/);
+    });
+
+    test('reports declared auto-merge that is disabled live', () => {
+        const result = verifyForge(base, { exec: () => '{"allow_auto_merge":false}' });
+        assert.match(result.problems.join('\n'), /declared true.*allow_auto_merge=false/);
+    });
+
+    test('reports live auto-merge missing from config', () => {
+        const cfg = { ...base, backend_overrides: { auto_merge: false } };
+        const result = verifyForge(cfg, { exec: () => '{"allow_auto_merge":true}' });
+        assert.match(result.problems.join('\n'), /allows auto-merge.*does not declare/);
+    });
+
+    test('requires status checks when auto-merge is declared', () => {
+        const exec = (_command, args) => args[1].includes('/protection')
+            ? '[]'
+            : '{"allow_auto_merge":true}';
+        const result = verifyForge(base, { exec });
+        assert.match(result.problems.join('\n'), /no required status checks/);
+    });
+
+    test('accepts matching auto-merge and protected branch state', () => {
+        const exec = (_command, args) => args[1].includes('/protection')
+            ? '["gates"]'
+            : '{"allow_auto_merge":true}';
+        assert.deepEqual(verifyForge(base, { exec }), { problems: [], skipped: null });
     });
 });

--- a/test/package.test.mjs
+++ b/test/package.test.mjs
@@ -1,0 +1,75 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+test('the packed artifact contains only the supported product surface and can render', () => {
+    const work = mkdtempSync(join(tmpdir(), 'cycle-package-'));
+    try {
+        const raw = execFileSync('npm', [
+            'pack', '--json', '--pack-destination', work, '--cache', join(work, 'npm-cache'),
+        ], { cwd: ROOT, encoding: 'utf8' });
+        const parsed = JSON.parse(raw);
+        const metadata = Array.isArray(parsed) ? parsed[0] : parsed['@brndnsh/the-cycle'];
+        assert.equal(metadata.name, '@brndnsh/the-cycle');
+
+        const files = metadata.files.map((entry) => entry.path);
+        for (const expected of [
+            'bin/cycle.mjs', 'templates/DOCTRINE.md.tmpl', 'backends/github.jsonc',
+            'harnesses/codex.jsonc', 'profiles/lean.jsonc', 'skills/cycle-setup/SKILL.md',
+            'docs/RELEASING.md',
+        ]) {
+            assert.ok(files.includes(expected), `packed artifact omitted ${expected}`);
+        }
+        for (const excluded of [
+            '.cycle/', '.claude/', '.agents/', '.github/', 'test/', 'AGENTS.md', 'CLAUDE.md',
+        ]) {
+            assert.ok(!files.some((path) => path.startsWith(excluded)), `packed artifact leaked ${excluded}`);
+        }
+
+        const unpacked = join(work, 'unpacked');
+        mkdirSync(unpacked);
+        execFileSync('tar', ['-xzf', join(work, metadata.filename), '-C', unpacked]);
+        const packageRoot = join(unpacked, 'package');
+        assert.equal(
+            execFileSync(process.execPath, [join(packageRoot, 'bin', 'cycle.mjs'), '--version'], {
+                encoding: 'utf8', env: { ...process.env, NO_COLOR: '1' },
+            }).trim(),
+            'v0.1.0',
+        );
+
+        const home = join(work, 'home');
+        mkdirSync(home);
+        execFileSync('bash', [join(packageRoot, 'install.sh')], {
+            encoding: 'utf8', env: { ...process.env, HOME: home },
+        });
+        assert.ok(existsSync(join(home, '.local', 'bin', 'cycle')));
+        assert.ok(existsSync(join(home, '.claude', 'skills', 'cycle-setup', 'SKILL.md')));
+        assert.ok(existsSync(join(home, '.agents', 'skills', 'cycle-setup', 'SKILL.md')));
+
+        const collisionHome = join(work, 'collision-home');
+        mkdirSync(join(collisionHome, '.agents', 'skills', 'cycle-setup'), { recursive: true });
+        const collision = spawnSync('bash', [join(packageRoot, 'install.sh')], {
+            encoding: 'utf8', env: { ...process.env, HOME: collisionHome },
+        });
+        assert.notEqual(collision.status, 0, 'installer silently accepted a real-directory collision');
+        assert.match(collision.stderr, /refusing to replace existing directory or file/);
+        assert.ok(!existsSync(join(collisionHome, '.agents', 'skills', 'cycle-setup', 'cycle-setup')));
+
+        const repo = join(work, 'consumer');
+        mkdirSync(repo);
+        execFileSync('git', ['init', '-q', '.'], { cwd: repo });
+        writeFileSync(join(repo, 'package.json'), '{"name":"packed-smoke"}\n');
+        execFileSync(process.execPath, [join(packageRoot, 'bin', 'cycle.mjs'), 'install', '-y'], {
+            cwd: repo, encoding: 'utf8', env: { ...process.env, NO_COLOR: '1' },
+        });
+        assert.ok(existsSync(join(repo, '.claude', 'skills', 'DOCTRINE.md')));
+    } finally {
+        rmSync(work, { recursive: true, force: true });
+    }
+});

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -304,13 +304,17 @@ describe('multi-harness render', () => {
         assert.match(codexCycle, /Shared rules in `\.agents\/skills\/DOCTRINE\.md`/);
     });
 
-    test('the structured-menu tool name differs per harness, both wrapped correctly', () => {
+    test('Codex uses direct chat when its structured menu is unavailable in normal skill execution', () => {
         const claudeIntake = readFileSync(join(dir, '.claude', 'skills', 'intake', 'SKILL.md'), 'utf8');
         const codexIntake = readFileSync(join(dir, '.agents', 'skills', 'intake', 'SKILL.md'), 'utf8');
         assert.match(claudeIntake, /`AskUserQuestion`/);
-        assert.doesNotMatch(claudeIntake, /ask_user_question/);
-        assert.match(codexIntake, /`ask_user_question`/);
+        assert.doesNotMatch(claudeIntake, /request_user_input/);
+        assert.match(codexIntake, /no structured menu tool/);
+        assert.doesNotMatch(codexIntake, /request_user_input/);
         assert.doesNotMatch(codexIntake, /AskUserQuestion/);
+
+        const codexDoctrine = readFileSync(join(dir, '.agents', 'skills', 'DOCTRINE.md'), 'utf8');
+        assert.doesNotMatch(codexDoctrine, /Sonnet|opus/);
     });
 
     test('check reports clean across both trees, and re-render is a byte-identical no-op', () => {
@@ -326,6 +330,95 @@ describe('multi-harness render', () => {
         assert.match(out, /\.agents\/skills\/wrap-up\/SKILL\.md/);
         assert.doesNotMatch(readFileSync(join(dir, '.claude', 'skills', 'wrap-up', 'SKILL.md'), 'utf8'), /cycle:rendered/);
         assert.doesNotMatch(readFileSync(join(dir, '.agents', 'skills', 'wrap-up', 'SKILL.md'), 'utf8'), /cycle:rendered/);
+    });
+});
+
+describe('dependency metadata contracts', () => {
+    test('a package.json-only repository gets a truthful no-lock workflow', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        cycle(dir, ['install', '--profile', 'standard', '-y']);
+
+        const skill = readFileSync(join(dir, '.claude', 'skills', 'dep-update', 'SKILL.md'), 'utf8');
+        assert.match(skill, /npm outdated/);
+        assert.doesNotMatch(skill, /npm audit/);
+        assert.doesNotMatch(skill, /package-lock\.json/);
+        assert.match(skill, /no configured\s+lockfile/i);
+        assert.match(skill, /`package\.json`/);
+    });
+
+    test('a configured manifest that does not exist fails with an actionable error', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        cycle(dir, ['install', '--profile', 'lean', '-y']);
+        const cfgPath = join(dir, '.cycle', 'config.jsonc');
+        writeFileSync(cfgPath, readFileSync(cfgPath, 'utf8').replace(
+            '"manifests": [\n      "package.json"\n    ]',
+            '"manifests": ["package.json", "missing.lock"]',
+        ));
+
+        const checked = cycleRaw(dir, ['check']);
+        assert.equal(checked.status, 1);
+        assert.match(checked.out, /configured dependency manifest missing: missing\.lock/);
+        assert.match(checked.out, /fix deps\.manifests/);
+    });
+
+    test('legacy configs infer their lockfile from dependency manifests', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        writeFileSync(join(dir, 'package-lock.json'), '{"name":"demo","lockfileVersion":3,"packages":{}}\n');
+        cycle(dir, ['install', '--profile', 'standard', '-y']);
+        const cfgPath = join(dir, '.cycle', 'config.jsonc');
+        const configured = readFileSync(cfgPath, 'utf8');
+        assert.match(configured, /"lockfile": "package-lock\.json"/);
+        const legacyConfig = configured.replace(
+            /^\s*"lockfile": "package-lock\.json",\n/m,
+            '',
+        );
+        assert.doesNotMatch(legacyConfig, /"lockfile":/);
+        writeFileSync(cfgPath, legacyConfig);
+
+        cycle(dir, ['update']);
+        const skill = readFileSync(join(dir, '.claude', 'skills', 'dep-update', 'SKILL.md'), 'utf8');
+        assert.match(skill, /Lockfile drift with nothing outdated/);
+        assert.match(skill, /`package-lock\.json`/);
+        assert.doesNotMatch(skill, /no configured\s+lockfile/i);
+    });
+
+    test('a repository with no recognized dependency ecosystem renders an honest stub', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'cycle-no-deps-'));
+        dirs.push(dir);
+        execFileSync('git', ['init', '-q', '.'], { cwd: dir });
+        execFileSync('git', ['remote', 'add', 'origin', REMOTES.github], { cwd: dir });
+        execFileSync('git', ['config', 'user.name', 'Brandon Shea'], { cwd: dir });
+        cycle(dir, ['install', '--profile', 'standard', '-y']);
+
+        const skill = readFileSync(join(dir, '.claude', 'skills', 'dep-update', 'SKILL.md'), 'utf8');
+        assert.match(skill, /## Not configured/);
+        assert.match(skill, /No supported dependency manifest was detected/);
+        assert.doesNotMatch(skill, /npm (?:outdated|update|install|audit)/);
+        assert.match(cycle(dir, ['check']), /clean/);
+    });
+});
+
+describe('commit attribution', () => {
+    test('omits invented coauthors by default and preserves legacy configured trailers', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        cycle(dir, ['install', '--profile', 'lean', '-y']);
+        const donePath = join(dir, '.claude', 'skills', 'done', 'SKILL.md');
+        assert.doesNotMatch(readFileSync(donePath, 'utf8'), /Co-Authored-By/);
+
+        const cfgPath = join(dir, '.cycle', 'config.jsonc');
+        writeFileSync(cfgPath, readFileSync(cfgPath, 'utf8').replace(
+            '"coauthor": ""',
+            '"coauthor": "Configured Agent <agent@example.com>"',
+        ));
+        cycle(dir, ['update']);
+        assert.match(
+            readFileSync(donePath, 'utf8'),
+            /Co-Authored-By: Configured Agent <agent@example\.com>/,
+        );
     });
 });
 
@@ -363,6 +456,22 @@ describe('deploy-test on a repo with no test environment', () => {
         assert.match(out, /put it on the test box/);
         assert.match(out, /\.\/deploy\.sh test/, 'the configured command must appear');
         assert.doesNotMatch(out, /not applicable here/);
+    });
+
+    test('Codex asks for the post-deploy verdict directly in chat', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        cycle(dir, ['install', '--profile', 'standard', '-y']);
+        const cfgPath = join(dir, '.cycle', 'config.jsonc');
+        const cfg = readCfg(cfgPath);
+        cfg.harnesses = ['claude', 'codex'];
+        cfg.deploy = { test: './deploy.sh test', prod: './deploy.sh prod' };
+        writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
+        cycle(dir, ['update', '--force']);
+
+        const out = readFileSync(join(dir, '.agents', 'skills', 'deploy-test', 'SKILL.md'), 'utf8');
+        assert.match(out, /directly in chat, offering \*\*Works\*\*/);
+        assert.doesNotMatch(out, /request_user_input/);
     });
 
     test('the stub is managed — it renders clean instead of reporting drift', () => {
@@ -533,6 +642,7 @@ describe('backend_overrides.auto_merge', () => {
 
     const doctrine = (d) => readFileSync(join(d, '.claude', 'skills', 'DOCTRINE.md'), 'utf8');
     const done = (d) => readFileSync(join(d, '.claude', 'skills', 'done', 'SKILL.md'), 'utf8');
+    const cycleSkill = (d) => readFileSync(join(d, '.claude', 'skills', 'cycle', 'SKILL.md'), 'utf8');
 
     test('default renders the poll-then-merge guard, not --auto', () => {
         const src = doctrine(guardDir);
@@ -549,8 +659,20 @@ describe('backend_overrides.auto_merge', () => {
     test('/done follows the same switch, so the flag is not doctrine-only', () => {
         assert.match(done(guardDir), /until gh pr checks/);
         assert.doesNotMatch(done(guardDir), /gh pr merge .*--auto/);
+        assert.match(done(guardDir), /background poll-then-merge guard/);
+        assert.doesNotMatch(done(guardDir), /queue server-side auto-merge/);
         assert.match(done(autoDir), /gh pr merge .*--auto/);
         assert.doesNotMatch(done(autoDir), /until gh pr checks/);
+        assert.match(done(autoDir), /queue server-side auto-merge/);
+        assert.match(done(autoDir), /CI-gated server-side auto-merge/);
+        assert.doesNotMatch(done(autoDir), /background poll-then-merge guard/);
+    });
+
+    test('/cycle reports the actual completion boundary in both modes', () => {
+        assert.match(cycleSkill(guardDir), /poll-then-merge → issue closed/);
+        assert.doesNotMatch(cycleSkill(guardDir), /server-side merge queued/);
+        assert.match(cycleSkill(autoDir), /server-side merge queued; issue closes when the forge lands it/);
+        assert.doesNotMatch(cycleSkill(autoDir), /poll-then-merge → issue closed/);
     });
 
     // The regression this change exists to prevent: `Closes #<n>` used to live INSIDE


### PR DESCRIPTION
## Summary

- add first-class Codex dogfooding, root agent guidance, and provider-neutral shared templates
- make the npm artifact installable and smoke-tested while keeping dependency workflows truthful across lockfile configurations
- strengthen runtime compatibility, render/forge validation, release documentation, and repository-local regression coverage

## Review findings actioned

- keep exact Node 20.0.0 compatibility inside the branch-protected `gates` job
- make `/done` and `/cycle` descriptions follow `backend.auto_merge`
- exclude repository-only agent instructions from the published package
- make the legacy lockfile inference regression non-vacuous

## Validation

- `npm test` — 107 tests passed
- exact Node 20.0.0 suite — 107 tests passed
- `node bin/cycle.mjs lint`
- `node bin/cycle.mjs check`
- `node bin/cycle.mjs check --verify-forge`
- `npm pack --dry-run --json`
- `git diff --check`

Closes #20

Also supports the package-preparation portion of #4; its credential-gated first npm publication remains separate.

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)
