### PR TITLE
feat(harnesses): add OpenCode and Pi harness targets (secondary)

### DIFF
--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -31,16 +31,16 @@ executables to keep in sync.
 
 ## The `harness.*` field vocabulary
 
-| Field | Example (claude) | Example (codex) | Example (copilot) | Purpose |
-| --- | --- | --- | --- | --- |
-| `harness.name` | `claude` | `codex` | `copilot` | the config key |
-| `harness.display` | `Claude Code` | `Codex CLI` | `Copilot CLI` | human-readable, for prose |
-| `harness.root` | `.claude/skills` | `.agents/skills` | `.github/skills` | where this tree's skills land |
-| `harness.doctrine_path` | `.claude/skills/DOCTRINE.md` | `.agents/skills/DOCTRINE.md` | `.github/skills/DOCTRINE.md` | computed (`root/DOCTRINE.md`) — every skill's "Shared rules in `…`" line |
-| `harness.has_menus` | `true` | `false` | `true` | a structured choice tool is callable in normal skill execution |
-| `harness.has_subagents` | `true` | `true` | `true` | a native parallel-subagent spawn tool exists |
-| `harness.attribution` | `🤖 Generated with [Claude Code](…)` | `🤖 Generated with [Codex CLI](…)` | `🤖 Generated with [Copilot CLI](…)` | the §8 PR-body trailer |
-| `harness.ask` | `` `AskUserQuestion` `` | `plain chat` | `` `ask_user` `` | how a workflow asks a discrete question |
+| Field | Example (claude) | Example (codex) | Example (copilot) | Example (opencode) | Example (pi) | Purpose |
+| --- | --- | --- | --- | --- | --- | --- |
+| `harness.name` | `claude` | `codex` | `copilot` | `opencode` | `pi` | the config key |
+| `harness.display` | `Claude Code` | `Codex CLI` | `Copilot CLI` | `OpenCode` | `Pi` | human-readable, for prose |
+| `harness.root` | `.claude/skills` | `.agents/skills` | `.github/skills` | `.opencode/skills` | `.pi/skills` | where this tree's skills land |
+| `harness.doctrine_path` | `.claude/skills/DOCTRINE.md` | `.agents/skills/DOCTRINE.md` | `.github/skills/DOCTRINE.md` | `.opencode/skills/DOCTRINE.md` | `.pi/skills/DOCTRINE.md` | computed (`root/DOCTRINE.md`) — every skill's "Shared rules in `…`" line |
+| `harness.has_menus` | `true` | `false` | `true` | `true` | `false` | a structured choice tool is callable in normal skill execution |
+| `harness.has_subagents` | `true` | `true` | `true` | `true` | `false` | a native parallel-subagent spawn tool exists |
+| `harness.attribution` | `🤖 Generated with [Claude Code](…)` | `🤖 Generated with [Codex CLI](…)` | `🤖 Generated with [Copilot CLI](…)` | `🤖 Generated with [OpenCode](…)` | `🤖 Generated with [Pi](…)` | the §8 PR-body trailer |
+| `harness.ask` | `` `AskUserQuestion` `` | `plain chat` | `` `ask_user` `` | `` `question` `` | `plain chat` | how a workflow asks a discrete question |
 
 `doctrine_path` is computed by the engine (`buildHarnessContext` in `bin/cycle.mjs`) from `root` —
 it isn't a field a harness file declares. Everything else comes straight from the `.jsonc` file.
@@ -52,17 +52,19 @@ them via `{{#if harness.…}}` / `{{#unless harness.…}}` — and `cycle lint`'
 the build if a template branches on a field the engine never populates (a typo inside a block is
 otherwise silently falsy, not a hard error — see `bin/lint.mjs`):
 
