### PR TITLE
fix(cycle): update --dry-run exits 1 when conflicts are pending

### DIFF
--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -1484,6 +1484,8 @@ function cmdUpdate(args) {
         else console.log(`${bold(f.rel)}  ${green('new')}`);
     }
 
+    process.exitCode = conflicts.length ? 1 : 0;
+
     if (values['dry-run']) {
         console.log(dim(`\n(dry run — ${writes.length} file(s) would change)`));
         printFormatterGuidance(guidance);
@@ -1497,7 +1499,6 @@ function cmdUpdate(args) {
     writeState(root, plan);
     console.log(`${green('✓')} updated ${bold(String(writes.length))} file(s) to the-cycle@${upstreamSha()}`);
     printFormatterGuidance(guidance);
-    if (conflicts.length) process.exitCode = 1;
 }
 
 function cmdEject(args) {

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -594,6 +594,18 @@ describe('drift detection', () => {
         assert.match(readFileSync(f, 'utf8'), /hand-written/, 'the hand edit must survive');
     });
 
+    test('--dry-run exits non-zero while a conflict and a pending write coexist', () => {
+        rmSync(join(dir, '.claude', 'skills', 'scout', 'SKILL.md'));
+
+        const dry = cycleRaw(dir, ['update', '--dry-run']);
+        assert.match(dry.out, /refusing to overwrite/);
+        assert.match(dry.out, /dry run/);
+        assert.equal(dry.status, 1, 'a dry run must not go green while the update it previews would refuse');
+
+        const applied = cycleRaw(dir, ['update']);
+        assert.equal(applied.status, 1, 'the real update refuses the same conflict');
+    });
+
     test('--force applies the template over a hand edit', () => {
         cycle(dir, ['update', '--force']);
         assert.doesNotMatch(readFileSync(join(dir, '.claude/skills/patch/SKILL.md'), 'utf8'), /hand-written/);


### PR DESCRIPTION
## What shipped

`cmdUpdate`'s dry-run early return never touched `process.exitCode`, so when a hand-edited managed file (conflict) coexisted with pending upstream changes, `cycle update --dry-run` printed the refusal and still exited 0 — a CI or pre-push drift gate went green while the update it previewed would refuse to complete. The conflict signal is now set once above every return path; the redundant trailing assignment is gone.

Closes #59

## Findings actioned

Inline review found nothing beyond the planned change; the new test covers the exact conflict+write window for both `--dry-run` and the real update.

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)