### PR TITLE
docs: AUTHORING lint/test steps match what the pipeline enforces today

### DIFF
--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -96,10 +96,10 @@ Current overlay points (all optional):
 1. Write `templates/skills/<name>.md.tmpl`. Frontmatter needs `name` (matching the filename) and
    `description`.
 2. Add it to the profiles that should install it.
-3. `cycle lint` — catches what rendering can't: a `§N` that points at nothing, a verb only one
-   backend binds called outside a `{{#if backend.…}}`, a `/other-skill` reference absent from a
-   profile that installs yours, and any command you inlined instead of binding.
-4. `npm test` — the render suite will build it on every profile × backend and check the
+3. `cycle lint` — catches what rendering can't: a `§N` that points at nothing, a verb no
+   backend binds, a `/other-skill` reference absent from a profile that installs yours, and any
+   command you inlined instead of binding.
+4. `npm test` — the render suite will build it on every profile × backend × harness and check the
    frontmatter, the absence of unrendered syntax, and idempotency.
 5. Render it into a scratch repo and **read the output**. Tests prove it renders; only reading
    proves it says something true.


### PR DESCRIPTION
## What shipped

AUTHORING.md's authoring checklist claimed `cycle lint` catches "a verb only one backend binds called outside a {{#if backend.…}}" and that tests build "every profile × backend" — but those verb-divergence checks were deliberately removed when github became the only backend (bin/lint.mjs:138-143), and the render suite now covers a harness axis too. Step 3 now claims only checks that exist; step 4 matches CLAUDE.md's "every profile × backend × harness".

Closes #63

## Findings actioned

Fast path: single-file docs change, gates green. Every surviving claim was re-verified against bin/lint.mjs and test/render.test.mjs before landing.

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)