### PR TITLE
docs: correct BACKENDS merge_guard to foreground resumable

### DIFF
--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -29,7 +29,7 @@ idea, different axis: this file is about the tracker, that one is about the harn
 | `issue_close` | `$1` number | close |
 | `pr_create` | `$1` branch `$2` title `$3` body | open a PR against `main` |
 | `pr_list` / `pr_view` / `pr_close` | `$1` number | PR surface |
-| `merge_guard` | `$1` pr `$2` issue | **backgrounded** poll-then-merge on green |
+| `merge_guard` | `$1` pr `$2` issue | **foreground, resumable** poll-then-merge on green (do not background with `&`) |
 | `set_status` | `$1` number `$2` status label | write the status value |
 | `ci_runs` | — | list CI runs |
 | `ci_log` / `ci_log_failed` | `$1` run | read one run's log / its failed steps |


### PR DESCRIPTION
Closes #51

Why: BACKENDS verb table said backgrounded but template/backend declare foreground resumable — cold reader would background with & and orphan poll.

Files: docs/BACKENDS.md
Diff fingerprint: 680bcc719e68
Gates: npm test PASS, cycle check PASS, cycle lint PASS

Receipt:
- docs/BACKENDS.md:32 backgrounded → foreground, resumable (do not background with &)
- templates/DOCTRINE.md.tmpl:180 and backends/github.jsonc:55 already foreground — now all three agree

Co-Authored-By: internal-model