### PR TITLE
fix(patch): allow required companion files

### DIFF
--- a/.agents/skills/patch/SKILL.md
+++ b/.agents/skills/patch/SKILL.md
@@ -2,7 +2,7 @@
 name: patch
 description: Address /review findings on the uncommitted the-cycle diff. Reads the most-recent review output from context, triages (fix-now is the DEFAULT for any finding about this diff — P0/P1/bounded-P2; escalate to Brandon if it needs a decision or is too big), presents a fix plan, then patches inline — no agent spawn, the orchestrator already holds the diff + findings. Re-runs the gates after. Use after /review, before /done. Plan-first.
 ---
-<!-- cycle:rendered template=skills/patch.md.tmpl hash=21b0fc67d17f — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/patch.md.tmpl hash=28b51408acdc — managed by the-cycle; edit the template, not this file -->
 
 # /patch — address reviewer findings
 
@@ -30,7 +30,8 @@ stays in progress.
    open `finding` issues should trend to *empty* (§2). A fix that's genuinely too big to do
    in-cycle is an **escalation** (with Brandon's nod), not a silent defer.
 3. **Present the patch plan** (Fix-now / Escalate, each with
-   `file:line` + a fix sketch + the §4 gates) — a status update, not a gate (§5).
+   `file:line` + a fix sketch + any directly required companion file and why + the §4 gates) — a
+   status update, not a gate (§5).
 4. **Patch inline immediately** in the same turn, with Edit/Write — no "Apply?" wait, unless a
    finding needed escalation (§5). **No spawn**: the orchestrator's context already holds the diff
    and the findings; a subagent would re-derive both and get them subtly wrong. Add a `**Why:**`
@@ -49,7 +50,10 @@ stays in progress.
 
 ## Safety
 
-- Never patch a file the most-recent `/review` didn't flag — that's scope creep.
+- Never patch an unrelated file. A file not cited by the most-recent `/review` may be changed only
+  when it is directly required to resolve a cited finding (for example a regression test, fixture,
+  shared type, or generated artifact), and that additional file + reason must appear in the patch
+  plan before editing. This exception never permits opportunistic cleanup or new ideas.
 - Never silently downgrade a P0 to avoid escalation; if you think it's overblown, say so and let
   Brandon decide.
 - Don't run reviewers here — that's `/review`'s job.

--- a/.claude/skills/patch/SKILL.md
+++ b/.claude/skills/patch/SKILL.md
@@ -2,7 +2,7 @@
 name: patch
 description: Address /review findings on the uncommitted the-cycle diff. Reads the most-recent review output from context, triages (fix-now is the DEFAULT for any finding about this diff — P0/P1/bounded-P2; escalate to Brandon if it needs a decision or is too big), presents a fix plan, then patches inline — no agent spawn, the orchestrator already holds the diff + findings. Re-runs the gates after. Use after /review, before /done. Plan-first.
 ---
-<!-- cycle:rendered template=skills/patch.md.tmpl hash=69279047fb66 — managed by the-cycle; edit the template, not this file -->
+<!-- cycle:rendered template=skills/patch.md.tmpl hash=ecd39ccaafd3 — managed by the-cycle; edit the template, not this file -->
 
 # /patch — address reviewer findings
 
@@ -30,7 +30,8 @@ stays in progress.
    open `finding` issues should trend to *empty* (§2). A fix that's genuinely too big to do
    in-cycle is an **escalation** (with Brandon's nod), not a silent defer.
 3. **Present the patch plan** (Fix-now / Escalate, each with
-   `file:line` + a fix sketch + the §4 gates) — a status update, not a gate (§5).
+   `file:line` + a fix sketch + any directly required companion file and why + the §4 gates) — a
+   status update, not a gate (§5).
 4. **Patch inline immediately** in the same turn, with Edit/Write — no "Apply?" wait, unless a
    finding needed escalation (§5). **No spawn**: the orchestrator's context already holds the diff
    and the findings; a subagent would re-derive both and get them subtly wrong. Add a `**Why:**`
@@ -49,7 +50,10 @@ stays in progress.
 
 ## Safety
 
-- Never patch a file the most-recent `/review` didn't flag — that's scope creep.
+- Never patch an unrelated file. A file not cited by the most-recent `/review` may be changed only
+  when it is directly required to resolve a cited finding (for example a regression test, fixture,
+  shared type, or generated artifact), and that additional file + reason must appear in the patch
+  plan before editing. This exception never permits opportunistic cleanup or new ideas.
 - Never silently downgrade a P0 to avoid escalation; if you think it's overblown, say so and let
   Brandon decide.
 - Don't run reviewers here — that's `/review`'s job.

