### PR TITLE
docs: promote npm bootstrap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,13 @@ Bootstrap, no clone required:
 
 ```sh
 # runs the interview and renders into the current repo
-npx --yes --allow-git=root --package=github:brndnsh-labs/the-cycle cycle install
+npx --yes @brndnsh/the-cycle install
 ```
 
-npx is for a one-off first render directly from GitHub — the fetched copy lives in npx's
-ephemeral cache, so `cycle update` / `cycle check` and the personal `/cycle-setup` skill need the
-durable clone below. `--allow-git=root` is the narrow npm opt-in for this explicitly requested root
-package; transitive git dependencies remain disabled. `cycle install`'s own output says as much
-when it ran this way.
+npx is for a one-off first render from npm — the fetched copy lives in npx's ephemeral cache, so
+`cycle update` / `cycle check` and the personal `/cycle-setup` skill need the durable clone below.
+`--yes` accepts npx's package-download prompt. `cycle install`'s own output says as much when it
+ran this way.
 
 For everyday use:
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,12 +1,12 @@
 # Releasing the-cycle
 
-The durable installation is a clone plus `./install.sh`. The README's explicit GitHub package
-spec is the bootstrap path for a first render and does not depend on the npm registry. Its
-`--allow-git=root` flag permits only the explicitly requested root git package, not transitive git
-dependencies.
+The durable installation is a clone plus `./install.sh`. The README's `npx --yes
+@brndnsh/the-cycle install` command is the bootstrap path for a first render. It fetches the
+published package from npm into npx's ephemeral cache, so follow-up `cycle update` / `cycle check`
+work still need the durable clone.
 
-The package metadata permits publication as `@brndnsh/the-cycle`, but publication is an explicit
-external release gate. Making a commit or merging a pull request does not authorize `npm publish`.
+`@brndnsh/the-cycle` is publicly published. Publishing a new version remains an explicit external
+release gate: making a commit or merging a pull request does not authorize `npm publish`.
 
 ## Preflight
 
@@ -26,5 +26,7 @@ checks the same boundary and exercises the packed artifact.
 
 ## Publish gate
 
-Before publishing, obtain explicit approval for the exact version and registry. Publish using the
-normal npm authentication flow, then verify the registry package with a fresh one-off invocation.
+Before publishing a new version, obtain explicit approval for the exact version and registry.
+Publish using the normal npm authentication flow, then verify the registry package with fresh
+one-off `npx --yes @brndnsh/the-cycle --version` and `npx --yes @brndnsh/the-cycle install`
+invocations.


### PR DESCRIPTION
## Summary

- replace the GitHub package bootstrap with the published npm package
- align release guidance with the live 0.1.0 publication and fresh npx verification

## Verification

- `npx --yes @brndnsh/the-cycle --version` — v0.1.0
- fresh Git repository: registry npx install renders 13 skills and `cycle check` passes
- `npm test` — 132/132
- `node bin/cycle.mjs check`
- `node bin/cycle.mjs lint`

Closes #4

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)