### PR TITLE
docs: align lint and coverage claims with what the checks actually do

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,9 @@ cycle lint                                  # internal consistency: §N citation
 ```
 
 `cycle lint` and `npm test` catch different things — lint checks that the pieces still refer to each
-other correctly (a renamed `§N`, a verb only one backend binds, a template in no profile); the test
-suite proves every template actually *renders* (every profile × backend × harness combination,
-frontmatter, idempotency). Run both before considering template work done.
+other correctly (a renamed `§N`, a verb no backend binds, a template in no profile); the test
+suite proves every template actually *renders* (every profile × backend combination, plus
+multi-harness suites covering a second harness, frontmatter, idempotency). Run both before considering template work done.
 
 Debug/inspection commands (not part of the normal edit loop, but useful when tracing a render):
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ templates/
 backends/*.jsonc       verb → command tables
 harnesses/*.jsonc      discovery path, tool names, capability flags per AI harness
 profiles/*.jsonc       which skills each profile installs
-test/                  node --test; renders every profile × backend × harness
+test/                  node --test; renders every profile × backend, plus multi-harness suites
 docs/
   AUTHORING.md         writing a template; the overlay points
   BACKENDS.md          the verb vocabulary; adding a backend

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -155,8 +155,9 @@ is a deliberate change to those two checks first — not something that can happ
 5. **Bind it to commands, not to an executable.** A verb may not name a `scripts/` path — nothing
    installs one. If the tracker's API is too awkward to drive from a verb string, that's a design
    conversation, not a helper you add quietly; see "No installed executables" above.
-6. `npm test` renders every profile against every backend in `backends/` and checks that the render
-   is prose only.
+6. `npm test` renders every profile against every backend listed in `test/render.test.mjs`'s
+   `BACKENDS` array — add yours there (and its remote to `REMOTES`) — and checks that the render is
+   prose only.
 
 ## Migrating off a backend (history)
 


### PR DESCRIPTION
Two docs drifts, verified against the code they describe:

- CLAUDE.md credited `cycle lint` with warning "a verb only one backend binds" — a check bin/lint.mjs:138-144 documents as deliberately removed with the single-backend collapse; the live check errors only when *no* backend binds a called verb. One word: "only one" → "no".
- Three files overstated test coverage. CLAUDE.md and README claimed "every profile × backend × harness"; the suite renders the main matrix into `.claude/` only plus two targeted multi-harness scenarios, with `BACKENDS = ['github']` hardcoded in test/render.test.mjs. BACKENDS.md's backend-authoring step 6 said `npm test` covers "every backend in `backends/`", hiding that new backends must be added to the test arrays by hand. All three now match docs/HARNESSES.md's accurate phrasing and point at the array to extend.

What shipped: wording-only edits in CLAUDE.md (lines 49-52), README.md (line 144), docs/BACKENDS.md (step 6). No behavior change; gates re-run locally (146 pass, lint ✓, check ✓).

Closes #80

Closes #81

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)