-| | Claude Code | Codex CLI | Copilot CLI |
-| --- | --- | --- | --- |
-| `has_menus` | `true` — `AskUserQuestion` | `false` — `request_user_input` is Plan-mode only | `true` — `ask_user` |
-| `has_subagents` | `true` — the Agent tool | `true` — subagents, GA 2026-03-14 | `true` — the `task` tool / `/fleet` |
+| | Claude Code | Codex CLI | Copilot CLI | OpenCode | Pi |
+| --- | --- | --- | --- | --- | --- |
+| `has_menus` | `true` — `AskUserQuestion` | `false` — `request_user_input` is Plan-mode only | `true` — `ask_user` | `true` — `question` | `false` — `ask_question` exists but its shape is unconfirmed |
+| `has_subagents` | `true` — the Agent tool | `true` — subagents, GA 2026-03-14 | `true` — the `task` tool / `/fleet` | `true` — the `task` tool | `false` — none by design |
 
-All three harnesses support the same open agent-skills format and native subagents. Codex's
-structured question tool is mode-scoped, so ordinary skill execution takes the direct-chat menu
-fallback there; Claude Code and Copilot CLI both expose theirs in normal sessions. The
-`{{#unless harness.has_menus}}` / `{{#unless harness.has_subagents}}` branches are real shipped
-behavior as well as the extension seam for a future, less-capable harness (Opencode, Pi — see the
-harness-target follow-up issues).
+All five harnesses support the same open agent-skills format. Codex's structured question tool is
+mode-scoped, so ordinary skill execution takes the direct-chat menu fallback there; Pi doesn't
+document its `ask_question` tool's shape well enough to assume it's multi-choice, so it gets the
+same conservative fallback. Claude Code, Copilot CLI, and OpenCode all expose a confirmed
+structured-choice tool in normal sessions. Pi also has no subagent mechanism at all, by explicit
+design choice — every other harness here does. The `{{#unless harness.has_menus}}` /
+`{{#unless harness.has_subagents}}` branches are real shipped behavior for both Codex and Pi, not
+just a speculative extension seam.
 
 ## Verified discovery paths, not assumed
 
