### PR TITLE
fix(eval): validate assertion schemas before execution

### DIFF
--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -159,6 +159,64 @@ function resolveSource(spec, sourceRoot, name) {
     return materializeRef(spec, join(sourceRoot, name));
 }
 
+const isNonEmptyString = (value) => typeof value === 'string' && Boolean(value.trim());
+const isStringArray = (value, { nonEmpty = false } = {}) =>
+    Array.isArray(value)
+    && (!nonEmpty || value.length > 0)
+    && value.every(isNonEmptyString);
+
+export function validateScenario(scenario) {
+    if (!scenario || typeof scenario !== 'object' || Array.isArray(scenario)) {
+        fail('evaluation scenario must be an object');
+    }
+    if (!isNonEmptyString(scenario.id) || !isNonEmptyString(scenario.prompt)
+        || !scenario.issue || !Array.isArray(scenario.assertions)) {
+        fail(`scenario ${scenario.id ?? '<unknown>'} is missing id, prompt, issue, or assertions`);
+    }
+
+    for (const [index, assertion] of scenario.assertions.entries()) {
+        const where = `scenario ${scenario.id} assertion[${index}]`;
+        if (!assertion || typeof assertion !== 'object' || Array.isArray(assertion)) {
+            fail(`${where} must be an object`);
+        }
+        const requirePath = () => {
+            if (!isNonEmptyString(assertion.path)) fail(`${where} requires a non-empty string path`);
+        };
+        const requireContains = () => {
+            if (!isNonEmptyString(assertion.contains)) fail(`${where} requires a non-empty string contains`);
+        };
+
+        switch (assertion.type) {
+            case 'file_equals':
+                requirePath();
+                if (typeof assertion.value !== 'string') fail(`${where} requires a string value`);
+                break;
+            case 'file_unchanged':
+            case 'path_unstaged':
+                requirePath();
+                break;
+            case 'changed_paths':
+                if (!isStringArray(assertion.value)) fail(`${where} requires a string-array value`);
+                break;
+            case 'command_succeeded':
+            case 'command_failed':
+            case 'command_absent':
+                requireContains();
+                break;
+            case 'commands_succeeded_in_order':
+                if (!isStringArray(assertion.value, { nonEmpty: true })) {
+                    fail(`${where} requires a non-empty string-array value`);
+                }
+                break;
+            case 'fixture_gate':
+                break;
+            default:
+                fail(`${where} has unknown type ${JSON.stringify(assertion.type)}`);
+        }
+    }
+    return scenario;
+}
+
 function loadScenarios(selected = []) {
     const wanted = new Set(selected);
     const scenarios = readdirSync(SCENARIOS)
@@ -169,11 +227,9 @@ function loadScenarios(selected = []) {
     if (!scenarios.length) fail('no evaluation scenarios selected');
     const ids = new Set();
     for (const scenario of scenarios) {
-        if (!scenario.id || ids.has(scenario.id)) fail(`invalid or duplicate scenario id: ${scenario.id}`);
+        validateScenario(scenario);
+        if (ids.has(scenario.id)) fail(`invalid or duplicate scenario id: ${scenario.id}`);
         ids.add(scenario.id);
-        if (!scenario.prompt || !scenario.issue || !Array.isArray(scenario.assertions)) {
-            fail(`scenario ${scenario.id} is missing prompt, issue, or assertions`);
-        }
     }
     if (wanted.size) {
         const missing = [...wanted].filter((id) => !ids.has(id));

--- a/test/eval.test.mjs
+++ b/test/eval.test.mjs
@@ -5,7 +5,7 @@ import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync }
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseExecEvents } from '../eval/run.mjs';
+import { parseExecEvents, validateScenario } from '../eval/run.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const RUNNER = join(ROOT, 'eval', 'run.mjs');
@@ -124,6 +124,38 @@ test('Codex JSONL parsing keeps usage and rejects malformed streams', () => {
         mixedInvalid.invalid,
         'malformed JSONL at line(s) 2; invalid JSONL event at line(s) 1',
     );
+});
+
+test('scenario assertion schemas fail during preflight with precise locations', () => {
+    const validAssertions = [
+        { type: 'file_equals', path: 'feature.txt', value: 'implemented\n' },
+        { type: 'file_unchanged', path: 'feature.txt' },
+        { type: 'path_unstaged', path: 'feature.txt' },
+        { type: 'changed_paths', value: [] },
+        { type: 'command_succeeded', contains: 'npm test' },
+        { type: 'command_failed', contains: 'gh issue view' },
+        { type: 'command_absent', contains: 'git push' },
+        { type: 'commands_succeeded_in_order', value: ['gh issue view', 'npm test'] },
+        { type: 'fixture_gate' },
+    ];
+    const scenario = { id: 'schema-test', prompt: '$implement #1', issue: {}, assertions: validAssertions };
+    assert.equal(validateScenario(scenario), scenario);
+
+    const invalidAssertions = [
+        [{ type: 'unknown' }, 'scenario schema-test assertion[0] has unknown type "unknown"'],
+        [{ type: 'file_equals', path: 'feature.txt' }, 'scenario schema-test assertion[0] requires a string value'],
+        [{ type: 'file_unchanged' }, 'scenario schema-test assertion[0] requires a non-empty string path'],
+        [{ type: 'changed_paths', value: ['ok', 7] }, 'scenario schema-test assertion[0] requires a string-array value'],
+        [{ type: 'command_succeeded', contains: '' }, 'scenario schema-test assertion[0] requires a non-empty string contains'],
+        [{ type: 'commands_succeeded_in_order', value: [] }, 'scenario schema-test assertion[0] requires a non-empty string-array value'],
+        [null, 'scenario schema-test assertion[0] must be an object'],
+    ];
+    for (const [assertion, message] of invalidAssertions) {
+        assert.throws(
+            () => validateScenario({ ...scenario, assertions: [assertion] }),
+            (error) => error.message === message,
+        );
+    }
 });
 
 test('behavioral runner compares isolated snapshots without making a model call', { timeout: 120_000 }, () => {


### PR DESCRIPTION
Adds a pure scenario preflight validator covering every implemented assertion type and reports the scenario ID plus assertion index for malformed inputs. Validation now runs while scenarios load, before Codex version discovery or model execution.

Review found no unresolved issues.

Verification:
- `npm test` — 270/270 passing
- `node bin/cycle.mjs lint` — clean
- `node bin/cycle.mjs check` — clean
- `git diff --check` — clean

Closes #104

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)