### PR TITLE
fix(cycle): use hasOwn in resolvePath to prevent prototype leak

### DIFF
--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -127,7 +127,7 @@ function resolvePath(ctx, path) {
     let cur = path.startsWith('.') ? ctx.__item : ctx;
     const parts = (path.startsWith('.') ? path.slice(1) : path).split('.').filter(Boolean);
     for (const p of parts) {
-        if (cur == null || typeof cur !== 'object' || !(p in cur)) return undefined;
+        if (cur == null || typeof cur !== 'object' || !Object.hasOwn(cur, p)) return undefined;
         cur = cur[p];
     }
     return cur;


### PR DESCRIPTION
Closes #48

## Summary
Single-line tightening in `bin/cycle.mjs:130`: `!(p in cur)` → `!Object.hasOwn(cur, p)` to prevent prototype-chain leak via paths like `{{constructor}}`/`{{__proto__}}`/`{{toString}}`.

Matches the existing pattern at `bin/cycle.mjs:1020` (`Object.hasOwn(parent, key)`) and preserves the "unresolved path is fatal" guarantee.

## Verification
- `npm test`: 138 pass, 0 fail
- `node bin/cycle.mjs check`: ✓ clean — every managed file matches its template
- `node bin/cycle.mjs lint`: ✓ consistent — citations, verbs, overlays and profiles all line up

## Acceptance
- `resolvePath({a:1}, "__proto__")` → `undefined` (fatal)
- Own `__proto__` via `Object.defineProperty`/`JSON.parse` still resolves correctly
- Inherited `constructor`/`toString`/`hasOwnProperty` → `undefined`

No other files touched.