@@ -79,6 +81,14 @@ finds the skills at all, and that failure is silent (no error, just nothing to i
   `docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-skills` (2026-08). Copilot
   also discovers `.claude/skills` and `.agents/skills` as equally valid project-skill roots —
   `.github/skills` is used here to avoid colliding with the codex harness's root.
+- **OpenCode** — `.opencode/skills/<name>/SKILL.md`, walking from cwd up to the git worktree root,
+  confirmed against `opencode.ai/docs/skills` (2026-08). OpenCode also passively reads
+  `.claude/skills` and `.agents/skills` along that walk — `.opencode/skills` is its dedicated root,
+  used here for the same collision-avoidance reason as Copilot's.
+- **Pi** — `.pi/skills/<name>/SKILL.md`, walking from cwd up through parent directories, confirmed
+  against `github.com/badlogic/pi-mono`'s coding-agent README (2026-08). Pi also discovers
+  `.agents/skills` the same way — `.pi/skills` is used here to avoid colliding with the codex
+  harness's root.
 
 Before adding a harness, re-verify its current discovery path against that tool's own docs at
 implementation time — these move, and a stale path here is worse than no harness at all.

--- a/harnesses/opencode.jsonc
+++ b/harnesses/opencode.jsonc
@@ -1,0 +1,35 @@
+// OpenCode — a secondary render target (#3): capture the registry entry now, same
+// shape as the priority three (claude/codex/copilot), since the abstraction already
+// exists and there's nothing else to build.
+//
+// Verified against the current release (2026-08), not assumed:
+//   - discovery path: opencode.ai/docs/skills — OpenCode walks up from cwd to the git
+//     worktree root loading `.opencode/skills/*/SKILL.md`, and *also* passively reads
+//     any `.claude/skills` or `.agents/skills` it passes along the way (plus global
+//     `~/.config/opencode/skills`, `~/.claude/skills`, `~/.agents/skills`). `.opencode/skills`
+//     is used here as the dedicated root — reusing `.claude/skills` or `.agents/skills`
+//     would collide with the claude/codex harness roots if a repo configured both.
+//   - subagents: a `task` tool spawns subagents with model/prompt/description params,
+//     matching the shape /fan-out and /cover's per-unit spawn rely on.
+//   - structured questions: a `question` tool presents multiple-choice options with an
+//     optional custom-text answer, single/multi-select, pausing execution for the
+//     response — functionally equivalent to AskUserQuestion. Gated by a `permission`
+//     config key that defaults to "allow" (most permissions do), so it's live out of
+//     the box rather than needing a repo to opt in.
+{
+  "name": "opencode",
+  "display": "OpenCode",
+
+  "root": ".opencode/skills",
+  "skill_file": "SKILL.md",
+
+  "capabilities": {
+    "has_menus": true,
+    "has_subagents": true
+  },
+
+  "notes": {
+    "attribution": "🤖 Generated with [OpenCode](https://opencode.ai)",
+    "ask": "`question`"
+  }
+}

--- a/harnesses/pi.jsonc
+++ b/harnesses/pi.jsonc
@@ -1,0 +1,37 @@
+// Pi (earendil-works/pi coding agent) — a secondary render target (#3), same as
+// OpenCode: the abstraction already exists, so this is just a registry entry.
+//
+// Verified against the current release (2026-08), not assumed:
+//   - discovery path: github.com/badlogic/pi-mono's coding-agent README — skills are
+//     discovered at `.pi/skills/*/SKILL.md` or `.agents/skills/*/SKILL.md` (walking cwd
+//     up through parent directories), plus global `~/.pi/agent/skills` and
+//     `~/.agents/skills`, or via a pi package. `.pi/skills` is used here as the
+//     dedicated root, to avoid colliding with the codex harness's `.agents/skills`.
+//   - subagents: explicitly absent by design. Pi's own docs: "No sub-agents. There's
+//     many ways to do this. Spawn pi instances via tmux, or build your own with
+//     extensions." Nothing to advertise here.
+//   - structured questions: an `ask_question` tool is real (it's excludable via
+//     `--exclude-tools ask_question` / `excludeTools`, which only makes sense for a
+//     tool that exists and runs by default), but Pi's docs never describe its actual
+//     shape — nothing confirms multi-choice options the way OpenCode's `question` tool
+//     or AskUserQuestion are documented. Advertised as unavailable rather than assumed;
+//     re-verify directly (a live Pi session, not just docs) before flipping this to
+//     true — Pi is a fast-moving minimalist tool and this is the flag most likely to
+//     be wrong here.
+{
+  "name": "pi",
+  "display": "Pi",
+
+  "root": ".pi/skills",
+  "skill_file": "SKILL.md",
+
+  "capabilities": {
+    "has_menus": false,
+    "has_subagents": false
+  },
+
+  "notes": {
+    "attribution": "🤖 Generated with [Pi](https://github.com/earendil-works/pi)",
+    "ask": "plain chat"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `harnesses/opencode.jsonc` and `harnesses/pi.jsonc`, the fourth and fifth render targets — same open agent-skills format as the other three, so no new template machinery.
- **OpenCode**: skills discovered at `.opencode/skills/<name>/SKILL.md`. `has_menus: true` (a `question` tool — structured multi-choice + custom text, enabled by default) and `has_subagents: true` (a `task` tool).
- **Pi**: skills discovered at `.pi/skills/<name>/SKILL.md`. `has_subagents: false` — Pi's own docs explicitly say "No sub-agents" by design. `has_menus: false` too, conservatively: an `ask_question` tool is real (it's excludable via `--exclude-tools`, which only makes sense for a tool that exists and runs by default) but its docs never confirm a structured multi-choice shape the way OpenCode's/Claude's do — advertised as unavailable rather than assumed, flagged in the file comment for live re-verification.
- Extends `docs/HARNESSES.md`'s verified-paths list and both harness-comparison tables to all five harnesses.

## Verification
- `npm test` — 116/116 passing
- `node bin/cycle.mjs check` — clean
- `node bin/cycle.mjs lint` — consistent
- Manual smoke test: `cycle install --plan` on this repo now lists all five harnesses (`claude, codex, copilot, opencode, pi`) as registry options, confirming the harness-selection question from #2 picks up new entries automatically.
- The issue's acceptance also calls for a behavioral loop per harness (a live session running a full `/cycle`) — not done here, same as the Copilot harness PR; I don't have OpenCode or Pi installs to test against. Flagged in both the Pi capability comment and here.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)