### PR TITLE
feat(cli): ask which harnesses to install instead of assuming claude

### DIFF
--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -812,6 +812,20 @@ export function detect(root) {
     // nothing to sniff for.
     out.backend = 'github';
 
+    // A repo can already show which AI harness(es) it runs — a .claude/ tree, an
+    // AGENTS.md or .agents/ tree (Codex), a .github/skills convention (Copilot CLI).
+    // A guess worth confirming, like everything else here — not proof of intent.
+    const harnessSignals = [
+        ['.claude', 'claude'],
+        ['AGENTS.md', 'codex'],
+        ['.agents', 'codex'],
+        [join('.github', 'skills'), 'copilot'],
+    ];
+    const harnesses = [...new Set(
+        harnessSignals.filter(([marker]) => existsSync(join(root, marker))).map(([, h]) => h),
+    )];
+    if (harnesses.length) out.harnesses = harnesses;
+
     if (existsSync(join(root, 'scripts', 'deploy.sh'))) {
         out.deploy = { test: './scripts/deploy.sh test', prod: './scripts/deploy.sh prod' };
     }
@@ -896,10 +910,10 @@ export function draftConfig(root, { backend: wanted, profile, set } = {}) {
         },
         profile: profile ?? 'lean',
         backend,
-        // Which harness trees to render. Claude Code only, by default — add another
-        // (e.g. "codex") by hand to also render into that harness's discovery root.
-        // See harnesses/*.jsonc and docs/HARNESSES.md.
-        harnesses: ['claude'],
+        // Which harness trees to render. Detected from filesystem markers when
+        // present (see `detect`), else Claude Code only. See harnesses/*.jsonc and
+        // docs/HARNESSES.md.
+        harnesses: d.harnesses ?? ['claude'],
         tracker: {
             description: `**GitHub issues** (\`${d.slug ?? ''}\`)`,
             statuses: DEFAULT_STATUSES[backend] ?? DEFAULT_STATUSES.github,
@@ -954,6 +968,8 @@ async function cmdInstall(args) {
         cfg.repo.name = await ask('Repo display name', cfg.repo.name);
         cfg.repo.human = await ask('Who does this pipeline interrupt?', cfg.repo.human);
         cfg.profile = await ask('Profile (lean/standard/full)', cfg.profile);
+        const harnesses = await ask('Harnesses (comma-separated, from the registry)', cfg.harnesses.join(', '));
+        cfg.harnesses = harnesses.split(',').map((s) => s.trim()).filter(Boolean);
         // No interactive question for backend itself: github is the only one the-cycle
         // binds today, so asking would be a confirm-the-only-answer prompt. `--backend`
         // still overrides it (draftConfig above), for whenever a second one exists.
@@ -972,6 +988,7 @@ async function cmdInstall(args) {
 
     loadProfile(cfg.profile);
     loadBackend(cfg.backend);
+    for (const h of harnessNames(cfg)) loadHarness(h);
 
     mkdirSync(join(root, '.cycle'), { recursive: true });
     mkdirSync(overlayDir(root), { recursive: true });
@@ -1024,6 +1041,9 @@ function cmdPlan(root, values) {
     const profiles = readdirSync(join(CYCLE_HOME, 'profiles'))
         .filter((f) => f.endsWith('.jsonc'))
         .map((f) => basename(f, '.jsonc'));
+    const harnesses = readdirSync(join(CYCLE_HOME, 'harnesses'))
+        .filter((f) => f.endsWith('.jsonc'))
+        .map((f) => basename(f, '.jsonc'));
 
     const overlayManifest = existsSync(templatePath('overlays.jsonc')) ? readJsonc(templatePath('overlays.jsonc')) : {};
 
@@ -1040,6 +1060,7 @@ function cmdPlan(root, values) {
             backend: detected.backend,
             gates: detected.gates,
             deploy: detected.deploy ?? null,
+            harnesses: detected.harnesses ?? null,
         },
         draft: cfg,
         // The decisions a draft cannot make for itself.
@@ -1050,6 +1071,13 @@ function cmdPlan(root, values) {
                 why: 'Machinery is opt-in — a repo should take a lane when it has earned it, not by default. Start lean unless the repo already does the thing.',
                 options: profiles,
                 default: cfg.profile,
+            },
+            {
+                path: 'harnesses',
+                asks: 'Which AI coding harnesses should this pipeline render into?',
+                why: 'Each configured harness gets its own complete, independent skill tree — same doctrine, same procedure, only the discovery root and harness-conditional prose differ. Detect what the repo already runs: a .claude/ tree suggests Claude Code, AGENTS.md or a .agents/ tree suggests Codex, a .github/ convention suggests Copilot CLI. Multiple can be configured together.',
+                options: harnesses,
+                default: cfg.harnesses,
             },
             {
                 path: 'repo.human',

--- a/skills/cycle-setup/SKILL.md
+++ b/skills/cycle-setup/SKILL.md
@@ -54,6 +54,11 @@ to prevent.
   GitHub verbs over the wrong tracker.
 - **Profile** — `lean` unless the repo already does the thing a bigger profile assumes. Don't
   install `/nightly` because it sounds useful; install it when there's an overnight lane.
+- **Harnesses** — which AI coding tool(s) actually run here. Detect before asking: a `.claude/`
+  tree means Claude Code, `AGENTS.md` or a `.agents/` tree means Codex CLI, a `.github/` skills
+  convention means Copilot CLI. More than one can be configured together — each gets its own
+  complete, independent skill tree. Default to what's detected; ask only when nothing points at
+  an answer. `cycle install --plan` lists the full registry as `options`.
 
 ## 2. Ask only what reading can't settle
 
@@ -105,7 +110,7 @@ the rendered file.
 
 ## Report
 
-- Profile and backend, with the evidence for each.
+- Profile, backend, and harnesses, with the evidence for each.
 - Every config value that differs from the draft, and why.
 - Overlays written, and overlays deliberately skipped.
 - Anything you couldn't verify — an unreachable tracker, a gate you couldn't run, a guessed brake.

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -599,6 +599,7 @@ describe('version stamp — no .git in CYCLE_HOME (an npm/npx install)', () => {
             [/Repo display name/, ''],
             [/interrupt\?/, ''],
             [/Profile \(lean/, ''],
+            [/Harnesses \(comma-separated/, ''],
             [/Typecheck gate/, ''],
             [/Test gate/, ''],
             [/Always-brake surfaces/, ''],


### PR DESCRIPTION
## Summary
- `cycle install --plan` and the raw interactive interview both now ask which AI coding harnesses to render into, with options drawn from the harness registry (`claude`/`codex`/`copilot`) and a default sourced from filesystem detection.
- `detect()` sniffs `.claude/`, `AGENTS.md`/`.agents/`, and `.github/skills` markers to guess the answer — a repo already running one or more harnesses doesn't have to spell it out.
- Harness names are validated via `loadHarness` at install time, the same as `profile`/`backend`.
- `skills/cycle-setup/SKILL.md` gets a matching "read the repo" bullet and report-checklist entry.

## Note on the issue's premise
The issue's "Fix (drafted)" section assumed `cycle adopt` would do the detection ("`cycle adopt` *detects* instead of asking cold"). `cycle adopt` was retired in #19 (its conversion queue went empty) before this issue's body was actually written up — so that bullet no longer applies as written. The detection idea itself is still sound; it's implemented in `detect()` instead, feeding both `install --plan` and the raw interview. Similarly, the issue named `.claude/skills/cycle-setup` — that path doesn't exist in this repo; the real file is `skills/cycle-setup/SKILL.md`, the personal setup skill `install.sh` links out to `~/.claude/skills` and `~/.agents/skills`.

## Verification
- `npm test` — 116/116 passing (includes a fix to the scripted-interview test for the new prompt)
- `node bin/cycle.mjs check` — clean
- `node bin/cycle.mjs lint` — consistent
- Manual smoke test: `cycle install --plan` on this repo itself correctly detects `["claude", "codex"]` from its own `.claude/`/`.agents/` trees

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)