### PR TITLE
fix(deploy-prod): render honest no-command stub

### DIFF
--- a/.agents/skills/deploy-prod/SKILL.md
+++ b/.agents/skills/deploy-prod/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: deploy-prod
-description: Deploy the-cycle to production — the gated ritual. Preflight (clean pushed main, what's actually shipping, any migration plan), then STOP for Brandon's explicit go, then deploy, then independently verify the public origin. Includes the rollback path. Never runs unattended. Usage `/deploy-prod`.
+description: the-cycle has no configured production deploy — a gated stub that refuses to improvise a command. Usage `/deploy-prod`.
 ---
-<!-- cycle:rendered template=skills/deploy-prod.md.tmpl hash=1d59d46239ff — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/deploy-prod.md.tmpl hash=1f4630487811 — managed by the-cycle; edit the template, not this file -->
 
 # /deploy-prod — ship to production
 
@@ -36,24 +36,6 @@ have a go, you don't.
 **`deploy.prod` is not set in `.cycle/config.jsonc`** — stop and say so.
 There is no deploy command to run, and prod is the last place to improvise one.
 
-## 4. Verify independently
-
-Don't trust the deploy script's own success report — check the **public origin** yourself:
-
-- It responds (and with the right status).
-- The served build **is the one you just deployed** — compare the revision, don't assume.
-- Spot-check one surface that actually changed in this deploy.
-
-Report green only if all of those hold. "The script said OK" is not verification.
-
-## 5. Report + rollback
-
-State what shipped, the live revision, and the verification results.
-
-**Rollback = roll forward.** `git revert` → PR → green → deploy again. Reverting the deploy in
-place leaves the repo and the box disagreeing about reality, which is worse than the bug you're
-rolling back.
-
 ## Why this one is gated
 
 Everything else in this pipeline is auto-merged on green because a wrong merge is cheap to walk
@@ -64,8 +46,5 @@ function* changes here, and the person who owns the consequences should be the o
 ## Edge cases
 
 - **Preflight fails:** stop, report which check. Never "deploy anyway."
-- **Deploy fails partway:** say exactly which step, and whether a migration ran. Do not retry
-  blindly — a half-applied migration needs a decision, not a rerun.
-- **Verification disagrees with the deploy script:** trust the origin. Report as a failure.
 - **Asked to deploy unattended** (from `/burndown`, an overnight lane, or a chained skill):
   **refuse.** Report that prod needs an explicit invocation.

--- a/.claude/skills/deploy-prod/SKILL.md
+++ b/.claude/skills/deploy-prod/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: deploy-prod
-description: Deploy the-cycle to production — the gated ritual. Preflight (clean pushed main, what's actually shipping, any migration plan), then STOP for Brandon's explicit go, then deploy, then independently verify the public origin. Includes the rollback path. Never runs unattended. Usage `/deploy-prod`.
+description: the-cycle has no configured production deploy — a gated stub that refuses to improvise a command. Usage `/deploy-prod`.
 ---
-<!-- cycle:rendered template=skills/deploy-prod.md.tmpl hash=41ad9d2f17db — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/deploy-prod.md.tmpl hash=3b1ca02dbbf1 — managed by the-cycle; edit the template, not this file -->
 
 # /deploy-prod — ship to production
 
@@ -36,24 +36,6 @@ have a go, you don't.
 **`deploy.prod` is not set in `.cycle/config.jsonc`** — stop and say so.
 There is no deploy command to run, and prod is the last place to improvise one.
 
-## 4. Verify independently
-
-Don't trust the deploy script's own success report — check the **public origin** yourself:
-
-- It responds (and with the right status).
-- The served build **is the one you just deployed** — compare the revision, don't assume.
-- Spot-check one surface that actually changed in this deploy.
-
-Report green only if all of those hold. "The script said OK" is not verification.
-
-## 5. Report + rollback
-
-State what shipped, the live revision, and the verification results.
-
-**Rollback = roll forward.** `git revert` → PR → green → deploy again. Reverting the deploy in
-place leaves the repo and the box disagreeing about reality, which is worse than the bug you're
-rolling back.
-
 ## Why this one is gated
 
 Everything else in this pipeline is auto-merged on green because a wrong merge is cheap to walk
@@ -64,8 +46,5 @@ function* changes here, and the person who owns the consequences should be the o
 ## Edge cases
 
 - **Preflight fails:** stop, report which check. Never "deploy anyway."
-- **Deploy fails partway:** say exactly which step, and whether a migration ran. Do not retry
-  blindly — a half-applied migration needs a decision, not a rerun.
-- **Verification disagrees with the deploy script:** trust the origin. Report as a failure.
 - **Asked to deploy unattended** (from `/burndown`, an overnight lane, or a chained skill):
   **refuse.** Report that prod needs an explicit invocation.

--- a/.cycle/state.json
+++ b/.cycle/state.json
@@ -1,5 +1,5 @@
 {
-  "upstream": "e144554-dirty",
+  "upstream": "f36cb2b-dirty",
   "files": {
     ".claude/skills/DOCTRINE.md": "93cd41a26537",
     ".claude/skills/cycle/SKILL.md": "b1189a01a5f2",
@@ -13,7 +13,7 @@
     ".claude/skills/burndown/SKILL.md": "02acecf85f8d",
     ".claude/skills/dep-update/SKILL.md": "b5d36ac6dff1",
     ".claude/skills/deploy-test/SKILL.md": "8a0cf4447165",
-    ".claude/skills/deploy-prod/SKILL.md": "41ad9d2f17db",
+    ".claude/skills/deploy-prod/SKILL.md": "3b1ca02dbbf1",
     ".agents/skills/DOCTRINE.md": "c42be5075c3a",
     ".agents/skills/cycle/SKILL.md": "b941afd3af57",
     ".agents/skills/implement/SKILL.md": "c9ea4d7d4f0f",
@@ -26,6 +26,6 @@
     ".agents/skills/burndown/SKILL.md": "b87b67671d30",
     ".agents/skills/dep-update/SKILL.md": "70677227a33a",
     ".agents/skills/deploy-test/SKILL.md": "8a0cf4447165",
-    ".agents/skills/deploy-prod/SKILL.md": "1d59d46239ff"
+    ".agents/skills/deploy-prod/SKILL.md": "1f4630487811"
   }
 }

--- a/templates/skills/deploy-prod.md.tmpl
+++ b/templates/skills/deploy-prod.md.tmpl
@@ -1,6 +1,6 @@
 ---
 name: deploy-prod
-description: Deploy {{repo.name}} to production — the gated ritual. Preflight (clean pushed main, what's actually shipping, any migration plan), then STOP for {{repo.human}}'s explicit go, then deploy, then independently verify the public origin. Includes the rollback path. Never runs unattended. Usage `/deploy-prod`.
+description: {{#if deploy.prod}}Deploy {{repo.name}} to production — the gated ritual. Preflight (clean pushed main, what's actually shipping, any migration plan), then STOP for {{repo.human}}'s explicit go, then deploy, then independently verify the public origin. Includes the rollback path. Never runs unattended. Usage `/deploy-prod`.{{/if}}{{#unless deploy.prod}}{{repo.name}} has no configured production deploy — a gated stub that refuses to improvise a command. Usage `/deploy-prod`.{{/unless}}
 ---
 
 # /deploy-prod — ship to production
@@ -41,7 +41,7 @@ What that command does — and does *not* — do is the `deploy` overlay's job t
 assume it takes a backup, runs migrations, or waits for a healthy result; assume none of
 those unless the overlay says otherwise.{{/if}}
 
-## 4. Verify independently
+{{#if deploy.prod}}## 4. Verify independently
 
 Don't trust the deploy script's own success report — check the **public origin** yourself:
 
@@ -57,7 +57,7 @@ State what shipped, the live revision, and the verification results.
 
 **Rollback = roll forward.** `git revert` → PR → green → deploy again. Reverting the deploy in
 place leaves the repo and the box disagreeing about reality, which is worse than the bug you're
-rolling back.
+rolling back.{{/if}}
 
 ## Why this one is gated
 
@@ -69,8 +69,10 @@ function* changes here, and the person who owns the consequences should be the o
 ## Edge cases
 
 - **Preflight fails:** stop, report which check. Never "deploy anyway."
+{{#if deploy.prod}}
 - **Deploy fails partway:** say exactly which step, and whether a migration ran. Do not retry
   blindly — a half-applied migration needs a decision, not a rerun.
 - **Verification disagrees with the deploy script:** trust the origin. Report as a failure.
+{{/if}}
 - **Asked to deploy unattended** (from `/burndown`, an overnight lane, or a chained skill):
   **refuse.** Report that prod needs an explicit invocation.

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -529,6 +529,45 @@ describe('commit attribution', () => {
     });
 });
 
+// A repository with no production command must not render executable-sounding verification or
+// generic rollback instructions after the explicit stop. A consuming repo may document its real
+// external release topology in the deploy overlay; the shared template must not contradict it.
+describe('deploy-prod on a repo with no production command', () => {
+    const renderWith = (deployProd) => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        cycle(dir, ['install', '--profile', 'lean', '-y']);
+        const cfgPath = join(dir, '.cycle', 'config.jsonc');
+        const cfg = JSON.parse(
+            readFileSync(cfgPath, 'utf8').replace(/^\s*\/\/.*$/gm, '').replace(/,(\s*[}\]])/g, '$1'),
+        );
+        cfg.deploy = deployProd ? { prod: deployProd } : {};
+        writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
+        cycle(dir, ['update', '--force']);
+        return readFileSync(join(dir, '.claude', 'skills', 'deploy-prod', 'SKILL.md'), 'utf8');
+    };
+
+    test('renders an honest stop without generic verification or rollback steps', () => {
+        const out = renderWith(null);
+        assert.match(out, /has no configured production deploy/);
+        assert.match(out, /deploy\.prod` is not set/);
+        assert.doesNotMatch(out, /## 4\. Verify independently/);
+        assert.doesNotMatch(out, /Rollback = roll forward/);
+        assert.doesNotMatch(out, /Deploy fails partway/);
+        assert.doesNotMatch(out, /Verification disagrees with the deploy script/);
+    });
+
+    test('keeps the full verification and rollback flow when production is configured', () => {
+        const out = renderWith('./deploy.sh prod');
+        assert.match(out, /\.\/deploy\.sh prod/);
+        assert.match(out, /## 4\. Verify independently/);
+        assert.match(out, /Rollback = roll forward/);
+        assert.match(out, /Deploy fails partway/);
+        assert.match(out, /Verification disagrees with the deploy script/);
+        assert.doesNotMatch(out, /has no configured production deploy/);
+    });
+});
+
 // A single-environment repo has nowhere lower-stakes to deploy. The test-box flow is
 // deliberately ungated ("no gate, no explicit go") because a test box is cheap to get wrong;
 // rendering that framing where prod is the ONLY environment turns a preview into an unreviewed


### PR DESCRIPTION
## What shipped

- Render an explicit stub description when no production command is configured.
- Omit verification, rollback, and deploy-only failure guidance from that stub.
- Preserve the complete deployment flow for configured production targets.
- Cover both variants with render regression tests and regenerate both managed harness trees.

## Review findings actioned

- Fixed the P2 finding that partial-deploy and deploy-script verification edge cases still leaked into the no-command output.
- Added negative stub assertions and positive configured-flow assertions so the contradiction cannot regress.

## Validation

- npm test — 144/144 passing
- node bin/cycle.mjs check — clean
- node bin/cycle.mjs lint — consistent
- git diff --check — clean

Closes #71

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)