### PR TITLE
fix(cycle): cycle eject rejects names resolving outside the harness trees

### DIFF
--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -1519,7 +1519,12 @@ function cmdEject(args) {
     // the ejected file's sibling tree out from under it.
     const paths = harnessNames(cfg)
         .map((n) => loadHarness(n))
-        .map((h) => join(root, h.root, name, h.skill_file))
+        .map((h) => {
+            const p = join(root, h.root, name, h.skill_file);
+            if (relative(root, p).startsWith('..'))
+                fail(`"${name}" does not name a skill inside this repo's harness trees`);
+            return p;
+        })
         .filter((p) => existsSync(p));
     if (!paths.length) fail(`no rendered skill "${name}" in any configured harness`);
 

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -401,6 +401,16 @@ describe('multi-harness render', () => {
         assert.doesNotMatch(readFileSync(join(dir, '.claude', 'skills', 'wrap-up', 'SKILL.md'), 'utf8'), /cycle:rendered/);
         assert.doesNotMatch(readFileSync(join(dir, '.agents', 'skills', 'wrap-up', 'SKILL.md'), 'utf8'), /cycle:rendered/);
     });
+
+    test('eject rejects a name that resolves outside the harness trees', () => {
+        const outside = join(dir, '..', 'eject-victim.md');
+        writeFileSync(outside, '<!-- cycle:rendered template=x hash=abc -->\nhello');
+        const refused = cycleRaw(dir, ['eject', '../../../eject-victim.md/SKILL.md']);
+        assert.equal(refused.status, 1);
+        assert.match(refused.out, /does not name a skill inside/);
+        assert.match(readFileSync(outside, 'utf8'), /cycle:rendered/, 'the outside file must be untouched');
+        rmSync(outside);
+    });
 });
 
 describe('dependency metadata contracts', () => {


### PR DESCRIPTION
## What shipped

`cmdEject` interpolated raw argv into its paths and rewrote whatever existed there carrying a provenance header — so `cycle eject ../../…` escaped the repo root, a prompt-injection-to-write primitive when the caller is an agent (the common case for rendered skills). Each candidate path is now containment-checked against the repo root before any probe or write. Option A from the issue: costs zero legitimate input, unlike profile-membership validation which would break ejecting leftover copies after a profile change.

Closes #64

## Findings actioned

/security-review pass at build time: check fires before existsSync/read/write; lexical containment covers all `..` escapes; existing multi-harness eject test proves normal behavior unchanged. Known accepted scope: symlink-inside-tree pointing outward remains undetected (pre-existing, unchanged). Regression test writes a provenance-bearing victim outside the repo and asserts refusal plus untouched target.

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)