### PR TITLE
docs: align extension guidance with render matrix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,10 @@ cycle lint                                  # internal consistency: §N citation
 ```
 
 `cycle lint` and `npm test` catch different things — lint checks that the pieces still refer to each
-other correctly (a renamed `§N`, a verb no backend binds, a template in no profile); the test
-suite proves every template actually *renders* (every profile × backend combination, plus
-multi-harness suites covering a second harness, frontmatter, idempotency). Run both before considering template work done.
+other correctly (a renamed `§N`, a verb no backend binds, a template in no profile); the test suite
+discovers every profile, backend, and harness registry entry and proves every template actually
+*renders* across their exhaustive product. Specialized multi-harness-coexistence suites cover
+frontmatter and idempotency. Run both before considering template work done.
 
 Debug/inspection commands (not part of the normal edit loop, but useful when tracing a render):
 
@@ -66,7 +67,7 @@ Three axes of variation, each pulled out of the templates into its own binding l
 - **`backends/*.jsonc`** — tracker verb → command bindings (GitHub today; the shape supports
   more). Skills call verbs like `{{@issue_view "$1"}}`, never a literal tracker command.
   Vocabulary: `docs/BACKENDS.md`.
-- **`harnesses/*.jsonc`** — which AI coding tool runs the rendered skills (Claude Code / Codex),
+- **`harnesses/*.jsonc`** — which AI coding tool runs each rendered skill tree,
   behind `{{harness.*}}` fields (discovery path, tool names, capability flags). A config's
   `harnesses: [...]` array renders one complete, independent skill tree per harness. Vocabulary:
   `docs/HARNESSES.md`.

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ picks one or more; `cycle update` renders a complete, independent skill tree per
 | structured questions | `AskUserQuestion` | direct chat | `ask_user` | `question` | plain chat |
 | parallel subagents | the Agent tool | subagents | task tool | task tool | none by design |
 
-Full vocabulary, the honesty rule around capability flags, and how to add a third harness:
+Full vocabulary, the honesty rule around capability flags, and how to add a harness:
 `docs/HARNESSES.md`.
 
 ## Layout
@@ -191,7 +191,7 @@ templates/
 backends/*.jsonc       verb → command tables
 harnesses/*.jsonc      discovery path, tool names, capability flags per AI harness
 profiles/*.jsonc       which skills each profile installs
-test/                  node --test; renders every profile × backend, plus multi-harness suites
+test/                  node --test; registry-driven profile × backend × harness matrix + coexistence
 docs/
   AUTHORING.md         writing a template; the overlay points
   BACKENDS.md          the verb vocabulary; adding a backend

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -155,9 +155,9 @@ is a deliberate change to those two checks first — not something that can happ
 5. **Bind it to commands, not to an executable.** A verb may not name a `scripts/` path — nothing
    installs one. If the tracker's API is too awkward to drive from a verb string, that's a design
    conversation, not a helper you add quietly; see "No installed executables" above.
-6. `npm test` renders every profile against every backend listed in `test/render.test.mjs`'s
-   `BACKENDS` array — add yours there (and its remote to `REMOTES`) — and checks that the render is
-   prose only.
+6. `npm test` discovers every JSONC entry in the profile, backend, and harness registries and
+   renders their full product. Adding the backend registry file automatically puts it in that
+   exhaustive baseline, which also checks that the render is prose only.
 
 ## Migrating off a backend (history)
 

--- a/docs/HARNESSES.md
+++ b/docs/HARNESSES.md
@@ -103,9 +103,10 @@ implementation time — these move, and a stale path here is worse than no harne
 5. `cycle lint` — catches a filename/`name` mismatch, a missing required field, and two harnesses
    sharing a `root` (which would let one silently overwrite the other's tree if both were ever
    configured together).
-6. `npm test` renders every profile against every backend **and** a second harness in the
-   multi-harness suite (`test/render.test.mjs`), and checks frontmatter, provenance, idempotency,
-   and that harness-conditional prose actually differs between trees.
+6. `npm test` discovers every JSONC entry in the profile, backend, and harness registries, so adding
+   the harness registry file automatically puts it in the exhaustive profile × backend × harness
+   render baseline. Specialized multi-harness-coexistence suites also check frontmatter,
+   provenance, idempotency, and that harness-conditional prose actually differs between trees.
 7. The acceptance bar is behavioral (`docs/PATTERNS.md`'s spirit): render into a real repo and run
    a session **in that harness** through a full `/cycle` on a live issue, merge guard included,
    before calling the harness supported.


### PR DESCRIPTION
## Summary

Align backend, harness, contributor, and layout guidance with the registry-driven exhaustive profile × backend × harness render matrix. Preserve the separate multi-harness coexistence and live behavioral checks.

Closes #106

## Verification

- obsolete-guidance rg acceptance search
- npm test (270 passing)
- node bin/cycle.mjs lint
- node bin/cycle.mjs check
- git diff --check

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)