### PR TITLE
docs(doctrine): §8 — a code span suppresses the Closes keyword

### DIFF
--- a/.agents/skills/DOCTRINE.md
+++ b/.agents/skills/DOCTRINE.md
@@ -1,4 +1,4 @@
-<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=db27d5bb6420 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=4352fab2aa2a — managed by the-cycle; edit the template, not this file -->
 # Pipeline doctrine (shared)
 
 Single source of truth for the rules the the-cycle work-loop skills share. A skill that says
@@ -235,7 +235,9 @@ that isn't in the §1 table.
   🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)
   ```
 - The `Closes/Fixes/Resolves #N` keyword fires **anywhere** in the body regardless of surrounding
-  prose — writing "`Closes #844` is NOT set" still closes #844. When carving one item out of a
+  prose — writing "Closes #844 is NOT set" still closes #844 — **except inside a code span or code
+  block, which suppresses it entirely.** Never backtick the token when the close is wanted, and
+  never leave it bare next to a number that shouldn't close. When carving one item out of a
   multi-item umbrella issue, never put that token next to the umbrella's number at all, not even to
   deny it — write "part of #844" instead.
 - Post a one-line issue comment linking the PR; the narrative lives in the PR body.

--- a/.claude/skills/DOCTRINE.md
+++ b/.claude/skills/DOCTRINE.md
@@ -1,4 +1,4 @@
-<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=ca3495622ea1 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=2f8fb7cb28e9 — managed by the-cycle; edit the template, not this file -->
 # Pipeline doctrine (shared)
 
 Single source of truth for the rules the the-cycle work-loop skills share. A skill that says
@@ -235,7 +235,9 @@ that isn't in the §1 table.
   🤖 Generated with [Claude Code](https://claude.com/claude-code)
   ```
 - The `Closes/Fixes/Resolves #N` keyword fires **anywhere** in the body regardless of surrounding
-  prose — writing "`Closes #844` is NOT set" still closes #844. When carving one item out of a
+  prose — writing "Closes #844 is NOT set" still closes #844 — **except inside a code span or code
+  block, which suppresses it entirely.** Never backtick the token when the close is wanted, and
+  never leave it bare next to a number that shouldn't close. When carving one item out of a
   multi-item umbrella issue, never put that token next to the umbrella's number at all, not even to
   deny it — write "part of #844" instead.
 - Post a one-line issue comment linking the PR; the narrative lives in the PR body.

--- a/.cycle/state.json
+++ b/.cycle/state.json
@@ -1,7 +1,7 @@
 {
-  "upstream": "b4fb261-dirty",
+  "upstream": "a9112eb-dirty",
   "files": {
-    ".claude/skills/DOCTRINE.md": "ca3495622ea1",
+    ".claude/skills/DOCTRINE.md": "2f8fb7cb28e9",
     ".claude/skills/cycle/SKILL.md": "c5fa85661a41",
     ".claude/skills/implement/SKILL.md": "4b772c66fd5a",
     ".claude/skills/review/SKILL.md": "881cb15dba91",
@@ -14,7 +14,7 @@
     ".claude/skills/dep-update/SKILL.md": "b5d36ac6dff1",
     ".claude/skills/deploy-test/SKILL.md": "8a0cf4447165",
     ".claude/skills/deploy-prod/SKILL.md": "41ad9d2f17db",
-    ".agents/skills/DOCTRINE.md": "db27d5bb6420",
+    ".agents/skills/DOCTRINE.md": "4352fab2aa2a",
     ".agents/skills/cycle/SKILL.md": "260b386a0a4c",
     ".agents/skills/implement/SKILL.md": "920f7a99e2ed",
     ".agents/skills/review/SKILL.md": "056a46e2d908",

--- a/templates/DOCTRINE.md.tmpl
+++ b/templates/DOCTRINE.md.tmpl
@@ -267,7 +267,9 @@ that isn't in the §1 table.
   {{harness.attribution}}
   ```
 - The `Closes/Fixes/Resolves #N` keyword fires **anywhere** in the body regardless of surrounding
-  prose — writing "`Closes #844` is NOT set" still closes #844. When carving one item out of a
+  prose — writing "Closes #844 is NOT set" still closes #844 — **except inside a code span or code
+  block, which suppresses it entirely.** Never backtick the token when the close is wanted, and
+  never leave it bare next to a number that shouldn't close. When carving one item out of a
   multi-item umbrella issue, never put that token next to the umbrella's number at all, not even to
   deny it — write "part of #844" instead.
 - Post a one-line issue comment linking the PR; the narrative lives in the PR body.


### PR DESCRIPTION
## Summary
- DOCTRINE §8 now documents both failure directions of the `Closes/Fixes/Resolves #N` keyword: it fires anywhere in the body regardless of surrounding prose, **except** inside a code span or code block, which suppresses it entirely.
- Live counterexample that motivated this: `#13`'s body had the token backticked and didn't auto-close on merge — only the accidental-close direction was documented before, not this inverse one.
- Also fixed the bullet's own illustrative example: it previously backticked `` `Closes #844` `` to demonstrate that surrounding prose doesn't suppress the keyword — under the new rule, that same backticked example would no longer close anything, directly contradicting the point it's making. Switched to plain quotes (`"Closes #844 is NOT set"`, no backticks) so the example stays true under the rule it illustrates.
- Rendered into both configured harness trees (`.claude/skills/DOCTRINE.md`, `.agents/skills/DOCTRINE.md`) via `cycle update`, since this repo dogfoods its own pipeline.

## Verification
- `node bin/cycle.mjs lint` — consistent
- `npm test` — 116/116 passing
- `node bin/cycle.mjs check` — clean

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)