### PR TITLE
fix(cycle): contain registry-name resolution inside the cycle home

### DIFF
--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -458,38 +458,25 @@ function loadConfig(root) {
     return readJsonc(p);
 }
 
-function loadBackend(name) {
-    const p = join(CYCLE_HOME, 'backends', `${name}.jsonc`);
+// Registry names arrive from tamperable sources (.cycle/config.jsonc, CLI flags) and are
+// interpolated into a path under CYCLE_HOME, so a name must resolve inside its registry
+// directory before anything is read from it — the same containment cmdEject enforces.
+function loadRegistry(dir, name, label) {
+    const base = join(CYCLE_HOME, dir);
+    const p = join(base, `${name}.jsonc`);
+    if (relative(base, p).startsWith('..')) {
+        fail(`"${name}" is not a ${label} registered in this cycle home`);
+    }
     if (!existsSync(p)) {
-        const have = readdirSync(join(CYCLE_HOME, 'backends'))
-            .filter((f) => f.endsWith('.jsonc'))
-            .map((f) => basename(f, '.jsonc'));
-        fail(`unknown backend "${name}"`, `available: ${have.join(', ')}`);
+        const have = readdirSync(base).filter((f) => f.endsWith('.jsonc')).map((f) => basename(f, '.jsonc'));
+        fail(`unknown ${label} "${name}"`, `available: ${have.join(', ')}`);
     }
     return readJsonc(p);
 }
 
-function loadProfile(name) {
-    const p = join(CYCLE_HOME, 'profiles', `${name}.jsonc`);
-    if (!existsSync(p)) {
-        const have = readdirSync(join(CYCLE_HOME, 'profiles'))
-            .filter((f) => f.endsWith('.jsonc'))
-            .map((f) => basename(f, '.jsonc'));
-        fail(`unknown profile "${name}"`, `available: ${have.join(', ')}`);
-    }
-    return readJsonc(p);
-}
-
-function loadHarness(name) {
-    const p = join(CYCLE_HOME, 'harnesses', `${name}.jsonc`);
-    if (!existsSync(p)) {
-        const have = readdirSync(join(CYCLE_HOME, 'harnesses'))
-            .filter((f) => f.endsWith('.jsonc'))
-            .map((f) => basename(f, '.jsonc'));
-        fail(`unknown harness "${name}"`, `available: ${have.join(', ')}`);
-    }
-    return readJsonc(p);
-}
+const loadBackend = (name) => loadRegistry('backends', name, 'backend');
+const loadProfile = (name) => loadRegistry('profiles', name, 'profile');
+const loadHarness = (name) => loadRegistry('harnesses', name, 'harness');
 
 // Which harness trees a render targets. Absent/empty means "just Claude Code" — every
 // config written before this field existed renders exactly as it always did.

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -10,7 +10,7 @@ import assert from 'node:assert/strict';
 import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { cpSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -1217,5 +1217,69 @@ describe('fast path & verification receipts (#24)', () => {
         const src = doctrine(dir);
         assert.match(src, /still performs tracker status, branch policy, §4's gates, and normal delivery safety/);
         assert.match(src, /compresses \*\*ceremony and duplicate reads\*\*, never the checks themselves/);
+    });
+});
+
+// #75: loadBackend/loadProfile/loadHarness interpolated a registry name straight into a
+// path under CYCLE_HOME. Names come from .cycle/config.jsonc and flags, so a tampered
+// config could aim that path anywhere on disk and feed the renderer an attacker-chosen
+// registry whose root/skills fields direct arbitrary writes. The planted file is invalid
+// JSONC with a marker: reading it AT ALL fails differently than refusing it, so the clean
+// refusal message plus an absent marker is proof of containment.
+describe('registry name containment (#75)', () => {
+    const MARKER = 'cycle-evil-registry-marker-75';
+    const evilBody = `{ "root": "${MARKER}", "skills": ["${MARKER}"],\n`;
+    let evilFile;
+
+    // The containment boundary is this checkout itself — CYCLE_HOME resolves from
+    // bin/cycle.mjs's location — so the name is computed as real relative-path
+    // arithmetic from each registry directory out to the planted file.
+    const evilNameFor = (registry) =>
+        relative(join(HERE, '..', registry), evilFile).replace(/\.jsonc$/, '');
+
+    before(() => {
+        const evilDir = mkdtempSync(join(tmpdir(), 'cycle-evil-registry-'));
+        dirs.push(evilDir);
+        evilFile = join(evilDir, 'pwn.jsonc');
+        writeFileSync(evilFile, evilBody);
+    });
+
+    test('--backend aimed outside the backends registry refuses instead of reading it', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        const r = cycleRaw(dir, ['install', '-y', '--backend', evilNameFor('backends')]);
+        assert.equal(r.status, 1);
+        assert.match(r.out, /is not a backend registered in this cycle home/);
+        assert.ok(!r.out.includes(MARKER), 'the planted marker must never surface');
+    });
+
+    test('--profile aimed outside the profiles registry refuses instead of reading it', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        const r = cycleRaw(dir, ['install', '-y', '--profile', evilNameFor('profiles')]);
+        assert.equal(r.status, 1);
+        assert.match(r.out, /is not a profile registered in this cycle home/);
+        assert.ok(!r.out.includes(MARKER), 'the planted marker must never surface');
+    });
+
+    test('a tampered config harnesses entry refuses instead of reading it', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+        cycle(dir, ['install', '-y', '--profile', 'lean', '--backend', 'github']);
+        const cfgPath = join(dir, '.cycle', 'config.jsonc');
+        const cfg = JSON.parse(
+            readFileSync(cfgPath, 'utf8').replace(/^\s*\/\/.*$/gm, '').replace(/,(\s*[}\]])/g, '$1'),
+        );
+        cfg.harnesses = [evilNameFor('harnesses')];
+        writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
+
+        const r = cycleRaw(dir, ['update']);
+        assert.equal(r.status, 1);
+        assert.match(r.out, /is not a harness registered in this cycle home/);
+        assert.ok(!r.out.includes(MARKER), 'the planted marker must never surface');
+    });
+
+    test('the planted file outside the cycle home is untouched throughout', () => {
+        assert.equal(readFileSync(evilFile, 'utf8'), evilBody);
     });
 });


### PR DESCRIPTION
Closes #75

## What shipped

`loadBackend`/`loadProfile`/`loadHarness` pasted their name argument straight into a path under `CYCLE_HOME`. A tampered `.cycle/config.jsonc` — or a `--profile`/`--backend` flag — naming `../../../../tmp/pwn` could load attacker-chosen JSONC from anywhere on disk, whose `root`/`skills[]` fields then direct arbitrary directory creation and file writes during render. The same threat #70 closed for `eject`'s argv; this is the structurally identical loader path it didn't cover.

The three loaders collapse into one `loadRegistry(dir, name, label)` that refuses any name resolving outside its registry directory *before reading anything*, then keeps today's unknown-name treatment verbatim. Pure tightening: every registered name resolves exactly as before.

## Review findings actioned

- The containment check deliberately runs **after** the `join`, not on the raw name: `join(base, '/abs/name.jsonc')` discards `base` entirely for an absolute second argument, so checking post-join catches absolute-name escapes a pre-check on the name string would miss.
- Tests prove **non-read**, not merely non-write: planted files are invalid JSONC with a marker, so an escape would fail as a parse error / leak the marker instead of the clean refusal each test asserts.

## Verification

- `npm test` — 151 pass / 0 fail (four new tests: one per loader surface + planted-file integrity)
- `node bin/cycle.mjs check` — clean
- `node bin/cycle.mjs lint` — consistent

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)