### PR TITLE
fix(templates): avoid no-menu trailing whitespace

### DIFF
--- a/templates/skills/deploy-test.md.tmpl
+++ b/templates/skills/deploy-test.md.tmpl
@@ -52,8 +52,8 @@ by-eye work gets checked *before* it merges.
    `Acceptance:` line. **Derive it; don't invent it.** No generic "click around and see if it
    works" filler: only *user-visible* surfaces earn a checkbox, and each one names what changed and
    what should now be true.
-5. **Ask for a verdict** — {{#if harness.has_menus}}via {{harness.ask}}, with{{/if}}{{#unless harness.has_menus}}
-   directly in chat, offering{{/unless}} **Works** / **Something's off** / **Haven't checked**.
+{{#if harness.has_menus}}5. **Ask for a verdict** — via {{harness.ask}}, with **Works** / **Something's off** / **Haven't checked**.{{/if}}
+{{#unless harness.has_menus}}5. **Ask for a verdict** — directly in chat, offering **Works** / **Something's off** / **Haven't checked**.{{/unless}}
    Skip this step entirely when nothing observable shipped (a refactor, a test-only change);
    asking for a verdict on an invisible change trains people to click through.
 6. **On "Something's off": capture, don't debug.** Get {{repo.human}}'s description verbatim first

--- a/templates/skills/unblock.md.tmpl
+++ b/templates/skills/unblock.md.tmpl
@@ -48,10 +48,11 @@ both and presents desk first, then hands-on.
    **A recommendation is mandatory on every item.** "What do you want to do?" hands the work back;
    the point of this skill is to hand back only the *decision*.
 
-6. **Ask.** {{#if harness.has_menus}}Via {{harness.ask}} — one question per item, **recommended
-   option first and labeled `(Recommended)`**, max 4 per call.{{/if}}{{#unless harness.has_menus}}
-   This harness has no structured menu tool — ask one question per item directly in chat, stating
-   the recommendation first, and wait for the reply before moving to the next item.{{/unless}}
+{{#if harness.has_menus}}6. **Ask.** Via {{harness.ask}} — one question per item, **recommended
+   option first and labeled `(Recommended)`**, max 4 per call.{{/if}}
+{{#unless harness.has_menus}}6. **Ask.** This harness has no structured menu tool — ask one question
+   per item directly in chat, stating the recommendation first, and wait for the reply before
+   moving to the next item.{{/unless}}
    - **desk** verdicts: the actual options, recommendation first.
    - **hands-on** verdicts: **Works** / **Doesn't work** / **Not now**.
      **"Not now" is a first-class answer, not a failure** — declining to go test something is a

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -102,6 +102,13 @@ for (const backend of BACKENDS) {
                 }
             });
 
+            test('managed output contains no trailing whitespace', () => {
+                for (const s of [...skills.map((x) => join('.claude/skills', x, 'SKILL.md')), '.claude/skills/DOCTRINE.md']) {
+                    const text = readFileSync(join(dir, s), 'utf8');
+                    assert.doesNotMatch(text, /[ \t]+$/m, `${s}: trailing whitespace`);
+                }
+            });
+
             // The inverse of the guard that used to live here. An install renders prose
             // and nothing else: no executable is installed into a consuming repo, so a
             // rendered command can never point at a script the repo doesn't have. If a


### PR DESCRIPTION
## Summary

- render the full numbered step inside each harness conditional
- preserve Claude menu wording and Codex direct-chat wording without space-only line tails
- assert every managed skill is free of trailing whitespace across all profiles

## Validation

- `npm test` — 110 tests passed
- `node bin/cycle.mjs lint`
- `node bin/cycle.mjs check`
- `git diff --check`

Closes #22

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)
