### PR TITLE
fix(cycle): redact origin URL credentials before install --plan stdout

### DIFF
--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -826,7 +826,10 @@ export function detect(root) {
 
     const remote = git(['remote', 'get-url', 'origin'], root);
     if (remote) {
-        out.remote = remote;
+        // Remotes configured for CI or convenience routinely embed credentials
+        // (https://x-access-token:ghp_…@host/repo.git); detect()'s output reaches the
+        // --plan stdout an agent reads, so only the credential-free URL travels.
+        out.remote = remote.replace(/\/\/[^/@]*@/, '//');
         const m = /[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/.exec(remote);
         if (m) out.slug = `${m[1]}/${m[2]}`;
     }

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -219,6 +219,17 @@ describe('install --plan', () => {
         assert.equal(existsSync(join(dir, '.claude')), false, '--plan must not write');
     });
 
+    test('a credentialed remote reaches the plan without its userinfo', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        execFileSync('git', ['remote', 'set-url', 'origin', 'https://x-access-token:ghp_SECRET123@github.com/brandon/demo.git'], { cwd: dir, stdio: 'pipe' });
+
+        const out = cycle(dir, ['install', '--plan']);
+        assert.doesNotMatch(out, /ghp_SECRET123/, 'the token must not reach plan stdout');
+        assert.equal(JSON.parse(out).detected.remote, 'https://github.com/brandon/demo.git');
+        assert.equal(JSON.parse(out).detected.slug, 'brandon/demo', 'redaction must not cost the slug');
+    });
+
     test('every question carries a reason, not just a default', () => {
         const dir = scratchRepo('github');
         dirs.push(dir);


### PR DESCRIPTION
## What shipped

`detect()` stored the origin URL verbatim and `cmdPlan` emitted it into the plan JSON whose documented consumer is the setup agent — so an HTTPS remote configured for CI (`https://x-access-token:ghp_…@github.com/org/repo.git`) put the embedded token straight into model context, session transcripts, and logs. Userinfo is now stripped at the `detect()` boundary (`//[^/@]*@` → `//`); the slug survives, scp-like and ssh forms are untouched, and grep confirms no other consumer of the raw value exists.

Closes #60

## Findings actioned

/security-review pass run at build time (per the scout flag on this secrets surface): single leak path closed at source, regex cannot overrun, nothing legitimate lost — no findings. Regression test feeds a credentialed URL and asserts the token never reaches plan stdout while slug stays intact.

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)