### PR TITLE
docs(setup): remove retired backend-shim promise

### DIFF
--- a/skills/cycle-setup/SKILL.md
+++ b/skills/cycle-setup/SKILL.md
@@ -99,7 +99,7 @@ invent, and say which you skipped and why.
 ## 5. Render and verify
 
 ```sh
-cycle update                  # renders skills + backend shims from the config
+cycle update                  # renders every configured harness skill tree
 cycle check                   # must report clean
 ```
 


### PR DESCRIPTION
## Summary

Update the setup skill command comment to describe the current exhaustive harness-tree renderer instead of promising retired backend shims.

Closes #105

## Verification

- npm test
- node bin/cycle.mjs lint
- node bin/cycle.mjs check
- git diff --check

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)