### PR TITLE
fix(cli): detect and report formatter/drift conflicts, never auto-fix

### DIFF
--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -843,6 +843,95 @@ export function detect(root) {
     return out;
 }
 
+// A formatter that reflows a rendered skill's markdown (prettier, dprint) changes
+// only whitespace, but the drift hash is over raw bytes — so a reflow reads as a
+// hand edit and permanently blocks `cycle update` until someone passes --force.
+// The fix is to keep the formatter off these files entirely, not to weaken the
+// hash. Detected and reported, never auto-written — same reasoning as the `gh
+// label create` lines below: a command this runs should be one the operator ran
+// on purpose, and a third-party tool's config isn't this command's to touch.
+const PRETTIER_MARKERS = [
+    '.prettierrc', '.prettierrc.json', '.prettierrc.yaml', '.prettierrc.yml',
+    '.prettierrc.js', '.prettierrc.cjs', '.prettierrc.mjs', '.prettierrc.ts',
+    'prettier.config.js', 'prettier.config.cjs', 'prettier.config.mjs',
+];
+function usesPrettier(root) {
+    if (PRETTIER_MARKERS.some((m) => existsSync(join(root, m)))) return true;
+    const pkgPath = join(root, 'package.json');
+    if (!existsSync(pkgPath)) return false;
+    try {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+        return Boolean(pkg.prettier ?? pkg.devDependencies?.prettier ?? pkg.dependencies?.prettier);
+    } catch {
+        return false;
+    }
+}
+
+const DPRINT_CONFIGS = ['dprint.json', 'dprint.jsonc', '.dprintrc.json', '.dprintrc.jsonc'];
+const findDprintConfig = (root) => DPRINT_CONFIGS.map((f) => join(root, f)).find((p) => existsSync(p)) ?? null;
+
+/**
+ * Missing formatter-ignore entries for the currently configured harness roots, as
+ * ready-to-paste blocks — or `[]` if every detected formatter already covers them
+ * (or none is detected). Best-effort: a malformed dprint config is reported as
+ * "can't verify", never a crash.
+ */
+function formatterGuidance(root, cfg) {
+    const roots = harnessNames(cfg).map((h) => loadHarness(h).root);
+    const blocks = [];
+
+    if (usesPrettier(root)) {
+        const ignorePath = join(root, '.prettierignore');
+        const have = existsSync(ignorePath) ? readFileSync(ignorePath, 'utf8').split('\n') : [];
+        const missing = roots.filter((r) => !have.includes(`${r}/`));
+        if (missing.length) {
+            blocks.push([
+                'prettier reformats markdown here, which will fight `cycle update`\'s drift detection.',
+                `add these lines to ${relative(root, ignorePath)} (create it if missing):`,
+                ...missing.map((r) => `  ${r}/`),
+            ]);
+        }
+    }
+
+    const dprintPath = findDprintConfig(root);
+    if (dprintPath) {
+        let excludes = [];
+        try {
+            const parsed = readJsonc(dprintPath);
+            excludes = Array.isArray(parsed.excludes) ? parsed.excludes : [];
+        } catch {
+            blocks.push([`dprint config at ${relative(root, dprintPath)} could not be parsed — check its "excludes" by hand.`]);
+            excludes = null;
+        }
+        if (excludes) {
+            // Only a glob that denotes the whole subtree counts as coverage — a prefix
+            // match like `startsWith` would also accept `.claude/skills/README.md`,
+            // which excludes one file and leaves every actual SKILL.md (nested one
+            // level deeper) still exposed to reflow. Erring toward an extra reminder
+            // beats erring toward a silent gap.
+            const missing = roots.filter((r) => !excludes.some((e) => e === r || e === `${r}/` || e === `${r}/**`));
+            if (missing.length) {
+                blocks.push([
+                    'dprint reformats markdown here, which will fight `cycle update`\'s drift detection.',
+                    `add these globs to ${relative(root, dprintPath)}'s "excludes" array:`,
+                    ...missing.map((r) => `  "${r}/**"`),
+                ]);
+            }
+        }
+    }
+
+    return blocks;
+}
+
+function printFormatterGuidance(blocks) {
+    if (!blocks.length) return;
+    console.log(`\n${yellow('formatter:')} a reflow-only edit will read as local drift until this is addressed —`);
+    for (const block of blocks) {
+        for (const line of block) console.log(`  ${dim(line)}`);
+        console.log('');
+    }
+}
+
 // ---------------------------------------------------------------------------
 // commands
 // ---------------------------------------------------------------------------
