### PR TITLE
fix(tracker): retry sandbox-blocked reads once

### DIFF
--- a/.agents/skills/DOCTRINE.md
+++ b/.agents/skills/DOCTRINE.md
@@ -1,4 +1,4 @@
-<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=bc4a598c89a1 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=e8da0295b5f6 — managed by the-cycle; edit the template, not this file -->
 # Pipeline doctrine (shared)
 
 Single source of truth for the rules the the-cycle work-loop skills share. A skill that says
@@ -224,7 +224,12 @@ A status label that doesn't exist in the repo makes `gh` **fail loudly** — tha
 behavior. Create the label rather than working around the error, and never invent a status value
 that isn't in the §1 table.
 
-**Unreachable → STOP.** `gh` unauthenticated or offline: say so and stop. Never guess tracker state.
+**Confirm unreachable, then STOP.** A first transport or OS-permission failure can be the harness
+sandbox rather than the tracker. When the error is compatible with a sandbox restriction and the
+harness exposes a policy-supported escalation or approval path, retry the **exact same read once**
+through that path — same target and arguments, with no weakened authentication or command. Stop if
+that retry fails, `gh` is unauthenticated, the API rejects the authenticated request, or no allowed
+escalation path exists. Never loop, guess tracker state, or substitute cached data.
 
 ## §8 Commit & PR conventions
 

--- a/.claude/skills/DOCTRINE.md
+++ b/.claude/skills/DOCTRINE.md
@@ -1,4 +1,4 @@
-<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=8c49afc6266f — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=6bb6a5b2186f — managed by the-cycle; edit the template, not this file -->
 # Pipeline doctrine (shared)
 
 Single source of truth for the rules the the-cycle work-loop skills share. A skill that says
@@ -224,7 +224,12 @@ A status label that doesn't exist in the repo makes `gh` **fail loudly** — tha
 behavior. Create the label rather than working around the error, and never invent a status value
 that isn't in the §1 table.
 
-**Unreachable → STOP.** `gh` unauthenticated or offline: say so and stop. Never guess tracker state.
+**Confirm unreachable, then STOP.** A first transport or OS-permission failure can be the harness
+sandbox rather than the tracker. When the error is compatible with a sandbox restriction and the
+harness exposes a policy-supported escalation or approval path, retry the **exact same read once**
+through that path — same target and arguments, with no weakened authentication or command. Stop if
+that retry fails, `gh` is unauthenticated, the API rejects the authenticated request, or no allowed
+escalation path exists. Never loop, guess tracker state, or substitute cached data.
 
 ## §8 Commit & PR conventions
 

--- a/.cycle/state.json
+++ b/.cycle/state.json
@@ -1,7 +1,7 @@
 {
-  "upstream": "a55d7a4-dirty",
+  "upstream": "5a116a7-dirty",
   "files": {
-    ".claude/skills/DOCTRINE.md": "8c49afc6266f",
+    ".claude/skills/DOCTRINE.md": "6bb6a5b2186f",
     ".claude/skills/cycle/SKILL.md": "b1189a01a5f2",
     ".claude/skills/implement/SKILL.md": "cf203f5d5482",
     ".claude/skills/review/SKILL.md": "881cb15dba91",
@@ -14,7 +14,7 @@
     ".claude/skills/dep-update/SKILL.md": "b5d36ac6dff1",
     ".claude/skills/deploy-test/SKILL.md": "8a0cf4447165",
     ".claude/skills/deploy-prod/SKILL.md": "41ad9d2f17db",
-    ".agents/skills/DOCTRINE.md": "bc4a598c89a1",
+    ".agents/skills/DOCTRINE.md": "e8da0295b5f6",
     ".agents/skills/cycle/SKILL.md": "b941afd3af57",
     ".agents/skills/implement/SKILL.md": "c9ea4d7d4f0f",
     ".agents/skills/review/SKILL.md": "056a46e2d908",

--- a/templates/DOCTRINE.md.tmpl
+++ b/templates/DOCTRINE.md.tmpl
@@ -251,7 +251,12 @@ A status label that doesn't exist in the repo makes `gh` **fail loudly** — tha
 behavior. Create the label rather than working around the error, and never invent a status value
 that isn't in the §1 table.
 
-**Unreachable → STOP.** `gh` unauthenticated or offline: say so and stop. Never guess tracker state.
+**Confirm unreachable, then STOP.** A first transport or OS-permission failure can be the harness
+sandbox rather than the tracker. When the error is compatible with a sandbox restriction and the
+harness exposes a policy-supported escalation or approval path, retry the **exact same read once**
+through that path — same target and arguments, with no weakened authentication or command. Stop if
+that retry fails, `gh` is unauthenticated, the API rejects the authenticated request, or no allowed
+escalation path exists. Never loop, guess tracker state, or substitute cached data.
 
 {{> overlay?:doctrine-tracker-mechanics}}
 

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -331,6 +331,16 @@ describe('multi-harness render', () => {
         assert.ok(existsSync(join(dir, '.agents', 'skills', 'cycle', 'SKILL.md')));
     });
 
+    test('both doctrines distinguish a sandbox-blocked read from a confirmed tracker outage', () => {
+        for (const root of ['.claude', '.agents']) {
+            const doctrine = readFileSync(join(dir, root, 'skills', 'DOCTRINE.md'), 'utf8');
+            assert.match(doctrine, /first transport or OS-permission failure can be the harness\s+sandbox/);
+            assert.match(doctrine, /retry the \*\*exact same read once\*\*/);
+            assert.match(doctrine, /Stop if\s+that retry fails/);
+            assert.match(doctrine, /Never loop, guess tracker state, or substitute cached data/);
+        }
+    });
+
     test('every codex-tree skill has parseable frontmatter and a provenance stamp', () => {
         for (const s of readdirSync(join(dir, '.agents', 'skills'), { withFileTypes: true })
             .filter((e) => e.isDirectory()).map((e) => e.name)) {


### PR DESCRIPTION
## What shipped

- distinguish sandbox-compatible transport/OS permission failures from confirmed tracker outages
- allow exactly one policy-supported retry of the same tracker read
- retain hard stops for failed retries, missing auth, authenticated API rejection, and unavailable escalation
- cover the contract in both Claude and Codex rendered doctrines

## Review and verification

- inline correctness/editorial review found no findings
- `node bin/cycle.mjs lint` passes
- `npm test` passes: 138/138 tests
- `node bin/cycle.mjs check` passes
- the initial restricted test run reproduced the repository-documented `spawnSync git EPERM`; the exact suite passed outside that sandbox

Closes #43

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)
