### PR TITLE
docs(backends): add missing merge_auto verb to the vocabulary table

### DIFF
--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -30,6 +30,7 @@ idea, different axis: this file is about the tracker, that one is about the harn
 | `pr_create` | `$1` branch `$2` title `$3` body | open a PR against `main` |
 | `pr_list` / `pr_view` / `pr_close` | `$1` number | PR surface |
 | `merge_guard` | `$1` pr `$2` issue | **foreground, resumable** poll-then-merge on green (do not background with `&`) |
+| `merge_auto` | `$1` pr | queue server-side auto-merge (`gh pr merge $1 --auto --squash`); only rendered when `auto_merge` is true, so bind it before honestly setting that flag |
 | `set_status` | `$1` number `$2` status label | write the status value |
 | `ci_runs` | — | list CI runs |
 | `ci_log` / `ci_log_failed` | `$1` run | read one run's log / its failed steps |


### PR DESCRIPTION
docs/BACKENDS.md's verb vocabulary table jumped from `merge_guard` straight to `set_status`, omitting `merge_auto` — even though `backends/github.jsonc` binds it (`gh pr merge $1 --auto --squash`) and two templates call it (`done` and DOCTRINE §10). Step 2 of "Adding a backend" instructs authors to bind "every verb in the table above", so a cold reader standing up a second backend would faithfully follow an incomplete table, omit `merge_auto`, and hit a hard render error as soon as `backend_overrides.auto_merge` is true.

The fix is one table row, placed between `merge_guard` and `set_status`, noting both its `$1`-pr arity and that it only renders when `auto_merge` is true.

Verified: every key under `verbs` in `backends/github.jsonc` (20 verbs) now appears in the table; gates (`npm test`, `cycle lint`, `cycle check`) pass.

Closes #79

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)