### PR TITLE
chore(cycle): derive knownLockfiles from ECOSYSTEMS instead of hand-listing

### DIFF
--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -525,10 +525,9 @@ function buildContext(cfg, backend) {
             .map(([, v]) => v);
     }
     const dependencyManifests = cfg.deps?.manifests ?? [];
-    const knownLockfiles = new Set([
-        'pnpm-lock.yaml', 'yarn.lock', 'package-lock.json', 'Cargo.lock',
-        'go.sum', 'uv.lock', 'poetry.lock', 'Gemfile.lock',
-    ]);
+    // Derived from ECOSYSTEMS rather than hand-listed, so adding an ecosystem can't
+    // silently drop legacy-config lockfile inference for it.
+    const knownLockfiles = new Set(ECOSYSTEMS.flatMap(([key, e]) => [key, e.lockfile]));
     // Configs written before deps.lockfile existed still carry the same fact in
     // deps.manifests. Preserve their meaning on the next `cycle update`.
     const inferredLockfile = dependencyManifests.find((path) => knownLockfiles.has(basename(path))) ?? '';


### PR DESCRIPTION
Standing hygiene from the burndown pass: the legacy-config lockfile inference kept a second, hand-maintained copy of the ecosystem lockfile names (`knownLockfiles`) beside the authoritative `ECOSYSTEMS` table. Adding an ecosystem to the table without editing the set compiled, linted, and passed tests — while legacy-config migration silently rendered an empty `lockfile:` for it.

What shipped: the set is now derived — `new Set(ECOSYSTEMS.flatMap(([key, e]) => [key, e.lockfile]))` — so the table is the single source of that fact. Behavior today is byte-identical (the pre-existing "legacy configs infer their lockfile" test still passes unchanged); only future drift is prevented.

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)