### PR TITLE
fix(cycle): surface git stderr instead of silently swallowing

### DIFF
--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -425,8 +425,10 @@ export function stampProvenance(body, template, rel = template) {
 
 function git(args, cwd = process.cwd()) {
     try {
-        return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
-    } catch {
+        return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+    } catch (e) {
+        const msg = e.stderr?.toString?.().trim() ?? '';
+        if (msg) console.error(dim(`git ${args.join(' ')} failed: ${msg}`));
         return '';
     }
 }


### PR DESCRIPTION
Closes #52

**What:** `bin/cycle.mjs:426-434` `git()` now captures stderr (`stdio pipe`) and logs `dim(`git <args> failed: <msg>`)` instead of silently returning '' with `stdio ignore`.

**Why:** Previously any git failure (bad cwd, corrupted .git, not on PATH) was misreported as 'not a git repository' with no diagnostic. Preserve caller contracts — `findRepoRoot` still fails with 'not a git repo', `detect()` stays best-effort — but failure is now visible on stderr.

**Gates:**
- `npm test` — PASS (138/138)
- `node bin/cycle.mjs check` — PASS (clean)
- `node bin/cycle.mjs lint` — PASS (consistent)

**Diff fingerprint:**
```diff
- stdio: ['ignore','pipe','ignore'] -> ['ignore','pipe','pipe']
- catch {} -> catch (e) { const msg = e.stderr?.toString?.().trim() ?? ''; if (msg) console.error(dim(`git ${args.join(' ')} failed: ${msg}`)); return ''; }
```
