### PR TITLE
feat(harnesses): add Copilot CLI harness target

### DIFF
--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -31,16 +31,16 @@ executables to keep in sync.
 
 ## The `harness.*` field vocabulary
 
-| Field | Example (claude) | Example (codex) | Purpose |
-| --- | --- | --- | --- |
-| `harness.name` | `claude` | `codex` | the config key |
-| `harness.display` | `Claude Code` | `Codex CLI` | human-readable, for prose |
-| `harness.root` | `.claude/skills` | `.agents/skills` | where this tree's skills land |
-| `harness.doctrine_path` | `.claude/skills/DOCTRINE.md` | `.agents/skills/DOCTRINE.md` | computed (`root/DOCTRINE.md`) — every skill's "Shared rules in `…`" line |
-| `harness.has_menus` | `true` | `false` | a structured choice tool is callable in normal skill execution |
-| `harness.has_subagents` | `true` | `true` | a native parallel-subagent spawn tool exists |
-| `harness.attribution` | `🤖 Generated with [Claude Code](…)` | `🤖 Generated with [Codex CLI](…)` | the §8 PR-body trailer |
-| `harness.ask` | `` `AskUserQuestion` `` | `plain chat` | how a workflow asks a discrete question |
+| Field | Example (claude) | Example (codex) | Example (copilot) | Purpose |
+| --- | --- | --- | --- | --- |
+| `harness.name` | `claude` | `codex` | `copilot` | the config key |
+| `harness.display` | `Claude Code` | `Codex CLI` | `Copilot CLI` | human-readable, for prose |
+| `harness.root` | `.claude/skills` | `.agents/skills` | `.github/skills` | where this tree's skills land |
+| `harness.doctrine_path` | `.claude/skills/DOCTRINE.md` | `.agents/skills/DOCTRINE.md` | `.github/skills/DOCTRINE.md` | computed (`root/DOCTRINE.md`) — every skill's "Shared rules in `…`" line |
+| `harness.has_menus` | `true` | `false` | `true` | a structured choice tool is callable in normal skill execution |
+| `harness.has_subagents` | `true` | `true` | `true` | a native parallel-subagent spawn tool exists |
+| `harness.attribution` | `🤖 Generated with [Claude Code](…)` | `🤖 Generated with [Codex CLI](…)` | `🤖 Generated with [Copilot CLI](…)` | the §8 PR-body trailer |
+| `harness.ask` | `` `AskUserQuestion` `` | `plain chat` | `` `ask_user` `` | how a workflow asks a discrete question |
 
 `doctrine_path` is computed by the engine (`buildHarnessContext` in `bin/cycle.mjs`) from `root` —
 it isn't a field a harness file declares. Everything else comes straight from the `.jsonc` file.
@@ -52,16 +52,17 @@ them via `{{#if harness.…}}` / `{{#unless harness.…}}` — and `cycle lint`'
 the build if a template branches on a field the engine never populates (a typo inside a block is
 otherwise silently falsy, not a hard error — see `bin/lint.mjs`):
 
-| | Claude Code | Codex CLI |
-| --- | --- | --- |
-| `has_menus` | `true` — `AskUserQuestion` | `false` — `request_user_input` is Plan-mode only |
-| `has_subagents` | `true` — the Agent tool | `true` — subagents, GA 2026-03-14 |
+| | Claude Code | Codex CLI | Copilot CLI |
+| --- | --- | --- | --- |
+| `has_menus` | `true` — `AskUserQuestion` | `false` — `request_user_input` is Plan-mode only | `true` — `ask_user` |
+| `has_subagents` | `true` — the Agent tool | `true` — subagents, GA 2026-03-14 | `true` — the `task` tool / `/fleet` |
 
-Both harnesses support the same open agent-skills format and native subagents. Codex's structured
-question tool is mode-scoped, however, so ordinary skill execution takes the direct-chat menu
-fallback. The `{{#unless harness.has_menus}}` / `{{#unless harness.has_subagents}}` branches are
-real shipped behavior as well as the extension seam for a future, less-capable harness (Opencode,
-Pi — see the harness-target follow-up issues).
+All three harnesses support the same open agent-skills format and native subagents. Codex's
+structured question tool is mode-scoped, so ordinary skill execution takes the direct-chat menu
+fallback there; Claude Code and Copilot CLI both expose theirs in normal sessions. The
+`{{#unless harness.has_menus}}` / `{{#unless harness.has_subagents}}` branches are real shipped
+behavior as well as the extension seam for a future, less-capable harness (Opencode, Pi — see the
+harness-target follow-up issues).
 
 ## Verified discovery paths, not assumed
 
