### PR TITLE
fix(cycle): abort install interview loudly when stdin closes instead of exiting 0

### DIFF
--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -1118,7 +1118,9 @@ async function cmdInstall(args) {
 
     if (!values.yes) {
         const rl = createInterface({ input: process.stdin, output: process.stdout });
-        const ask = async (q, def) => (await rl.question(`${q} ${dim(`[${def}]`)} `)).trim() || def;
+        const closed = new Promise((_, rej) =>
+            rl.once('close', () => rej(new CycleError('interview aborted: stdin closed before setup completed'))));
+        const ask = async (q, def) => (await Promise.race([rl.question(`${q} ${dim(`[${def}]`)} `), closed])).trim() || def;
         console.log(bold('\nSetting up the-cycle. Enter accepts the detected value.\n'));
         cfg.repo.name = await ask('Repo display name', cfg.repo.name);
         cfg.repo.human = await ask('Who does this pipeline interrupt?', cfg.repo.human);

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -318,6 +318,24 @@ describe('install --plan', () => {
     });
 });
 
+// #77: a stdin EOF mid-interview used to leave rl.question's promise pending forever,
+// so `cycle install < /dev/null` exited 0 having written nothing — a silent success for
+// an aborted setup. EOF must abort loudly instead.
+describe('install interview vs stdin EOF (#77)', () => {
+    test('a closed stdin exits non-zero with the abort error instead of silently succeeding', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+
+        // input: '' closes the child's stdin immediately — the `< /dev/null` repro.
+        const r = spawnSync(process.execPath, [CLI, 'install'], {
+            cwd: dir, input: '', encoding: 'utf8', env: { ...process.env, NO_COLOR: '1' },
+        });
+        assert.equal(r.status, 1, `expected exit 1, got ${r.status}\n${r.stdout}${r.stderr}`);
+        assert.match(r.stderr, /interview aborted: stdin closed before setup completed/);
+        assert.equal(existsSync(join(dir, '.cycle')), false, 'the aborted install must write nothing');
+    });
+});
+
 // Multi-harness: one config renders more than one skill tree. The engine-level
 // concern is that the second tree is genuinely independent — its own root, its own
 // {{harness.*}} substitutions — not a copy that happens to share output with Claude


### PR DESCRIPTION
## What shipped

`cycle install`'s interactive interview hung its promise forever on stdin EOF and exited 0 having done nothing. Empirically verified before the fix: `cycle install < /dev/null` in a fresh git repo printed the first prompt, then exited code 0 writing nothing — `rl.question`'s promise never settles when the stream closes, so the aborted setup read as silent success.

**The fix** (bin/cycle.mjs): a single `closed` rejection promise wired to `rl.once('close', …)` is raced against every `rl.question`, so EOF settles the pending answer as a loud `CycleError('interview aborted: stdin closed before setup completed')`. The top-level handler prints `✗ <message>` and exits 1; no extra teardown needed. The existing happy-path `rl.close()` is kept — after it fires, the losing race promise already has a reaction attached via `Promise.race`, so its late rejection cannot surface as unhandled.

**The regression test** (test/render.test.mjs): reuses the established `scratchRepo()`/`CLI` helpers and drives the child with `spawnSync(..., { input: '' })` — the `< /dev/null` repro — asserting exit 1, stderr matching the abort message, and that nothing was written (no `.cycle/`). Placed next to the other install-interview coverage.

Closes #77

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)
