### PR TITLE
Auto-branch reviewed work in done workflow

### DIFF
--- a/.agents/skills/done/SKILL.md
+++ b/.agents/skills/done/SKILL.md
@@ -2,7 +2,7 @@
 name: done
 description: Ship a the-cycle story — commit the reviewed work, push, open a PR that Closes #<n>, and (for a safe story) queue server-side auto-merge; a judgment-call story's PR is left for Brandon's manual merge. Done = the issue closes on merge. Plan-first. Usage `/done #<n>`. Use after /review (+ /patch) pass clean.
 ---
-<!-- cycle:rendered template=skills/done.md.tmpl hash=00fab4fd845d — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/done.md.tmpl hash=dcab23d1cfda — managed by the-cycle; edit the template, not this file -->
 
 # /done #<n> — ship a story
 
@@ -19,8 +19,9 @@ just the ordering.
 
 ## Workflow
 
-1. **Parse the issue ref(s)** — `#<n>`. Several only if one diff genuinely ships them together;
-   usually one PR = one issue.
+1. **Parse and read the issue ref(s)** — `#<n>`. Several only if one diff genuinely ships them
+   together; usually one PR = one issue. Run `gh issue view "<n>" --json number,title,state,url,labels,milestone,body` for each and capture its title
+   plus milestone/epic before choosing a branch.
 2. **Confirm gates green** (§4) — never `/done` over a red build. If a fast-path verification
    receipt (§5) is in context, recompute its diff fingerprint over the same file list: a match,
    with every gate in it reading PASS, **stands as this confirmation** — don't re-run. A stale
@@ -32,7 +33,15 @@ just the ordering.
 3. **Confirm findings were actioned, not parked** (§5) — `/patch` fixed every real finding, or
    each was an explicit escalation to a `finding` issue. Never a silent defer.
 4. **Survey the diff** — `git status` + `git diff --stat`. Only expected files; flag drift.
-5. **Branch check** (§9) — must be on a feature branch, not `main`. If on `main`, stop.
+5. **Branch check** (§9) — inspect `git status --short` and the current branch before staging.
+   - If an existing epic branch applies, switch to and reuse it as `/implement` does. Otherwise,
+     on a feature branch, continue.
+   - On `main` with a reviewed uncommitted diff that has something to ship and no applicable epic
+     branch, derive `<slug>` from the issue title, create `fix/<issue>-<slug>`, and continue
+     (`git checkout -b fix/<issue>-<slug>`). If that branch name already exists, STOP for the
+     naming collision — do not guess or build on `main`.
+   - On `main` with no diff or nothing to ship, STOP. Never stage, commit, or otherwise build on
+     `main`; branch before delivery work.
 6. **Compose the narrative** — the "what shipped + which findings were actioned + why" summary
    that becomes the **PR body**.
 7. **Commit** (§8) — Conventional Commit, explicit paths (never `-A` / `.`), HEREDOC body.

--- a/.claude/skills/done/SKILL.md
+++ b/.claude/skills/done/SKILL.md
@@ -2,7 +2,7 @@
 name: done
 description: Ship a the-cycle story — commit the reviewed work, push, open a PR that Closes #<n>, and (for a safe story) queue server-side auto-merge; a judgment-call story's PR is left for Brandon's manual merge. Done = the issue closes on merge. Plan-first. Usage `/done #<n>`. Use after /review (+ /patch) pass clean.
 ---
-<!-- cycle:rendered template=skills/done.md.tmpl hash=efd1862e7324 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/done.md.tmpl hash=ce89688f4e8a — managed by the-cycle; edit the template, not this file -->
 
 # /done #<n> — ship a story
 
@@ -19,8 +19,9 @@ just the ordering.
 
 ## Workflow
 
