### PR TITLE
docs: cycle-setup personal links span five harness dirs, not two

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ automatically, for machines that would rather not reach GitHub.
 
 Don't push to the Forgejo mirror directly — the next sync from GitHub overwrites it.
 
-`install.sh` also links `/cycle-setup` into both `~/.claude/skills` and `~/.agents/skills` as a personal
+`install.sh` also links `/cycle-setup` into your personal skills directory (`~/.claude/skills`, `~/.agents/skills`, `~/.github/skills`, `~/.opencode/skills`, or `~/.pi/skills`) as a personal
 skill — it has to work in a repo that doesn't have the-cycle yet.
 
 Then, in a repo:


### PR DESCRIPTION
## What shipped

README still said install.sh links the cycle-setup personal skill into "both" `~/.claude/skills` and `~/.agents/skills` — residue of the multi-harness expansion that fixed the repo-level table (#49) and harness-root linking (#50) but missed this sibling claim. Now lists all five directories from install.sh's SKILL_DIRS.

Closes #62

## Findings actioned

Fast path: single-file docs change, fingerprint-verified, gates green. Review found nothing beyond the planned edit.

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)