@@ -1016,6 +1105,8 @@ async function cmdInstall(args) {
             console.log(`  ${dim(`gh label create "${s.name}" --description ${JSON.stringify(s.meaning ?? '')} --force`)}`);
         }
     }
+
+    printFormatterGuidance(formatterGuidance(root, cfg));
 
     if (!cycleHomeIsClone()) {
         console.log(
@@ -1301,6 +1392,7 @@ function cmdUpdate(args) {
     });
     const cfg = loadConfig(root);
     const plan = planRender(root, cfg);
+    const guidance = formatterGuidance(root, cfg);
 
     const writes = [];
     const conflicts = [];
@@ -1326,6 +1418,7 @@ function cmdUpdate(args) {
 
     if (!writes.length) {
         console.log(conflicts.length ? dim('nothing else to update.') : green('✓ already up to date — nothing to write'));
+        printFormatterGuidance(guidance);
         process.exitCode = conflicts.length ? 1 : 0;
         return;
     }
@@ -1337,6 +1430,7 @@ function cmdUpdate(args) {
 
     if (values['dry-run']) {
         console.log(dim(`\n(dry run — ${writes.length} file(s) would change)`));
+        printFormatterGuidance(guidance);
         return;
     }
 
@@ -1346,6 +1440,7 @@ function cmdUpdate(args) {
     }
     writeState(root, plan);
     console.log(`${green('✓')} updated ${bold(String(writes.length))} file(s) to the-cycle@${upstreamSha()}`);
+    printFormatterGuidance(guidance);
     if (conflicts.length) process.exitCode = 1;
 }
 

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -101,3 +101,19 @@ Current overlay points (all optional):
 3. If a repo has locally drifted, `update` refuses. That's the design — resolve it by folding the
    local edit **into the template**, not by forcing over it. A local edit that's genuinely
    repo-specific means you found a missing config value or overlay point.
+
+## Formatters and drift
+
+Drift detection hashes a rendered file's raw bytes (`stripProvenance` then `hashContent` — both in
+`bin/cycle.mjs`), so a markdown formatter that reflows line wrapping — prettier, dprint — reads as
+a hand edit even though the prose is identical. Left alone, that permanently blocks `cycle update`
+for that repo: every run refuses the "edit" and `--force` becomes a habit, which eventually
+clobbers a genuine local change.
+
+The fix is keeping the formatter off rendered skill trees entirely, not loosening the hash — a
+looser hash would let a real reflow-only hand edit pass silently, which is the failure this
+detector exists to catch. `cycle install` and `cycle update` detect a configured prettier or dprint
+setup and, if the configured harness roots aren't already excluded, print the exact lines to add
+(`.prettierignore` entries, or a dprint `excludes` glob) — never written automatically, same
+reasoning as the `gh label create` lines they sit next to: a repo's own tooling config isn't
+`cycle`'s to touch without the operator asking for it.

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -522,6 +522,77 @@ describe('drift detection', () => {
     });
 });
 
