### PR TITLE
fix: link setup skills into all 5 harness roots

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 
 CYCLE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BIN_DIR="$HOME/.local/bin"
-SKILL_DIRS=("$HOME/.claude/skills" "$HOME/.agents/skills")
+SKILL_DIRS=("$HOME/.claude/skills" "$HOME/.agents/skills" "$HOME/.github/skills" "$HOME/.opencode/skills" "$HOME/.pi/skills")
 PATH_LINE='export PATH="$HOME/.local/bin:$PATH"'
 
 mkdir -p "$BIN_DIR" "${SKILL_DIRS[@]}"


### PR DESCRIPTION
Closes #50

Why: install.sh:14 only linked setup skills into 2 harness roots; 3 supported harnesses (copilot/.github/skills, opencode/.opencode/skills, pi/.pi/skills) never received /cycle-setup.

Fix: SKILL_DIRS 2 → 5 (add $HOME/.github/skills $HOME/.opencode/skills $HOME/.pi/skills). No other files touched.

Receipt:
- npm test: 138 pass, 0 fail
- cycle check: clean
- cycle lint: consistent