### PR TITLE
fix(cli): close formatter detection gaps

### DIFF
--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -852,11 +852,22 @@ export function detect(root) {
 // on purpose, and a third-party tool's config isn't this command's to touch.
 const PRETTIER_MARKERS = [
     '.prettierrc', '.prettierrc.json', '.prettierrc.yaml', '.prettierrc.yml',
+    '.prettierrc.json5', '.prettierrc.toml',
     '.prettierrc.js', '.prettierrc.cjs', '.prettierrc.mjs', '.prettierrc.ts',
+    '.prettierrc.cts', '.prettierrc.mts',
     'prettier.config.js', 'prettier.config.cjs', 'prettier.config.mjs',
+    'prettier.config.ts', 'prettier.config.cts', 'prettier.config.mts',
 ];
 function usesPrettier(root) {
     if (PRETTIER_MARKERS.some((m) => existsSync(join(root, m)))) return true;
+    const packageYamlPath = join(root, 'package.yaml');
+    if (existsSync(packageYamlPath)) {
+        // Prettier recognizes a top-level `prettier` key in package.yaml. Keep
+        // this deliberately narrow so an unrelated nested key does not make a
+        // non-Prettier repo look configured.
+        const packageYaml = readFileSync(packageYamlPath, 'utf8');
+        if (/^(?:prettier|["']prettier["'])\s*:/m.test(packageYaml)) return true;
+    }
     const pkgPath = join(root, 'package.json');
     if (!existsSync(pkgPath)) return false;
     try {
@@ -867,8 +878,42 @@ function usesPrettier(root) {
     }
 }
 
-const DPRINT_CONFIGS = ['dprint.json', 'dprint.jsonc', '.dprintrc.json', '.dprintrc.jsonc'];
+const DPRINT_CONFIGS = ['dprint.json', 'dprint.jsonc', '.dprint.json', '.dprint.jsonc'];
 const findDprintConfig = (root) => DPRINT_CONFIGS.map((f) => join(root, f)).find((p) => existsSync(p)) ?? null;
+
+function negationMayReincludeRoot(entry, root) {
+    if (typeof entry !== 'string' || !entry.startsWith('!')) return false;
+    const pattern = entry.slice(1).replace(/^\/+/, '');
+    if (pattern === root || pattern.startsWith(`${root}/`)) return true;
+
+    // A slashless gitignore pattern applies at any depth. Managed harness trees
+    // contain markdown only, so a literal non-markdown basename (for example
+    // `!dist.js`) is provably unrelated; wildcard or markdown patterns are not.
+    if (!pattern.includes('/')) return /[*?\[]/.test(pattern) || pattern.endsWith('.md');
+
+    // For globbed paths, compare the literal prefix on either side of the first
+    // wildcard. An empty prefix (`!**/DOCTRINE.md`) may match anywhere.
+    const wildcard = pattern.search(/[*?\[]/);
+    if (wildcard === -1) return false;
+    const prefix = pattern.slice(0, wildcard);
+    return prefix === '' || root.startsWith(prefix) || prefix.startsWith(`${root}/`);
+}
+
+function ignorePatternsCoverRoot(patterns, root) {
+    let covered = false;
+    for (const rawEntry of patterns) {
+        const entry = typeof rawEntry === 'string' ? rawEntry.trim() : rawEntry;
+        if (entry === root || entry === `${root}/` || entry === `${root}/**`) {
+            covered = true;
+            continue;
+        }
+        // Both formatter ignore formats use ordered gitignore-style patterns. A
+        // relevant later negation reopens the tree; a later exact whole-tree
+        // exclude restores coverage.
+        if (covered && negationMayReincludeRoot(entry, root)) covered = false;
+    }
+    return covered;
+}
 
 /**
  * Missing formatter-ignore entries for the currently configured harness roots, as
@@ -883,7 +928,7 @@ function formatterGuidance(root, cfg) {
     if (usesPrettier(root)) {
         const ignorePath = join(root, '.prettierignore');
         const have = existsSync(ignorePath) ? readFileSync(ignorePath, 'utf8').split('\n') : [];
-        const missing = roots.filter((r) => !have.includes(`${r}/`));
+        const missing = roots.filter((r) => !ignorePatternsCoverRoot(have, r));
         if (missing.length) {
             blocks.push([
                 'prettier reformats markdown here, which will fight `cycle update`\'s drift detection.',
@@ -909,7 +954,7 @@ function formatterGuidance(root, cfg) {
             // which excludes one file and leaves every actual SKILL.md (nested one
             // level deeper) still exposed to reflow. Erring toward an extra reminder
             // beats erring toward a silent gap.
-            const missing = roots.filter((r) => !excludes.some((e) => e === r || e === `${r}/` || e === `${r}/**`));
+            const missing = roots.filter((r) => !ignorePatternsCoverRoot(excludes, r));
             if (missing.length) {
                 blocks.push([
                     'dprint reformats markdown here, which will fight `cycle update`\'s drift detection.',

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -536,6 +536,32 @@ describe('formatter guidance (#11)', () => {
         assert.match(out, /\.claude\/skills\//);
     });
 
+    test('every supported standalone prettier config filename triggers guidance', () => {
+        const markers = [
+            '.prettierrc', '.prettierrc.json', '.prettierrc.yaml', '.prettierrc.yml',
+            '.prettierrc.json5', '.prettierrc.toml',
+            '.prettierrc.js', '.prettierrc.cjs', '.prettierrc.mjs', '.prettierrc.ts',
+            '.prettierrc.cts', '.prettierrc.mts',
+            'prettier.config.js', 'prettier.config.cjs', 'prettier.config.mjs',
+            'prettier.config.ts', 'prettier.config.cts', 'prettier.config.mts',
+        ];
+        for (const marker of markers) {
+            const dir = scratchRepo('github');
+            dirs.push(dir);
+            writeFileSync(join(dir, marker), '{}');
+            const out = cycle(dir, ['install', '--profile', 'lean', '-y']);
+            assert.match(out, /prettier reformats markdown/, marker);
+        }
+    });
+
+    test('a package.yaml prettier key triggers guidance without a local dependency', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        writeFileSync(join(dir, 'package.yaml'), 'name: example\nprettier:\n  printWidth: 100\n');
+        const out = cycle(dir, ['install', '--profile', 'lean', '-y']);
+        assert.match(out, /prettier reformats markdown/);
+    });
+
     test('a prettier repo whose .prettierignore already covers the harness root gets no guidance', () => {
         const dir = scratchRepo('github');
         dirs.push(dir);
@@ -546,6 +572,15 @@ describe('formatter guidance (#11)', () => {
 
         const updated = cycleRaw(dir, ['update']);
         assert.doesNotMatch(updated.out, /formatter:/);
+    });
+
+    test('a later prettier negation makes whole-tree coverage unproven', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        writeFileSync(join(dir, '.prettierrc.json'), '{}');
+        writeFileSync(join(dir, '.prettierignore'), '.claude/skills/\n!.claude/skills/DOCTRINE.md\n');
+        const out = cycle(dir, ['install', '--profile', 'lean', '-y']);
+        assert.match(out, /prettier reformats markdown/);
     });
 
     test('a dprint repo with no matching exclude is told exactly what to add', () => {
@@ -562,6 +597,36 @@ describe('formatter guidance (#11)', () => {
         const dir = scratchRepo('github');
         dirs.push(dir);
         writeFileSync(join(dir, 'dprint.json'), JSON.stringify({ excludes: ['.claude/skills/**'] }));
+        const out = cycle(dir, ['install', '--profile', 'lean', '-y']);
+        assert.doesNotMatch(out, /formatter:/);
+    });
+
+    test('dprint hidden config filenames are detected', () => {
+        for (const config of ['.dprint.json', '.dprint.jsonc']) {
+            const dir = scratchRepo('github');
+            dirs.push(dir);
+            writeFileSync(join(dir, config), JSON.stringify({ excludes: [] }));
+            const out = cycle(dir, ['install', '--profile', 'lean', '-y']);
+            assert.match(out, /dprint reformats markdown/, config);
+        }
+    });
+
+    test('a later dprint negation makes whole-tree coverage unproven', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        writeFileSync(join(dir, 'dprint.json'), JSON.stringify({
+            excludes: ['.claude/skills/**', '!.claude/skills/DOCTRINE.md'],
+        }));
+        const out = cycle(dir, ['install', '--profile', 'lean', '-y']);
+        assert.match(out, /dprint reformats markdown/);
+    });
+
+    test('an unrelated later dprint negation leaves whole-tree coverage intact', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        writeFileSync(join(dir, 'dprint.json'), JSON.stringify({
+            excludes: ['.claude/skills/**', '!dist.js'],
+        }));
         const out = cycle(dir, ['install', '--profile', 'lean', '-y']);
         assert.doesNotMatch(out, /formatter:/);
     });


### PR DESCRIPTION
## Summary
- recognize all current standalone Prettier config names plus package.yaml configuration
- detect dprint hidden .dprint.json and .dprint.jsonc files
- evaluate ordered ignore negations for both formatters without warning on unrelated literal paths
- add regressions for every independent-review finding

## Review and verification
- independent Terra/high review found two P1s and one P2 in the original merged detector; all were patched
- follow-up review found the analogous Prettier negation gap and dprint false-positive; both were patched and re-reviewed clean
- npm test: 129/129 passing
- node bin/cycle.mjs check: clean
- node bin/cycle.mjs lint: consistent

Closes #11

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)