### PR TITLE
fix(cycle): map parseArgs failures onto the standard error treatment

### DIFF
--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -1633,6 +1633,14 @@ if (invokedDirectly()) {
             console.error(`${red('✗')} ${e.message}`);
             process.exit(1);
         }
+        // parseArgs (strict mode) throws a bare TypeError with an ERR_PARSE_ARGS code on a
+        // typo'd flag — same class of user mistake as the `default:` arm above, so it gets
+        // the same clean treatment instead of an internal stack trace.
+        if (typeof e?.code === 'string' && e.code.startsWith('ERR_PARSE_ARGS')) {
+            console.error(`${red('✗')} ${e.message}`);
+            console.error(dim('  run `cycle --help` for usage'));
+            process.exit(1);
+        }
         console.error(e.stack ?? String(e));
         process.exit(1);
     });

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -336,6 +336,23 @@ describe('install interview vs stdin EOF (#77)', () => {
     });
 });
 
+// #78: a typo'd flag used to dump parseArgs' internal stack trace instead of getting
+// the same clean ✗ + hint every other user-facing failure gets.
+describe('unknown flag vs error treatment (#78)', () => {
+    test('an unknown option exits 1 with a clean message and no stack trace', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+
+        const r = spawnSync(process.execPath, [CLI, 'update', '--dr-run'], {
+            cwd: dir, encoding: 'utf8', env: { ...process.env, NO_COLOR: '1' },
+        });
+        assert.equal(r.status, 1, `expected exit 1, got ${r.status}\n${r.stdout}${r.stderr}`);
+        assert.match(r.stderr, /✗.*[Uu]nknown option/);
+        assert.match(r.stderr, /cycle --help/);
+        assert.doesNotMatch(r.stderr, /^\s+at /m, 'no internal stack trace');
+    });
+});
+
 // Multi-harness: one config renders more than one skill tree. The engine-level
 // concern is that the second tree is genuinely independent — its own root, its own
 // {{harness.*}} substitutions — not a copy that happens to share output with Claude


### PR DESCRIPTION
A typo'd flag hit `parseArgs` strict mode and dumped a raw internal stack (`TypeError ... at checkOptionUsage (node:internal/util/parse_args/...)`) — inconsistent with the clean `✗` + hint treatment every other user-facing failure gets via `fail()`/`CycleError`.

What shipped:
- `main().catch` now maps `ERR_PARSE_ARGS_*` codes onto the standard treatment: one `✗ <message>` line plus a `run \`cycle --help\` for usage` hint, exit 1, no stack.
- Regression test drives `cycle update --dr-run` and pins: exit 1, `✗ … Unknown option`, help hint present, no `at …` frames.

Closes #78

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)