-1. **Parse the issue ref(s)** — `#<n>`. Several only if one diff genuinely ships them together;
-   usually one PR = one issue.
+1. **Parse and read the issue ref(s)** — `#<n>`. Several only if one diff genuinely ships them
+   together; usually one PR = one issue. Run `gh issue view "<n>" --json number,title,state,url,labels,milestone,body` for each and capture its title
+   plus milestone/epic before choosing a branch.
 2. **Confirm gates green** (§4) — never `/done` over a red build. If a fast-path verification
    receipt (§5) is in context, recompute its diff fingerprint over the same file list: a match,
    with every gate in it reading PASS, **stands as this confirmation** — don't re-run. A stale
@@ -32,7 +33,15 @@ just the ordering.
 3. **Confirm findings were actioned, not parked** (§5) — `/patch` fixed every real finding, or
    each was an explicit escalation to a `finding` issue. Never a silent defer.
 4. **Survey the diff** — `git status` + `git diff --stat`. Only expected files; flag drift.
-5. **Branch check** (§9) — must be on a feature branch, not `main`. If on `main`, stop.
+5. **Branch check** (§9) — inspect `git status --short` and the current branch before staging.
+   - If an existing epic branch applies, switch to and reuse it as `/implement` does. Otherwise,
+     on a feature branch, continue.
+   - On `main` with a reviewed uncommitted diff that has something to ship and no applicable epic
+     branch, derive `<slug>` from the issue title, create `fix/<issue>-<slug>`, and continue
+     (`git checkout -b fix/<issue>-<slug>`). If that branch name already exists, STOP for the
+     naming collision — do not guess or build on `main`.
+   - On `main` with no diff or nothing to ship, STOP. Never stage, commit, or otherwise build on
+     `main`; branch before delivery work.
 6. **Compose the narrative** — the "what shipped + which findings were actioned + why" summary
    that becomes the **PR body**.
 7. **Commit** (§8) — Conventional Commit, explicit paths (never `-A` / `.`), HEREDOC body.

