### PR TITLE
fix(cli): make ANSI styling stream-aware

### DIFF
--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -31,21 +31,37 @@ const CYCLE_HOME = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 // output
 // ---------------------------------------------------------------------------
 
-const supportsColor = process.stdout.isTTY && process.env.NO_COLOR === undefined;
 // util.styleText arrived after the initial Node 20 release. Keep the declared
 // >=20 floor honest instead of crashing during module evaluation on early 20.x.
-const paint = (style, s) => (supportsColor && nodeUtil.styleText ? nodeUtil.styleText(style, s) : s);
-const bold = (s) => paint('bold', s);
-const dim = (s) => paint('dim', s);
-const red = (s) => paint('red', s);
-const green = (s) => paint('green', s);
-const yellow = (s) => paint('yellow', s);
-const cyan = (s) => paint('cyan', s);
+const stylesFor = (stream) => {
+    const supportsColor = stream.isTTY && process.env.NO_COLOR === undefined;
+    const paint = (style, s) => (
+        supportsColor && nodeUtil.styleText
+            ? nodeUtil.styleText(style, s, { stream })
+            : s
+    );
+    return {
+        bold: (s) => paint('bold', s),
+        dim: (s) => paint('dim', s),
+        red: (s) => paint('red', s),
+        green: (s) => paint('green', s),
+        yellow: (s) => paint('yellow', s),
+        cyan: (s) => paint('cyan', s),
+    };
+};
 
-class CycleError extends Error {}
+const { bold, dim, red, green, yellow, cyan } = stylesFor(process.stdout);
+const { dim: stderrDim, red: stderrRed } = stylesFor(process.stderr);
+
+class CycleError extends Error {
+    constructor(message, hint) {
+        super(message);
+        this.hint = hint;
+    }
+}
 
 const fail = (msg, hint) => {
-    throw new CycleError(hint ? `${msg}\n  ${dim(hint)}` : msg);
+    throw new CycleError(msg, hint);
 };
 
 // ---------------------------------------------------------------------------
@@ -435,7 +451,7 @@ function git(args, cwd = process.cwd()) {
         return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
     } catch (e) {
         const msg = e.stderr?.toString?.().trim() ?? '';
-        if (msg) console.error(dim(`git ${args.join(' ')} failed: ${msg}`));
+        if (msg) console.error(stderrDim(`git ${args.join(' ')} failed: ${msg}`));
         return '';
     }
 }
@@ -1627,15 +1643,16 @@ function invokedDirectly() {
 if (invokedDirectly()) {
     main().catch((e) => {
         if (e instanceof CycleError) {
-            console.error(`${red('✗')} ${e.message}`);
+            console.error(`${stderrRed('✗')} ${e.message}`);
+            if (e.hint) console.error(stderrDim(`  ${e.hint}`));
             process.exit(1);
         }
         // parseArgs (strict mode) throws a bare TypeError with an ERR_PARSE_ARGS code on a
         // typo'd flag — same class of user mistake as the `default:` arm above, so it gets
         // the same clean treatment instead of an internal stack trace.
         if (typeof e?.code === 'string' && e.code.startsWith('ERR_PARSE_ARGS')) {
-            console.error(`${red('✗')} ${e.message}`);
-            console.error(dim('  run `cycle --help` for usage'));
+            console.error(`${stderrRed('✗')} ${e.message}`);
+            console.error(stderrDim('  run `cycle --help` for usage'));
             process.exit(1);
         }
         console.error(e.stack ?? String(e));

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -12,7 +12,8 @@ import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { cpSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, relative } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import * as nodeUtil from 'node:util';
 import { readJsonc } from '../bin/cycle.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -51,6 +52,24 @@ const cycleRaw = (dir, args) => {
     });
     return { status: r.status, out: `${r.stdout ?? ''}${r.stderr ?? ''}` };
 };
+
+function cycleWithTtys(dir, args, { stdoutTTY, stderrTTY, noColor = false }) {
+    const env = { ...process.env };
+    delete env.NO_COLOR;
+    delete env.NODE_DISABLE_COLORS;
+    delete env.FORCE_COLOR;
+    if (noColor) env.NO_COLOR = '1';
+
+    const launcher = `
+        Object.defineProperty(process.stdout, 'isTTY', { value: ${stdoutTTY} });
+        Object.defineProperty(process.stderr, 'isTTY', { value: ${stderrTTY} });
+        process.argv = [process.execPath, ${JSON.stringify(CLI)}, ...${JSON.stringify(args)}];
+        await import(${JSON.stringify(pathToFileURL(CLI).href)});
+    `;
+    return spawnSync(process.execPath, ['--input-type=module', '--eval', launcher], {
+        cwd: dir, encoding: 'utf8', env,
+    });
+}
 
 const dirs = [];
 after(() => dirs.forEach((d) => rmSync(d, { recursive: true, force: true })));
@@ -405,6 +424,50 @@ describe('unknown flag vs error treatment (#78)', () => {
         assert.match(r.stderr, /✗.*[Uu]nknown option/);
         assert.match(r.stderr, /cycle --help/);
         assert.doesNotMatch(r.stderr, /^\s+at /m, 'no internal stack trace');
+    });
+});
+
+// #107: color support belongs to the stream receiving the text. A stdout-only
+// decision leaked SGR escapes into redirected stderr when stdout was a TTY.
+describe('stream-aware CLI color (#107)', () => {
+    test('redirected stderr stays plain when stdout is a TTY', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+
+        const r = cycleWithTtys(dir, ['unknown'], { stdoutTTY: true, stderrTTY: false });
+        assert.equal(r.status, 1);
+        assert.doesNotMatch(r.stderr, /\x1b\[/);
+        assert.match(r.stderr, /unknown command/);
+    });
+
+    test('redirected stdout stays plain when stderr is a TTY', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+
+        const r = cycleWithTtys(dir, ['--help'], { stdoutTTY: false, stderrTTY: true });
+        assert.equal(r.status, 0);
+        assert.doesNotMatch(r.stdout, /\x1b\[/);
+        assert.match(r.stdout, /cycle install/);
+    });
+
+    test('TTY destinations can still be styled', { skip: !nodeUtil.styleText }, () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+
+        const stdout = cycleWithTtys(dir, ['--help'], { stdoutTTY: true, stderrTTY: false });
+        const stderr = cycleWithTtys(dir, ['unknown'], { stdoutTTY: false, stderrTTY: true });
+        assert.match(stdout.stdout, /\x1b\[/);
+        assert.match(stderr.stderr, /\x1b\[/);
+    });
+
+    test('NO_COLOR disables styling on both TTY destinations', () => {
+        const dir = scratchRepo('github');
+        dirs.push(dir);
+
+        const stdout = cycleWithTtys(dir, ['--help'], { stdoutTTY: true, stderrTTY: true, noColor: true });
+        const stderr = cycleWithTtys(dir, ['unknown'], { stdoutTTY: true, stderrTTY: true, noColor: true });
+        assert.doesNotMatch(stdout.stdout, /\x1b\[/);
+        assert.doesNotMatch(stderr.stderr, /\x1b\[/);
     });
 });
 


### PR DESCRIPTION
## Summary

Bind ANSI styling to the stream that receives each message so redirected stdout and stderr remain plain independently. Keep CycleError hints unstyled until stderr rendering and preserve the Node 20 fallback when util.styleText is unavailable.

Closes #107

## Verification

- targeted split-stream CLI tests
- npm test (274 passing)
- node bin/cycle.mjs lint
- node bin/cycle.mjs check
- git diff --check

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)