### PR TITLE
fix(cycle): redact remote userinfo that a [^/@] regex cannot cross

### DIFF
--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -827,8 +827,19 @@ export function detect(root) {
     if (remote) {
         // Remotes configured for CI or convenience routinely embed credentials
         // (https://x-access-token:ghp_…@host/repo.git); detect()'s output reaches the
-        // --plan stdout an agent reads, so only the credential-free URL travels.
-        out.remote = remote.replace(/\/\/[^/@]*@/, '//');
+        // --plan stdout an agent reads, so only the credential-free URL travels. A
+        // parseable URL is blanked field-by-field (lossless for credential-free
+        // remotes, and the only way to catch userinfo a `[^/@]` regex cannot cross);
+        // anything that fails to parse has no working host/authority to protect, so it
+        // gets the aggressive strip rather than a second leak.
+        try {
+            const u = new URL(remote);
+            u.username = '';
+            u.password = '';
+            out.remote = u.toString();
+        } catch {
+            out.remote = remote.replace(/\/\/[^@]+@/, '//');
+        }
         const m = /[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/.exec(remote);
         if (m) out.slug = `${m[1]}/${m[2]}`;
     }

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -230,6 +230,33 @@ describe('install --plan', () => {
         assert.equal(JSON.parse(out).detected.slug, 'brandon/demo', 'redaction must not cost the slug');
     });
 
+    test('a credentialed remote whose userinfo contains a slash still redacts', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        // WHATWG URL parsing cannot represent a raw "/" inside userinfo — the whole
+        // remote fails to parse — so this exercises the fallback strip, not the URL
+        // branch. A token that only reaches stdout unredacted through that gap.
+        execFileSync('git', ['remote', 'set-url', 'origin', 'https://x-access-token:ghp_SLASH/y9ZTOKEN@github.com/brandon/demo.git'], { cwd: dir, stdio: 'pipe' });
+
+        const out = cycle(dir, ['install', '--plan']);
+        assert.doesNotMatch(out, /ghp_SLASH/, 'the token must not reach plan stdout');
+        assert.doesNotMatch(out, /y9ZTOKEN/, 'neither may its second half');
+        assert.equal(JSON.parse(out).detected.remote, 'https://github.com/brandon/demo.git');
+        assert.equal(JSON.parse(out).detected.slug, 'brandon/demo', 'redaction must not cost the slug');
+    });
+
+    test('a percent-encoded credential rides the URL branch and still redacts', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        execFileSync('git', ['remote', 'set-url', 'origin', 'https://x-access-token:ghp_ENC%2Fx9@github.com/brandon/demo.git'], { cwd: dir, stdio: 'pipe' });
+
+        const out = cycle(dir, ['install', '--plan']);
+        assert.doesNotMatch(out, /ghp_ENC/, 'the encoded token must not reach plan stdout');
+        assert.doesNotMatch(out, /%2F/, 'not even encoded');
+        assert.equal(JSON.parse(out).detected.remote, 'https://github.com/brandon/demo.git');
+        assert.equal(JSON.parse(out).detected.slug, 'brandon/demo', 'redaction must not cost the slug');
+    });
+
     test('every question carries a reason, not just a default', () => {
         const dir = scratchRepo('github');
         dirs.push(dir);


### PR DESCRIPTION
Closes #76

## What shipped

`detect()` printed the origin remote to `install --plan` stdout with only a single regex standing between an embedded credential and agent context/session logs — and that regex (`//[^/@]*@`) structurally cannot cross a `/` inside userinfo. This closes the gap with two branches:

- **Parseable URL** → blank `username`/`password`, `toString()`. Lossless for credential-free remotes, and the only mechanism that catches percent-encoded credentials (`%2F`) as well.
- **Unparseable remote** (the headline case: WHATWG parsing rejects a raw `/` in userinfo outright) → aggressive strip (`//[^@]+@`). Safe to be greedy here precisely because the string already failed URL parsing — no valid host/authority exists to corrupt.

Slug derivation untouched; tests pin it for both new input classes.

## Review findings actioned

- **The issue's drafted fix failed its own acceptance criterion** (found in review, fixed): `new URL('https://u:tok/en@host/…')` throws, so the draft's catch-branch fell back to the old leaking regex for exactly the userinfo-slash class it existed to close. The fallback is now an authority-agnostic strip.
- Test coverage strengthened beyond the draft: token halves asserted separately, plus a second test proving the URL branch handles percent-encoded credentials.

## Noted, out of scope (pre-existing, unchanged)

- Query-string tokens (`https://host/o/r.git?token=…`) are not stripped — neither before nor after this diff.
- scp-form usernames (`user@host:repo.git`) print as-is; SSH transport doesn't take bearer tokens, so exposure is theoretical.

## Verification

- `npm test` — 149 pass / 0 fail (two new tests)
- `node bin/cycle.mjs check` — clean
- `node bin/cycle.mjs lint` — consistent

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)