--- a/.cycle/state.json
+++ b/.cycle/state.json
@@ -1,12 +1,12 @@
 {
-  "upstream": "137fb35-dirty",
+  "upstream": "7d5e1e0-dirty",
   "files": {
     ".claude/skills/DOCTRINE.md": "db83b82616d4",
     ".claude/skills/cycle/SKILL.md": "c5fa85661a41",
     ".claude/skills/implement/SKILL.md": "cf203f5d5482",
     ".claude/skills/review/SKILL.md": "881cb15dba91",
     ".claude/skills/patch/SKILL.md": "69279047fb66",
-    ".claude/skills/done/SKILL.md": "efd1862e7324",
+    ".claude/skills/done/SKILL.md": "ce89688f4e8a",
     ".claude/skills/next/SKILL.md": "0afc40565e46",
     ".claude/skills/intake/SKILL.md": "51a3e4a81229",
     ".claude/skills/scout/SKILL.md": "99ef77295706",
@@ -19,7 +19,7 @@
     ".agents/skills/implement/SKILL.md": "c9ea4d7d4f0f",
     ".agents/skills/review/SKILL.md": "056a46e2d908",
     ".agents/skills/patch/SKILL.md": "21b0fc67d17f",
-    ".agents/skills/done/SKILL.md": "00fab4fd845d",
+    ".agents/skills/done/SKILL.md": "dcab23d1cfda",
     ".agents/skills/next/SKILL.md": "f49c75d042fd",
     ".agents/skills/intake/SKILL.md": "737d2a8abe76",
     ".agents/skills/scout/SKILL.md": "19ebcf6d5009",

--- a/templates/skills/done.md.tmpl
+++ b/templates/skills/done.md.tmpl
@@ -19,8 +19,9 @@ just the ordering.
 
 ## Workflow
 
-1. **Parse the issue ref(s)** — `#<n>`. Several only if one diff genuinely ships them together;
-   usually one PR = one issue.
+1. **Parse and read the issue ref(s)** — `#<n>`. Several only if one diff genuinely ships them
+   together; usually one PR = one issue. Run `{{@issue_view "<n>"}}` for each and capture its title
+   plus milestone/epic before choosing a branch.
 2. **Confirm gates green** (§4) — never `/done` over a red build. If a fast-path verification
    receipt (§5) is in context, recompute its diff fingerprint over the same file list: a match,
    with every gate in it reading PASS, **stands as this confirmation** — don't re-run. A stale
@@ -31,7 +32,15 @@ just the ordering.
 3. **Confirm findings were actioned, not parked** (§5) — `/patch` fixed every real finding, or
    each was an explicit escalation to a `finding` issue. Never a silent defer.
 4. **Survey the diff** — `git status` + `git diff --stat`. Only expected files; flag drift.
-5. **Branch check** (§9) — must be on a feature branch, not `main`. If on `main`, stop.
+5. **Branch check** (§9) — inspect `git status --short` and the current branch before staging.
+   - If an existing epic branch applies, switch to and reuse it as `/implement` does. Otherwise,
+     on a feature branch, continue.
+   - On `main` with a reviewed uncommitted diff that has something to ship and no applicable epic
+     branch, derive `<slug>` from the issue title, create `fix/<issue>-<slug>`, and continue
+     (`git checkout -b fix/<issue>-<slug>`). If that branch name already exists, STOP for the
+     naming collision — do not guess or build on `main`.
+   - On `main` with no diff or nothing to ship, STOP. Never stage, commit, or otherwise build on
+     `main`; branch before delivery work.
 6. **Compose the narrative** — the "what shipped + which findings were actioned + why" summary
    that becomes the **PR body**.
 7. **Commit** (§8) — Conventional Commit, explicit paths (never `-A` / `.`), HEREDOC body.{{#if commit.coauthor}}

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -970,6 +970,21 @@ describe('fast path & verification receipts (#24)', () => {
         assert.match(doneSrc, /a missing receipt, or any gate reading FAIL: run them here as usual/);
     });
 
+    test('/done turns a dirty main tree into an issue branch, with bounded hard stops', () => {
+        const src = done(dir);
+        assert.match(src, /gh issue view "<n>"/);
+        assert.match(src, /capture its title\s+plus milestone\/epic before choosing a branch/);
+        assert.match(src, /existing epic branch applies, switch to and reuse it as `\/implement` does/);
+        assert.match(src, /On `main` with a reviewed uncommitted diff that has something to ship/);
+        assert.match(src, /derive `<slug>` from the issue title/);
+        assert.match(src, /create\s+`fix\/<issue>-<slug>`, and continue/);
+        assert.match(src, /git checkout -b fix\/<issue>-<slug>/);
+        assert.match(src, /branch name\s+already exists, STOP for the\s+naming collision/);
+        assert.match(src, /On `main` with no diff or nothing to ship, STOP/);
+        assert.match(src, /Never stage, commit, or otherwise build on\s+`main`/);
+        assert.doesNotMatch(src, /must be on a feature branch, not `main`\. If on `main`, stop/);
+    });
+
     test('the fast path never skips gates, branch policy, or tracker status — only ceremony', () => {
         const src = doctrine(dir);
         assert.match(src, /still performs tracker status, branch policy, §4's gates, and normal delivery safety/);


### PR DESCRIPTION
## Summary

- make `/done` read issue title and milestone before branch selection
- reuse an applicable epic branch or create `fix/<issue>-<slug>` for reviewed work found on `main`
- retain hard stops for nothing to ship and branch-name collisions
- render both harness trees and lock the behavior with a focused contract test

## Review

- independent Luna implementation slice, centrally integrated
- independent Terra correctness review found one issue-read gap; patched and re-reviewed clean

## Verification

- `npm test` — 132/132 passing
- `node bin/cycle.mjs check`
- `node bin/cycle.mjs lint`
- `git diff --check`

Closes #32

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)