+// #11: a reflow-only formatter pass reads as a hand edit under the byte-hash drift
+// check, which permanently blocks `cycle update` — the fix keeps the formatter off
+// rendered trees, reported (never auto-written) at both install and update time.
+describe('formatter guidance (#11)', () => {
+    test('a prettier repo with no .prettierignore is told exactly what to add', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        writeFileSync(join(dir, '.prettierrc.json'), '{}');
+        const out = cycle(dir, ['install', '--profile', 'lean', '-y']);
+        assert.match(out, /prettier reformats markdown/);
+        assert.match(out, /\.prettierignore/);
+        assert.match(out, /\.claude\/skills\//);
+    });
+
+    test('a prettier repo whose .prettierignore already covers the harness root gets no guidance', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        writeFileSync(join(dir, '.prettierrc.json'), '{}');
+        writeFileSync(join(dir, '.prettierignore'), '.claude/skills/\n');
+        const out = cycle(dir, ['install', '--profile', 'lean', '-y']);
+        assert.doesNotMatch(out, /formatter:/);
+
+        const updated = cycleRaw(dir, ['update']);
+        assert.doesNotMatch(updated.out, /formatter:/);
+    });
+
+    test('a dprint repo with no matching exclude is told exactly what to add', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        writeFileSync(join(dir, 'dprint.json'), JSON.stringify({ excludes: [] }));
+        const out = cycle(dir, ['install', '--profile', 'lean', '-y']);
+        assert.match(out, /dprint reformats markdown/);
+        assert.match(out, /dprint\.json/);
+        assert.match(out, /"\.claude\/skills\/\*\*"/);
+    });
+
+    test('a dprint repo whose excludes already cover the harness root gets no guidance', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        writeFileSync(join(dir, 'dprint.json'), JSON.stringify({ excludes: ['.claude/skills/**'] }));
+        const out = cycle(dir, ['install', '--profile', 'lean', '-y']);
+        assert.doesNotMatch(out, /formatter:/);
+    });
+
+    test('a dprint exclude that only names one file still gets flagged as missing', () => {
+        // `.claude/skills/README.md` excludes a single file, not the subtree — every
+        // actual SKILL.md (nested one level deeper) is still exposed to reflow, so this
+        // must not be mistaken for coverage the way a naive prefix match would.
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        writeFileSync(join(dir, 'dprint.json'), JSON.stringify({ excludes: ['.claude/skills/README.md'] }));
+        const out = cycle(dir, ['install', '--profile', 'lean', '-y']);
+        assert.match(out, /dprint reformats markdown/);
+    });
+
+    test('a malformed dprint config is reported, not crashed on', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        writeFileSync(join(dir, 'dprint.json'), '{ not valid json');
+        const out = cycle(dir, ['install', '--profile', 'lean', '-y']);
+        assert.match(out, /could not be parsed/);
+    });
+
+    test('a repo with neither formatter gets no guidance at all', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        const out = cycle(dir, ['install', '--profile', 'lean', '-y']);
+        assert.doesNotMatch(out, /formatter:/);
+    });
+});
+
 describe('version stamp — no .git in CYCLE_HOME (an npm/npx install)', () => {
     let gitlessHome;
     let expectedVersion;


### PR DESCRIPTION
## Summary
- `cycle install` and `cycle update` now detect a configured prettier or dprint setup in the consuming repo and, if the currently configured harness roots aren't already excluded from formatting, print the exact lines to add — never written automatically.
- Prettier: `.prettierignore` entries. Dprint: globs for its `excludes` array (read-only inspection via the existing `readJsonc`, best-effort — a malformed config is reported, not crashed on).
- `docs/AUTHORING.md` gets a short "Formatters and drift" section explaining the mechanism and why the fix is detection + reporting, not loosening the drift hash.
- 7 new tests covering: guidance shown/not-shown for both formatters, a malformed dprint config, no formatter present, and a regression test for a review finding caught before merge (below).

## Design note
The issue offered two options — normalize before hashing, or an ignore-file. I went with the ignore-file approach it recommended (weakening the hash would let a genuine reflow-only hand edit pass silently, which is exactly what drift detection exists to catch). I also chose **detect + print instructions** over auto-writing either config file, matching the existing precedent right next to this code — `cycle install` already prints `gh label create` lines rather than creating labels itself, for the same reason: a repo's own tooling/tracker isn't this command's to touch without the operator asking for it.

## Caught in review
The first pass of the dprint coverage check used `startsWith` as a prefix match, which would treat an exclude like `.claude/skills/README.md` (one file) as covering the whole subtree — silently missing that every actual `SKILL.md` (nested one level deeper) was still exposed. Fixed to require an exclude that denotes the whole subtree, with a regression test.

## Verification
- `npm test` — 123/123 passing
- `node bin/cycle.mjs check` — clean
- `node bin/cycle.mjs lint` — consistent
- Manual smoke test in a scratch repo: `.prettierrc.json` present → install prints the missing `.prettierignore` lines; adding them → `cycle update` reports "already up to date" with no guidance, and `cycle check` reports clean.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)