@@ -74,6 +75,10 @@ finds the skills at all, and that failure is silent (no error, just nothing to i
   `developers.openai.com/codex/skills` (2026-07). Codex also discovers skills at a parent directory,
   `~/.agents/skills`, `/etc/codex/skills`, and its own built-ins — the repo-root path is what a
   rendered install writes to.
+- **Copilot CLI** — `.github/skills/<name>/SKILL.md` at the repo root, confirmed against
+  `docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-skills` (2026-08). Copilot
+  also discovers `.claude/skills` and `.agents/skills` as equally valid project-skill roots —
+  `.github/skills` is used here to avoid colliding with the codex harness's root.
 
 Before adding a harness, re-verify its current discovery path against that tool's own docs at
 implementation time — these move, and a stale path here is worse than no harness at all.

--- a/harnesses/copilot.jsonc
+++ b/harnesses/copilot.jsonc
@@ -1,0 +1,40 @@
+// GitHub Copilot CLI — the third render target, and the second registry entry on top
+// of the harness abstraction (that machinery shipped with Claude Code + Codex CLI).
+//
+// Skills are the same open agent-skills format the other two harnesses use (SKILL.md +
+// name/description frontmatter), so almost nothing here differs from claude.jsonc or
+// codex.jsonc. Verified against the current release (2026-08), not assumed:
+//   - discovery path: docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-skills
+//     — project skills are discovered at .github/skills, .claude/skills, OR .agents/skills
+//     at the repo root, all three equally valid. .github/skills is used here rather than
+//     .agents/skills specifically to avoid colliding with the codex harness's root if a
+//     repo ever configures both (cycle lint's root-collision check would catch a clash,
+//     but there's no reason to court it).
+//   - subagents: a `task` tool exists for general-purpose delegation in normal/default
+//     sessions (it survives even Plan mode's stripped-to-4-tools set), plus a `/fleet`
+//     user command for larger multi-agent decomposition — so /fan-out and /cover's
+//     per-unit spawn apply here too.
+//   - structured questions: an `ask_user` tool exists with predefined choices plus an
+//     auto-appended "Other" freeform escape hatch, functionally equivalent to
+//     AskUserQuestion, and available in normal/default sessions (unlike Codex's
+//     Plan-mode-only equivalent). Note for future re-verification: Copilot CLI ships
+//     updates constantly and there's at least one open upstream report of `ask_user`
+//     intermittently disappearing — re-confirm this flag against a live session before
+//     leaning on it hard.
+{
+  "name": "copilot",
+  "display": "Copilot CLI",
+
+  "root": ".github/skills",
+  "skill_file": "SKILL.md",
+
+  "capabilities": {
+    "has_menus": true,
+    "has_subagents": true
+  },
+
+  "notes": {
+    "attribution": "🤖 Generated with [Copilot CLI](https://github.com/features/copilot/cli)",
+    "ask": "`ask_user`"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `harnesses/copilot.jsonc`, the third render target, mirroring the same open agent-skills format as Claude Code and Codex CLI — the harness abstraction already existed, so this is the second registry entry, not new machinery.
- Discovery path (`.github/skills/<name>/SKILL.md`), frontmatter dialect, and capability flags (`has_menus`, `has_subagents`) verified against the current Copilot CLI release (2026-08) rather than assumed. `.github/skills` was chosen over the also-valid `.agents/skills` specifically to avoid a root collision with the codex harness.
- Extends `docs/HARNESSES.md`'s verified-paths list and both harness-comparison tables to cover Copilot CLI.

## Verification
- `npm test` — 116/116 passing
- `node bin/cycle.mjs check` — clean, no drift
- `node bin/cycle.mjs lint` — consistent
- Behavioral half of the issue's acceptance (a live Copilot CLI session running a full `/cycle`) was informally confirmed by Brandon already — the rendered skills were picked up correctly.

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)