--- a/.cycle/state.json
+++ b/.cycle/state.json
@@ -1,11 +1,11 @@
 {
-  "upstream": "f3d29c5-dirty",
+  "upstream": "f232a94-dirty",
   "files": {
     ".claude/skills/DOCTRINE.md": "93cd41a26537",
     ".claude/skills/cycle/SKILL.md": "b1189a01a5f2",
     ".claude/skills/implement/SKILL.md": "cf203f5d5482",
     ".claude/skills/review/SKILL.md": "881cb15dba91",
-    ".claude/skills/patch/SKILL.md": "69279047fb66",
+    ".claude/skills/patch/SKILL.md": "ecd39ccaafd3",
     ".claude/skills/done/SKILL.md": "bb780a9b5880",
     ".claude/skills/next/SKILL.md": "0afc40565e46",
     ".claude/skills/intake/SKILL.md": "51a3e4a81229",
@@ -18,7 +18,7 @@
     ".agents/skills/cycle/SKILL.md": "b941afd3af57",
     ".agents/skills/implement/SKILL.md": "c9ea4d7d4f0f",
     ".agents/skills/review/SKILL.md": "056a46e2d908",
-    ".agents/skills/patch/SKILL.md": "21b0fc67d17f",
+    ".agents/skills/patch/SKILL.md": "28b51408acdc",
     ".agents/skills/done/SKILL.md": "e3a0f7b50cd6",
     ".agents/skills/next/SKILL.md": "f49c75d042fd",
     ".agents/skills/intake/SKILL.md": "737d2a8abe76",

--- a/templates/skills/patch.md.tmpl
+++ b/templates/skills/patch.md.tmpl
@@ -31,7 +31,8 @@ stays in progress.
    open `finding` issues should trend to *empty* (§2). A fix that's genuinely too big to do
    in-cycle is an **escalation** (with {{repo.human}}'s nod), not a silent defer.
 3. **Present the patch plan** (Fix-now / Escalate{{#if labels.backlog}} / Backlog{{/if}}, each with
-   `file:line` + a fix sketch + the §4 gates) — a status update, not a gate (§5).
+   `file:line` + a fix sketch + any directly required companion file and why + the §4 gates) — a
+   status update, not a gate (§5).
 4. **Patch inline immediately** in the same turn, with Edit/Write — no "Apply?" wait, unless a
    finding needed escalation (§5). **No spawn**: the orchestrator's context already holds the diff
    and the findings; a subagent would re-derive both and get them subtly wrong. Add a `**Why:**`
@@ -52,7 +53,10 @@ stays in progress.
 
 ## Safety
 
-- Never patch a file the most-recent `/review` didn't flag — that's scope creep.
+- Never patch an unrelated file. A file not cited by the most-recent `/review` may be changed only
+  when it is directly required to resolve a cited finding (for example a regression test, fixture,
+  shared type, or generated artifact), and that additional file + reason must appear in the patch
+  plan before editing. This exception never permits opportunistic cleanup or new ideas.
 - Never silently downgrade a P0 to avoid escalation; if you think it's overblown, say so and let
   {{repo.human}} decide.
 - Don't run reviewers here — that's `/review`'s job.

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -57,6 +57,7 @@ after(() => dirs.forEach((d) => rmSync(d, { recursive: true, force: true })));
 
 for (const backend of BACKENDS) {
     for (const profile of PROFILES) {
+        const profileConfig = registryEntry('profiles', profile);
         for (const harness of HARNESSES) {
             describe(`${profile} on ${backend} through ${harness.name}`, () => {
                 let dir;
@@ -82,7 +83,7 @@ for (const backend of BACKENDS) {
                 });
 
                 test('renders every skill in the profile', () => {
-                    const expected = registryEntry('profiles', profile).skills;
+                    const expected = profileConfig.skills;
                     assert.deepEqual(skills.sort(), [...expected].sort());
                     assert.ok(existsSync(join(skillRoot, 'DOCTRINE.md')));
                 });
@@ -98,6 +99,17 @@ for (const backend of BACKENDS) {
                         assert.match(text, /<!-- cycle:rendered /, `${s}: no provenance`);
                     }
                 });
+
+                if (profileConfig.skills.includes('patch')) {
+                    test('patch permits only justified companion files', () => {
+                        const patch = readFileSync(join(skillRoot, 'patch', harness.skill_file), 'utf8');
+                        assert.match(patch, /Never patch an unrelated file/);
+                        assert.match(patch, /may be changed only\s+when it is directly required to resolve a cited finding/);
+                        assert.match(patch, /additional file \+ reason must appear in the patch\s+plan before editing/);
+                        assert.match(patch, /exception never permits opportunistic cleanup or new ideas/);
+                        assert.match(patch, /any directly required companion file and why/);
+                    });
+                }
 
                 // A leftover {{…}} means a template referenced something config doesn't have
                 // and the engine let it through — the exact failure the loud-unresolved rule


### PR DESCRIPTION
## What shipped

- replace the cited-file-only patch restriction with a causality boundary
- permit regression tests, fixtures, shared types, generated artifacts, and other companions only when directly required by a cited finding
- require every extra file and its reason in the patch plan before editing
- keep opportunistic cleanup and new ideas explicitly out of scope
- render the rule into the Claude and Codex patch skills and prove it across every applicable profile and harness

## Review findings actioned

- scope the new render assertion to profiles that actually install patch, preserving future valid minimal profiles
- refresh against merged PR #95 and retain both independent matrix assertions

## Verification

- npm test (267 passed on current mainline)
- node bin/cycle.mjs lint
- node bin/cycle.mjs check
- git diff --check

Closes #92

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)