### PR TITLE
fix(eval): reject invalid JSONL event shapes

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -391,18 +391,30 @@ function evaluateAssertions(scenario, fixture, events) {
 export function parseExecEvents(text) {
     const events = [];
     const malformed = [];
+    const invalidEvents = [];
     for (const [index, line] of text.split('\n').entries()) {
         if (!line.trim()) continue;
-        try { events.push(JSON.parse(line)); }
+        try {
+            const event = JSON.parse(line);
+            if (!event || typeof event !== 'object' || Array.isArray(event) || typeof event.type !== 'string') {
+                invalidEvents.push(index + 1);
+                continue;
+            }
+            events.push(event);
+        }
         catch { malformed.push(index + 1); }
     }
     const completed = events.filter((event) => event.type === 'turn.completed').at(-1);
     const failed = events.find((event) => event.type === 'turn.failed' || event.type === 'error');
+    const validationErrors = [
+        malformed.length ? `malformed JSONL at line(s) ${malformed.join(', ')}` : null,
+        invalidEvents.length ? `invalid JSONL event at line(s) ${invalidEvents.join(', ')}` : null,
+    ].filter(Boolean);
     return {
         events,
         usage: completed?.usage ?? null,
-        invalid: malformed.length
-            ? `malformed JSONL at line(s) ${malformed.join(', ')}`
+        invalid: validationErrors.length
+            ? validationErrors.join('; ')
             : failed
                 ? `Codex emitted ${failed.type}`
                 : completed

--- a/test/eval.test.mjs
+++ b/test/eval.test.mjs
@@ -102,6 +102,28 @@ test('Codex JSONL parsing keeps usage and rejects malformed streams', () => {
 
     const malformed = parseExecEvents('{"type":"turn.started"}\nnot json\n');
     assert.equal(malformed.invalid, 'malformed JSONL at line(s) 2');
+
+    for (const input of ['null\n', '7\n', '[]\n', '{}\n']) {
+        const invalid = parseExecEvents(input);
+        assert.equal(invalid.invalid, 'invalid JSONL event at line(s) 1');
+        assert.deepEqual(invalid.events, []);
+    }
+
+    const mixed = parseExecEvents([
+        JSON.stringify({ type: 'turn.started' }),
+        'null',
+        JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 7, output_tokens: 3 } }),
+        '',
+    ].join('\n'));
+    assert.equal(mixed.invalid, 'invalid JSONL event at line(s) 2');
+    assert.deepEqual(mixed.usage, { input_tokens: 7, output_tokens: 3 });
+    assert.deepEqual(mixed.events.map((event) => event.type), ['turn.started', 'turn.completed']);
+
+    const mixedInvalid = parseExecEvents('null\nnot json\n');
+    assert.equal(
+        mixedInvalid.invalid,
+        'malformed JSONL at line(s) 2; invalid JSONL event at line(s) 1',
+    );
 });
 
 test('behavioral runner compares isolated snapshots without making a model call', { timeout: 120_000 }, () => {


### PR DESCRIPTION
Validates every parsed Codex JSONL value before downstream property access, rejects null/scalar/array/missing-type records without throwing, and preserves valid events plus usage from mixed streams.

The inline review found that mixed syntax and shape failures could hide one line set; that finding was patched so both diagnostics survive.

Verification:
- `npm test` — 269/269 passing
- `node bin/cycle.mjs lint` — clean
- `node bin/cycle.mjs check` — clean
- `git diff --check` — clean

Closes #103

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)