### PR TITLE
feat(scout): surface broader finding threads

### DIFF
--- a/.agents/skills/scout/SKILL.md
+++ b/.agents/skills/scout/SKILL.md
@@ -2,7 +2,7 @@
 name: scout
 description: Discovery-driven finder for the-cycle — fans out read-only agents across security · performance · hygiene · context · a11y lenses, verifies each finding against the real code, dedupes against open issues, and files the worth-keeping candidates as actionable issues. Read-only over code: it FINDS and FILES, it never fixes, branches, or merges. Usage `/scout` (all lenses, tightly capped) or `/scout <lens>` (one focused lens, higher cap).
 ---
-<!-- cycle:rendered template=skills/scout.md.tmpl hash=19ebcf6d5009 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/scout.md.tmpl hash=1dfb69dfcd11 — managed by the-cycle; edit the template, not this file -->
 
 # /scout — find the-cycle's next work, on demand
 
@@ -46,6 +46,29 @@ Within §10.6's budget: **all-lenses run** — ~2 findings per lens, single digi
 
 **Filing zero because a lens is clean is a success, not a failure** — say so and stop. A flood of
 marginal issues is worse than a missed one: it burns trust in the whole queue.
+
+## Broader threads are a handoff, not an implicit wider sweep
+
+A verified finding can expose a shared pattern that may support distinct actionable issues across
+other parts of the codebase. That is useful Scout output, but it is **not** permission to exceed
+the current run's named lens or §10.6 filing budget.
+
+Inspect only enough adjacent, representative evidence to establish that the thread is credible.
+Cite what is confirmed, distinguish likely surfaces from verified ones, and stop before the
+current pass turns into the broader investigation. Finish the original sweep and slate normally.
+
+In the final report, add a **broader thread** handoff that includes:
+
+- the shared pattern and the evidence that makes it credible;
+- confirmed and likely affected surfaces, clearly distinguished;
+- whether one issue is sufficient or several independent issues are warranted — one issue when
+  the fix and acceptance are shared, several when the surfaces need independently shippable fixes
+  or proof — plus the proposed split; and
+- the focused follow-up `/scout <lens>` pass that would investigate and draft those issues.
+
+Do **not** automatically broaden the current sweep, file speculative related issues, or create an
+umbrella issue. The broader investigation and its filings begin only when that focused follow-up
+is requested.
 
 ## Verify before filing (non-negotiable)
 
@@ -95,7 +118,8 @@ never pickable.
    and there is nothing to batch around. Tracker unreachable → say so and stop; don't pretend it
    filed.
 8. **Report.** What was filed (links, labels, which ones flag a §5 brake for later), what was found
-   but not filed (dups, below-the-cut, "clean on this lens"), and point at `/next`.
+   but not filed (dups, below-the-cut, "clean on this lens"), any credible **broader thread**
+   handoff from above, and point at `/next`.
 
 ## Guardrails
 

--- a/.claude/skills/scout/SKILL.md
+++ b/.claude/skills/scout/SKILL.md
@@ -2,7 +2,7 @@
 name: scout
 description: Discovery-driven finder for the-cycle — fans out read-only agents across security · performance · hygiene · context · a11y lenses, verifies each finding against the real code, dedupes against open issues, and files the worth-keeping candidates as actionable issues. Read-only over code: it FINDS and FILES, it never fixes, branches, or merges. Usage `/scout` (all lenses, tightly capped) or `/scout <lens>` (one focused lens, higher cap).
 ---
-<!-- cycle:rendered template=skills/scout.md.tmpl hash=99ef77295706 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/scout.md.tmpl hash=cde8833eeb0b — managed by the-cycle; edit the template, not this file -->
 
 # /scout — find the-cycle's next work, on demand
 
@@ -46,6 +46,29 @@ Within §10.6's budget: **all-lenses run** — ~2 findings per lens, single digi
 
 **Filing zero because a lens is clean is a success, not a failure** — say so and stop. A flood of
 marginal issues is worse than a missed one: it burns trust in the whole queue.
+
+## Broader threads are a handoff, not an implicit wider sweep
+
+A verified finding can expose a shared pattern that may support distinct actionable issues across
+other parts of the codebase. That is useful Scout output, but it is **not** permission to exceed
+the current run's named lens or §10.6 filing budget.
+
+Inspect only enough adjacent, representative evidence to establish that the thread is credible.
+Cite what is confirmed, distinguish likely surfaces from verified ones, and stop before the
+current pass turns into the broader investigation. Finish the original sweep and slate normally.
+
+In the final report, add a **broader thread** handoff that includes:
+
+- the shared pattern and the evidence that makes it credible;
+- confirmed and likely affected surfaces, clearly distinguished;
+- whether one issue is sufficient or several independent issues are warranted — one issue when
+  the fix and acceptance are shared, several when the surfaces need independently shippable fixes
+  or proof — plus the proposed split; and
+- the focused follow-up `/scout <lens>` pass that would investigate and draft those issues.
+
+Do **not** automatically broaden the current sweep, file speculative related issues, or create an
+umbrella issue. The broader investigation and its filings begin only when that focused follow-up
+is requested.
 
 ## Verify before filing (non-negotiable)
 
@@ -95,7 +118,8 @@ never pickable.
    and there is nothing to batch around. Tracker unreachable → say so and stop; don't pretend it
    filed.
 8. **Report.** What was filed (links, labels, which ones flag a §5 brake for later), what was found
-   but not filed (dups, below-the-cut, "clean on this lens"), and point at `/next`.
+   but not filed (dups, below-the-cut, "clean on this lens"), any credible **broader thread**
+   handoff from above, and point at `/next`.
 
 ## Guardrails
 

