### PR TITLE
fix(delivery): keep merge guard in foreground

### DIFF
--- a/.agents/skills/DOCTRINE.md
+++ b/.agents/skills/DOCTRINE.md
@@ -1,4 +1,4 @@
-<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=e8da0295b5f6 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=c42be5075c3a — managed by the-cycle; edit the template, not this file -->
 # Pipeline doctrine (shared)
 
 Single source of truth for the rules the the-cycle work-loop skills share. A skill that says
@@ -196,7 +196,7 @@ unexplained red a hard stop.
 After a safe merge: **sync local main** (`git checkout main && git fetch origin && git reset --hard
 origin/main`) and prune the branch.
 
-**The harness's own auto-mode classifier can independently deny the background merge command**, even
+**The harness's own auto-mode classifier can independently deny the merge command**, even
 on a safe story with everything above satisfied. That's an environment-level permission gate, not a
 pipeline judgment call, and no skill text can route around it. If it fires: report the open,
 CI-pending PR and ask Brandon for a one-turn approval to re-run the merge (or to

--- a/.claude/skills/DOCTRINE.md
+++ b/.claude/skills/DOCTRINE.md
@@ -1,4 +1,4 @@
-<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=6bb6a5b2186f — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=DOCTRINE.md.tmpl hash=93cd41a26537 — managed by the-cycle; edit the template, not this file -->
 # Pipeline doctrine (shared)
 
 Single source of truth for the rules the the-cycle work-loop skills share. A skill that says
@@ -196,7 +196,7 @@ unexplained red a hard stop.
 After a safe merge: **sync local main** (`git checkout main && git fetch origin && git reset --hard
 origin/main`) and prune the branch.
 
-**The harness's own auto-mode classifier can independently deny the background merge command**, even
+**The harness's own auto-mode classifier can independently deny the merge command**, even
 on a safe story with everything above satisfied. That's an environment-level permission gate, not a
 pipeline judgment call, and no skill text can route around it. If it fires: report the open,
 CI-pending PR and ask Brandon for a one-turn approval to re-run the merge (or to

--- a/.cycle/state.json
+++ b/.cycle/state.json
@@ -1,7 +1,7 @@
 {
-  "upstream": "5a116a7-dirty",
+  "upstream": "e144554-dirty",
   "files": {
-    ".claude/skills/DOCTRINE.md": "6bb6a5b2186f",
+    ".claude/skills/DOCTRINE.md": "93cd41a26537",
     ".claude/skills/cycle/SKILL.md": "b1189a01a5f2",
     ".claude/skills/implement/SKILL.md": "cf203f5d5482",
     ".claude/skills/review/SKILL.md": "881cb15dba91",
@@ -14,7 +14,7 @@
     ".claude/skills/dep-update/SKILL.md": "b5d36ac6dff1",
     ".claude/skills/deploy-test/SKILL.md": "8a0cf4447165",
     ".claude/skills/deploy-prod/SKILL.md": "41ad9d2f17db",
-    ".agents/skills/DOCTRINE.md": "e8da0295b5f6",
+    ".agents/skills/DOCTRINE.md": "c42be5075c3a",
     ".agents/skills/cycle/SKILL.md": "b941afd3af57",
     ".agents/skills/implement/SKILL.md": "c9ea4d7d4f0f",
     ".agents/skills/review/SKILL.md": "056a46e2d908",

--- a/backends/github.jsonc
+++ b/backends/github.jsonc
@@ -51,9 +51,10 @@
     "pr_close": "gh pr close $1",
 
     // Two-step on purpose: --watch errors with "no checks reported" if it runs before
-    // any run exists, so wait for registration first. The && is the guard — merge only
-    // happens if every check passed.
-    "merge_guard": "(until gh pr checks $1 >/dev/null 2>&1; do sleep 30; done; gh pr checks $1 --watch --interval 30 --fail-fast && gh pr merge $1 --squash --delete-branch) &",
+    // any run exists, so wait for registration first. Keep this foreground so a harness
+    // can resume the yielded command instead of reaping the only merge process. The &&
+    // is the guard — merge only happens if every check passed.
+    "merge_guard": "until gh pr checks $1 >/dev/null 2>&1; do sleep 30; done; gh pr checks $1 --watch --interval 30 --fail-fast && gh pr merge $1 --squash --delete-branch",
 
     // The protected-repo counterpart to merge_guard: one foreground call, no polling.
     // Only rendered when `auto_merge` is true, because without required status checks

--- a/templates/DOCTRINE.md.tmpl
+++ b/templates/DOCTRINE.md.tmpl
@@ -177,16 +177,19 @@ report "ready for your merge: <url>" + *why* it's gated.
 **This repo has no server-side enforcement**, so the **poll-then-merge guard IS the enforcement**.
 Never use a fire-and-forget auto-merge flag here — `--auto` merges when the repo's merge
 *requirements* are met, and with no branch protection there are none, so it fires immediately with
-nothing to wait on. Run the guard in the **background** (the poll takes minutes; a foreground
-`sleep` is harness-blocked):
+nothing to wait on. Run the guard as **one foreground, resumable command**. If the command tool
+yields while CI is pending, resume that same command/session; do not append `&`, launch a detached
+watcher, or treat the yielded call as completion:
 
 ```bash
 {{@merge_guard "<pr>" "<n>"}}
 ```
 
-The guard is a client-side *simulation* of branch protection, with a simulation's weaknesses: it
-dies with the session, costs polling quota, and the harness can refuse to run it. If this repo ever
-gains protection, set `backend_overrides.auto_merge` and delete the guard.
+The guard is a client-side *simulation* of branch protection, with a simulation's weaknesses: the
+calling session must stay alive, it costs polling quota, and the harness can refuse to run it. If
+the session cannot retain a foreground command, leave the PR open and report that delivery is not
+complete — never detach the guard and claim success. If this repo ever gains protection, set
+`backend_overrides.auto_merge` and delete the guard.
 {{/unless}}
 {{#if backend.auto_merge}}
 **Server-side auto-merge is enabled here**, and the forge enforces the required checks — so queue
@@ -221,7 +224,7 @@ unexplained red a hard stop.
 After a safe merge: **sync local main** (`git checkout main && git fetch origin && git reset --hard
 origin/main`) and prune the branch.
 
-**The harness's own auto-mode classifier can independently deny the background merge command**, even
+**The harness's own auto-mode classifier can independently deny the merge command**, even
 on a safe story with everything above satisfied. That's an environment-level permission gate, not a
 pipeline judgment call, and no skill text can route around it. If it fires: report the open,
 CI-pending PR and ask {{repo.human}} for a one-turn approval to re-run the merge (or to

--- a/templates/skills/done.md.tmpl
+++ b/templates/skills/done.md.tmpl
@@ -1,13 +1,13 @@
 ---
 name: done
-description: Ship a {{repo.name}} story — commit the reviewed work, push, open a PR that Closes #<n>, and (for a safe story) {{#if backend.auto_merge}}queue server-side auto-merge{{/if}}{{#unless backend.auto_merge}}land it through the background poll-then-merge guard{{/unless}}; a judgment-call story's PR is left for {{repo.human}}'s manual merge. Done = the issue closes on merge. Plan-first. Usage `/done #<n>`. Use after /review (+ /patch) pass clean.
+description: Ship a {{repo.name}} story — commit the reviewed work, push, open a PR that Closes #<n>, and (for a safe story) {{#if backend.auto_merge}}queue server-side auto-merge{{/if}}{{#unless backend.auto_merge}}land it through the foreground poll-then-merge guard{{/unless}}; a judgment-call story's PR is left for {{repo.human}}'s manual merge. Done = the issue closes on merge. Plan-first. Usage `/done #<n>`. Use after /review (+ /patch) pass clean.
 ---
 
 # /done #<n> — ship a story
 
 Goal: commit the reviewed work, push, open a PR that closes the issue, and land it —
 {{#if backend.auto_merge}}queueing a safe story for CI-gated server-side auto-merge{{/if}}{{#unless backend.auto_merge}}
-auto-merging a safe story through the CI-gated background guard{{/unless}}, or leaving a
+auto-merging a safe story through the CI-gated foreground guard{{/unless}}, or leaving a
 judgment-call PR for {{repo.human}}.
 
 **Shared rules in `{{harness.doctrine_path}}` — read it if not already in context.** This skill
@@ -57,7 +57,7 @@ just the ordering.
 12. **Land it — the auto-merge decision (§5 + §6):**
 {{#unless backend.auto_merge}}
     - **Safe story** — none of §5's always-brake classes ({{brakes|join:, }}) **and** green CI →
-      run the **poll-then-merge guard in the background** (§6):
+      run the **poll-then-merge guard as one foreground, resumable command** (§6):
       ```bash
       {{@merge_guard "<pr>" "<n>"}}
       ```

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -869,7 +869,12 @@ describe('backend_overrides.auto_merge', () => {
 
     test('default renders the poll-then-merge guard, not --auto', () => {
         const src = doctrine(guardDir);
+        const guardLine = src.split('\n').find((line) => line.includes('until gh pr checks'));
+        assert.ok(guardLine, 'expected a rendered foreground guard command');
         assert.match(src, /gh pr checks .* --watch/, 'expected the poll guard');
+        assert.match(src, /one foreground, resumable command/);
+        assert.match(src, /resume that same command\/session/);
+        assert.doesNotMatch(guardLine, /&\s*$/, 'poll guard must not detach');
         assert.doesNotMatch(src, /gh pr merge .*--auto/, 'must not offer --auto without protection');
     });
 
@@ -882,13 +887,14 @@ describe('backend_overrides.auto_merge', () => {
     test('/done follows the same switch, so the flag is not doctrine-only', () => {
         assert.match(done(guardDir), /until gh pr checks/);
         assert.doesNotMatch(done(guardDir), /gh pr merge .*--auto/);
-        assert.match(done(guardDir), /background poll-then-merge guard/);
+        assert.match(done(guardDir), /foreground poll-then-merge guard/);
+        assert.match(done(guardDir), /one foreground, resumable command/);
         assert.doesNotMatch(done(guardDir), /queue server-side auto-merge/);
         assert.match(done(autoDir), /gh pr merge .*--auto/);
         assert.doesNotMatch(done(autoDir), /until gh pr checks/);
         assert.match(done(autoDir), /queue server-side auto-merge/);
         assert.match(done(autoDir), /CI-gated server-side auto-merge/);
-        assert.doesNotMatch(done(autoDir), /background poll-then-merge guard/);
+        assert.doesNotMatch(done(autoDir), /foreground poll-then-merge guard/);
     });
 
     test('/done marks review when the PR opens, never after merge or queueing', () => {


### PR DESCRIPTION
## What shipped

- keep the unprotected-repository poll-then-merge guard attached to the calling command session
- tell agents to resume a yielded foreground command instead of detaching a watcher
- preserve check registration, the 30-second watch interval, fail-fast behavior, and the conditional merge guard
- leave the protected repository `--auto --squash` path unchanged

## Review and verification

- inline correctness and test-quality review found no findings
- regression coverage asserts the rendered guard exists, is foreground/resumable, and has no trailing background operator
- `node bin/cycle.mjs lint` passes
- `npm test` passes: 138/138 tests
- `node bin/cycle.mjs check` passes

Closes #44

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)
