### PR TITLE
fix(cycle): backend verb positionals past arity fail at render time

### DIFF
--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -323,7 +323,14 @@ export function renderTemplate(src, ctx, opts = {}) {
             const sub = { ...opts, where: `backend verb @${name}`, depth: depth + 1 };
             const rendered = args.map((a) => renderTemplate(a, ctx, sub));
             let cmd = renderTemplate(tmpl, ctx, sub);
-            cmd = cmd.replace(/\$(\d)/g, (_, d) => rendered[Number(d) - 1] ?? '');
+            cmd = cmd.replace(/\$(\d)/g, (_, d) => {
+                const v = rendered[Number(d) - 1];
+                if (v === undefined)
+                    fail(
+                        `backend verb "@${name}" references $${d} but was called with ${rendered.length} argument(s) in ${where}`,
+                    );
+                return v;
+            });
             out += cmd.trim();
             i = after;
             continue;

--- a/test/engine.test.mjs
+++ b/test/engine.test.mjs
@@ -119,6 +119,13 @@ describe('backend verbs', () => {
         assert.throws(() => R('{{@nope}}'), /unknown backend verb/);
     });
 
+    test('a positional past the supplied arity is fatal, not silently empty', () => {
+        assert.throws(
+            () => R('{{@issue_view}}'),
+            /"@issue_view" references \$1 but was called with 0 argument\(s\)/,
+        );
+    });
+
     // Status names differ per backend (Todo vs ready), so call sites pass them from
     // config. That nests a tag inside a tag — the parser must not close on the inner one.
     test('an argument may itself be a lookup', () => {


### PR DESCRIPTION
## What shipped

Backend verb expansion used `rendered[Number(d) - 1] ?? ''`, so a verb template referencing a positional the call site didn't supply rendered silently empty — e.g. `{{@set_status "<n>"}}` against a `$2`-using template planted a bare dangling flag in rendered skill prose, failing only far downstream. The engine's own philosophy is that an unresolved path is a hard error; arity mismatches now fail at render time, naming the verb, the missing position, and the call site.

Closes #61

## Findings actioned

Inline review found nothing beyond the planned change; new engine test asserts the fatal path and message.

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)