--- a/.cycle/state.json
+++ b/.cycle/state.json
@@ -1,5 +1,5 @@
 {
-  "upstream": "f36cb2b-dirty",
+  "upstream": "f3d29c5-dirty",
   "files": {
     ".claude/skills/DOCTRINE.md": "93cd41a26537",
     ".claude/skills/cycle/SKILL.md": "b1189a01a5f2",
@@ -9,7 +9,7 @@
     ".claude/skills/done/SKILL.md": "bb780a9b5880",
     ".claude/skills/next/SKILL.md": "0afc40565e46",
     ".claude/skills/intake/SKILL.md": "51a3e4a81229",
-    ".claude/skills/scout/SKILL.md": "99ef77295706",
+    ".claude/skills/scout/SKILL.md": "cde8833eeb0b",
     ".claude/skills/burndown/SKILL.md": "02acecf85f8d",
     ".claude/skills/dep-update/SKILL.md": "b5d36ac6dff1",
     ".claude/skills/deploy-test/SKILL.md": "8a0cf4447165",
@@ -22,7 +22,7 @@
     ".agents/skills/done/SKILL.md": "e3a0f7b50cd6",
     ".agents/skills/next/SKILL.md": "f49c75d042fd",
     ".agents/skills/intake/SKILL.md": "737d2a8abe76",
-    ".agents/skills/scout/SKILL.md": "19ebcf6d5009",
+    ".agents/skills/scout/SKILL.md": "1dfb69dfcd11",
     ".agents/skills/burndown/SKILL.md": "b87b67671d30",
     ".agents/skills/dep-update/SKILL.md": "70677227a33a",
     ".agents/skills/deploy-test/SKILL.md": "8a0cf4447165",

--- a/templates/skills/scout.md.tmpl
+++ b/templates/skills/scout.md.tmpl
@@ -48,6 +48,29 @@ Within §10.6's budget: **all-lenses run** — ~2 findings per lens, single digi
 **Filing zero because a lens is clean is a success, not a failure** — say so and stop. A flood of
 marginal issues is worse than a missed one: it burns trust in the whole queue.
 
+## Broader threads are a handoff, not an implicit wider sweep
+
+A verified finding can expose a shared pattern that may support distinct actionable issues across
+other parts of the codebase. That is useful Scout output, but it is **not** permission to exceed
+the current run's named lens or §10.6 filing budget.
+
+Inspect only enough adjacent, representative evidence to establish that the thread is credible.
+Cite what is confirmed, distinguish likely surfaces from verified ones, and stop before the
+current pass turns into the broader investigation. Finish the original sweep and slate normally.
+
+In the final report, add a **broader thread** handoff that includes:
+
+- the shared pattern and the evidence that makes it credible;
+- confirmed and likely affected surfaces, clearly distinguished;
+- whether one issue is sufficient or several independent issues are warranted — one issue when
+  the fix and acceptance are shared, several when the surfaces need independently shippable fixes
+  or proof — plus the proposed split; and
+- the focused follow-up `/scout <lens>` pass that would investigate and draft those issues.
+
+Do **not** automatically broaden the current sweep, file speculative related issues, or create an
+umbrella issue. The broader investigation and its filings begin only when that focused follow-up
+is requested.
+
 ## Verify before filing (non-negotiable)
 
 Every finding is a **hypothesis with a citation** until you've read the cited code. Open the file,
@@ -96,7 +119,8 @@ never pickable.
    and there is nothing to batch around. Tracker unreachable → say so and stop; don't pretend it
    filed.
 8. **Report.** What was filed (links, labels, which ones flag a §5 brake for later), what was found
-   but not filed (dups, below-the-cut, "clean on this lens"), and point at `/next`.
+   but not filed (dups, below-the-cut, "clean on this lens"), any credible **broader thread**
+   handoff from above, and point at `/next`.
 
 ## Guardrails
 

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -352,6 +352,18 @@ describe('multi-harness render', () => {
         }
     });
 
+    test('both Scout trees hand broader threads to a separately requested focused pass', () => {
+        for (const root of ['.claude', '.agents']) {
+            const scout = readFileSync(join(dir, root, 'skills', 'scout', 'SKILL.md'), 'utf8');
+            assert.match(scout, /Broader threads are a handoff, not an implicit wider sweep/);
+            assert.match(scout, /distinguish likely surfaces from verified ones/);
+            assert.match(scout, /whether one issue is sufficient or several independent issues are warranted/);
+            assert.match(scout, /focused follow-up `\/scout <lens>` pass/);
+            assert.match(scout, /Do \*\*not\*\* automatically broaden the current sweep/);
+            assert.match(scout, /any credible \*\*broader thread\*\*\s+handoff from above/);
+        }
+    });
+
     test('every codex-tree skill has parseable frontmatter and a provenance stamp', () => {
         for (const s of readdirSync(join(dir, '.agents', 'skills'), { withFileTypes: true })
             .filter((e) => e.isDirectory()).map((e) => e.name)) {


### PR DESCRIPTION
## What shipped

- Added a bounded broader-thread handoff to Scout: confirm representative evidence, distinguish verified from likely surfaces, recommend one issue versus an independently shippable split, and propose a focused follow-up pass.
- Kept the current sweep within its named lens and filing budget; no speculative related issues or umbrella issue are created automatically.
- Regenerated the Claude and Codex dogfood skill trees and added multi-harness render coverage.

## Review findings actioned

- Updated the numbered report step to require any credible broader-thread handoff, closing the gap between the new contract and the workflow summary.

## Verification

- `npm test` — 145 tests passed
- `node bin/cycle.mjs lint` — consistent
- `node bin/cycle.mjs check` — clean
- `git diff --check` — clean
- Scratch install/check inspected clean Scout output for Claude, Codex, Copilot, OpenCode, and Pi

Closes #73

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)