### PR TITLE
docs(readme): separate public and operational guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,8 +88,8 @@ divergence — `cycle lint`'s inlining check exists specifically to catch it.
 body). `cycle check` reports *local drift* (hand-edited after rendering) and *upstream drift* (the
 template moved on since this copy rendered) as independent axes.
 
-Layout reference (what lives where) is in `README.md`'s Layout section — not duplicated here since
-it goes stale independently of this file.
+The source-tree layout is in `docs/DEVELOPMENT.md` — not duplicated here since it goes stale
+independently of this file.
 
 ## Adding or changing a template
 

--- a/README.md
+++ b/README.md
@@ -1,147 +1,64 @@
 # the-cycle
 
-An installable, self-updating work pipeline for AI coding harnesses — Claude Code, Codex CLI, Copilot CLI, OpenCode and Pi (`docs/HARNESSES.md`).
+An installable, self-updating work pipeline for AI coding harnesses — Claude Code, Codex CLI,
+Copilot CLI, OpenCode, and Pi.
 
-`the-cycle` renders a set of skills — `/cycle`, `/implement`, `/review`, `/patch`, `/done` and a
-maintenance layer around them — into any repo, adapted to that repo's gates, tracker, and risk
-surfaces. Improvements made here propagate outward with `cycle update`, and `cycle check` reports
-when a copy has drifted.
+`the-cycle` renders a set of skills — `/cycle`, `/implement`, `/review`, `/patch`, `/done`, and a
+maintenance layer around them — into any repository, adapted to that repository's gates, tracker,
+and risk surfaces. Improvements made here propagate outward with `cycle update`, and `cycle check`
+reports when an installed copy has drifted.
 
 ## Why this exists
 
-The same pipeline was copy-pasted into three repos and diverged in all three — hand-carried fixes
-usually didn't make it to the other copies, so bugs (and a stale hardcoded model name) sat fixed in
-one repo and broken in the others. The divergence wasn't the problem; **silent** divergence was. So
-the two features that matter most here are `cycle update` (propagate) and `cycle check` (make drift
-visible).
+The same pipeline was copy-pasted into three repositories and diverged in all three. Hand-carried
+fixes usually did not reach the other copies, so bugs and stale assumptions remained fixed in one
+place and broken in another. The divergence was not the problem; **silent** divergence was.
 
-## The design
+The two features that matter most are therefore:
 
-Every repo-specific value lives in one generated binding file, and skill templates become fully
-portable:
+- `cycle update` propagates reviewed pipeline improvements.
+- `cycle check` makes local and upstream drift visible.
 
-- **Backends** (`backends/*.jsonc`) bind tracker verbs — skills call `{{@issue_view "$1"}}`, never a
-  literal tracker command. `docs/BACKENDS.md`.
-- **Harnesses** (`harnesses/*.jsonc`) bind which AI tool runs the skills, behind `{{harness.*}}`
-  fields. `docs/HARNESSES.md`.
-- **Overlays** (`.cycle/overlays/*.md`) hold the irreducibly repo-specific blocks a template can't
-  generalize away — a reviewer routing table, scout lens bodies — injected at named points. A
-  missing required overlay fails the render loudly rather than shipping a skill with a hole in it.
-- **Drift detection**: every rendered file carries a provenance comment. `cycle check` reports
-  *local drift* (hand-edited since rendering) and *upstream drift* (the template moved on)
-  independently.
+## How it works
 
-Full rationale for all of the above: `docs/AUTHORING.md`.
+Every repository-specific value lives in a generated binding file, leaving the shared skill
+templates portable:
 
-## Install
+- **Backends** bind tracker operations such as issue reads and PR creation. GitHub is the backend
+  available today. See [Backends](docs/BACKENDS.md).
+- **Harnesses** describe which coding tool runs the skills and where that tool discovers them. See
+  [Harnesses](docs/HARNESSES.md).
+- **Overlays** hold the irreducibly repository-specific guidance a template cannot generalize,
+  such as reviewer routing and scout lenses. See [Authoring](docs/AUTHORING.md).
+- **Drift detection** records provenance in every rendered file. `cycle check` distinguishes a
+  locally edited render from a render whose source template has moved upstream.
 
-Bootstrap, no clone required:
+## Quick start
+
+Run the guided installer from the repository you want to configure:
 
 ```sh
-# runs the interview and renders into the current repo
 npx --yes @brndnsh/the-cycle install
 ```
 
-npx is for a one-off first render from npm — the fetched copy lives in npx's ephemeral cache, so
-`cycle update` / `cycle check` and the personal `/cycle-setup` skill need the durable clone below.
-`--yes` accepts npx's package-download prompt. `cycle install`'s own output says as much when it
-ran this way.
+That command performs a one-off first render without requiring a clone. The rendered skills keep
+working, but `cycle update`, `cycle check`, and the personal `/cycle-setup` skill require a durable
+installation.
 
-For everyday use:
-
-```sh
-git clone https://github.com/brndnsh-labs/the-cycle ~/code/the-cycle
-~/code/the-cycle/install.sh          # symlinks bin/cycle → ~/.local/bin
-```
-
-`github.com/brndnsh-labs/the-cycle` is canonical — issues, PRs and CI all happen there.
-`git.brndn.zip/brandon/the-cycle` is a read-only pull mirror of it, kept in sync
-automatically, for machines that would rather not reach GitHub.
-
-Don't push to the Forgejo mirror directly — the next sync from GitHub overwrites it.
-
-`install.sh` also links `/cycle-setup` into your personal skills directory (`~/.claude/skills`, `~/.agents/skills`, `~/.github/skills`, `~/.opencode/skills`, or `~/.pi/skills`) as a personal
-skill — it has to work in a repo that doesn't have the-cycle yet.
-
-### Ask a coding agent to install it
-
-Give an agent this prompt when you want it to bootstrap the durable install and set up the
-repository it is already working in:
-
-> Install the-cycle for durable use, then set it up in this repository. Verify Node ≥20, git, and
-> bash first; `gh` must be authenticated before tracker operations. Before cloning or changing
-> anything under my home directory, show me the paths and ask for approval. Once approved, clone
-> `https://github.com/brndnsh-labs/the-cycle` to `~/code/the-cycle` (or inspect the existing clone),
-> run `~/code/the-cycle/install.sh`, make sure `~/.local/bin` is on `PATH` as the installer directs,
-> and verify `cycle --version`. Restart or reload the coding harness if it does not discover the
-> newly linked personal skill. Then run `/cycle-setup` in this repository and follow it; do not
-> hand-edit generated harness skill trees.
-
-Then, in a repo:
+After a durable installation, the everyday commands are:
 
 ```sh
-/cycle-setup                         # guided: reads the repo, then writes config + overlays
+/cycle-setup                         # inspect this repository and guide its first setup
+cycle check                          # report local or upstream drift
+cycle update                         # re-render and show the resulting diff
 ```
 
-or drive it by hand:
-
-```sh
-cycle install --profile lean         # interview → .cycle/config.jsonc → render
-cycle check                          # drift report; non-zero exit on drift
-cycle update                         # re-render, show the diff
-```
-
-`cycle install` can detect a repo's name, remote, and gate commands, but not what breaks it
-irreversibly or what "ready" means there — so setup is guided rather than defaulted:
-`cycle install --plan` emits every open question and overlay point, and `/cycle-setup` reads the
-codebase to answer what it can, asking only the rest.
-
-When working on the-cycle itself:
-
-```sh
-cycle lint                           # §N citations, verb bindings, overlay docs,
-npm test                             # profiles, cross-skill refs
-```
-
-## Behavioral evaluation
-
-From a clone of this repository, the deterministic gates prove that skills render and remain
-internally consistent; they cannot prove that a workflow instruction changes agent behavior. The
-on-demand evaluator compares a baseline the-cycle snapshot with a candidate while holding the
-fixture, task, model, permissions,
-gates and assertions constant:
-
-```sh
-node eval/run.mjs \
-  --baseline HEAD \
-  --candidate . \
-  --model MODEL_ID \
-  --output /tmp/cycle-eval-run
-```
-
-`HEAD` is a git ref in this repository; `.` may include uncommitted template work. Each arm is
-rendered into its own physical repository and uses a local `gh` double, so the scenarios do not
-write to GitHub. Codex itself must already be authenticated through its `CODEX_HOME` login;
-ambient credential variables are not forwarded. The runner uses
-[`codex exec --json`](https://developers.openai.com/codex/noninteractive) and records the event
-stream (including tracker and gate commands), token usage when Codex reports it, final diff,
-source/skill/fixture hashes, and deterministic assertions in the requested output directory. It
-does not copy authentication into the fixtures: the Codex launcher retains its existing auth,
-while model-generated commands receive a core-only environment, an empty evaluation home, no
-network access, and no approval path out of the workspace sandbox.
-
-Start with the default single matched run. If the arms differ, or the result will justify a
-meaningful instruction change, add `--repeat 3` to repeat both arms. `--scenario <id>` narrows the
-run to one targeted behavior.
-
-Model-backed runs are externally metered and intentionally absent from `npm test` and CI. Ordinary
-tests exercise fixture isolation, the tracker double, JSONL parsing, assertions, and result
-formatting with a fake Codex executable. A behavioral FAIL is evidence in `results.jsonl`, not a
-merge-gate exit code; invalid runner or harness execution exits 2.
+See [Installing the-cycle](docs/INSTALLING.md) for the durable install, the manual setup path, and
+a prompt you can hand to a coding agent.
 
 ## Profiles
 
-Machinery is opt-in — a repo takes on a lane when it earns it.
+Machinery is opt-in: a repository takes on a lane when it earns it.
 
 | Profile | Skills |
 | --- | --- |
@@ -151,66 +68,41 @@ Machinery is opt-in — a repo takes on a lane when it earns it.
 
 ## Backends
 
-The tracker sits behind one verb vocabulary (`issue view`, `pr create`, `merge-guard`, …), bound
-today by `backends/github.jsonc` — GitHub issues and labels, nothing else. Status is a `status:*`
-label on the issue, so "the board" is just the open issue list. Swapping (or adding) a tracker is
-authoring one more `backends/*.jsonc` file, not touching a skill: `docs/BACKENDS.md` has the verb
-table, the semantic flags a backend must set honestly (`auto_merge`, …), and the contract a new
-one has to satisfy — including that a render is prose only, with no executable installed into the
-consuming repo.
+The tracker sits behind a verb vocabulary (`issue view`, `pr create`, `merge guard`, and so on).
+GitHub issues and labels are the only bound tracker today. Status is a `status:*` label on the
+issue, so the open issue list is the board.
+
+Adding another tracker means implementing the backend contract, not rewriting every skill. The
+complete vocabulary and its required semantics are documented in [Backends](docs/BACKENDS.md).
 
 ## Harnesses
 
-Which AI coding tool runs the rendered skills sits behind `{{harness.*}}` fields, the same way the
-tracker sits behind backend verbs. `.cycle/config.jsonc`'s `harnesses` array (default `["claude"]`)
-picks one or more; `cycle update` renders a complete, independent skill tree per harness.
+The configured harnesses each receive a complete, independent skill tree.
 
 | | Claude Code | Codex CLI | Copilot CLI | OpenCode | Pi |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- |
 | skills discovered at | `.claude/skills/<name>/SKILL.md` | `.agents/skills/<name>/SKILL.md` | `.github/skills/<name>/SKILL.md` | `.opencode/skills/<name>/SKILL.md` | `.pi/skills/<name>/SKILL.md` |
 | structured questions | `AskUserQuestion` | direct chat | `ask_user` | `question` | plain chat |
-| parallel subagents | the Agent tool | subagents | task tool | task tool | none by design |
+| parallel subagents | Agent tool | subagents | task tool | task tool | none by design |
 
-Full vocabulary, the honesty rule around capability flags, and how to add a harness:
-`docs/HARNESSES.md`.
-
-## Layout
-
-```
-.github/workflows/ci.yml    `npm test` + `cycle check` on PR + push to main
-AGENTS.md               cross-harness repository entry point
-bin/
-  cycle.mjs            the CLI — Node ESM, zero dependencies (plus lazily-imported lint.mjs)
-install.sh             symlink bin/cycle onto PATH
-skills/
-  cycle-setup/         guided install — personal skill, linked by install.sh
-templates/
-  DOCTRINE.md.tmpl     the §1–§10 spine
-  skills/*.md.tmpl     one per skill
-  overlays.jsonc       the overlay points, and what each is for
-backends/*.jsonc       verb → command tables
-harnesses/*.jsonc      discovery path, tool names, capability flags per AI harness
-profiles/*.jsonc       which skills each profile installs
-test/                  node --test; registry-driven profile × backend × harness matrix + coexistence
-docs/
-  AUTHORING.md         writing a template; the overlay points
-  BACKENDS.md          the verb vocabulary; adding a backend
-  HARNESSES.md         the harness.* vocabulary; adding a harness
-  PATTERNS.md          reviewer-agent skeleton, hooks, permissions
-  RELEASING.md         package boundary, preflight, and explicit publish gate
-```
+See [Harnesses](docs/HARNESSES.md) for the capability contract and instructions for adding a
+harness.
 
 ## Requirements
 
-Node ≥ 20, git, and bash for `install.sh`. No dependencies, no build step. `gh` must be
-authenticated for tracker operations; rendering, linting, and drift checks work offline.
+Node.js 20 or newer, git, and bash for the durable installer. The CLI has no runtime dependencies
+and no build step. `gh` must be authenticated for tracker operations; rendering, linting, and
+drift checks work offline.
 
-## Adopting an existing repo
+## Documentation
 
-There used to be a `cycle adopt` command (and a `/cycle-adopt` skill) that reverse-engineered a
-hand-written pipeline into config + overlays. It did its job: every legacy repo has converged onto
-the shared templates, so the command was retired rather than maintained against a queue of zero.
-If a hand-rolled pipeline ever needs converting again, resurrect it from git history
-(`git log --diff-filter=D -- bin/adopt.mjs`) — or do it by hand: extract the repo facts into
-`.cycle/config.jsonc`, move the irreducibly repo-specific prose into overlays, and diff each
-skill against its rendered replacement before letting `cycle update` overwrite it.
+- [Installing](docs/INSTALLING.md) — bootstrap, durable installation, agent-assisted setup, and
+  existing-pipeline reconciliation.
+- [Development](docs/DEVELOPMENT.md) — local gates, generated-source rules, and repository layout.
+- [Behavioral evaluation](docs/EVALUATION.md) — compare model behavior against two pipeline
+  revisions in isolated fixtures.
+- [Authoring](docs/AUTHORING.md) — write templates and overlays and propagate their changes.
+- [Backends](docs/BACKENDS.md) — tracker verbs and backend semantics.
+- [Harnesses](docs/HARNESSES.md) — harness fields, capabilities, and discovery paths.
+- [Patterns](docs/PATTERNS.md) — reviewer-agent, hook, and scoped-instruction patterns.
+- [Releasing](docs/RELEASING.md) — package boundaries, preflight, and the explicit publish gate.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,67 @@
+# Developing the-cycle
+
+The repository dogfoods its own generated pipeline. Pipeline prose and bindings belong in
+templates, config, overlays, backend definitions, or harness definitions; CLI, evaluator, tests,
+and documentation stay in their corresponding source directories. `.claude/skills/**` and
+`.agents/skills/**` are rendered output and must not be hand-edited.
+
+See [`CLAUDE.md`](../CLAUDE.md) for the detailed cross-harness repository guidance and
+[`AUTHORING.md`](AUTHORING.md) for template and overlay rules.
+
+## Local gates
+
+Run all three before considering repository work complete:
+
+```sh
+node bin/cycle.mjs lint
+npm test
+node bin/cycle.mjs check
+```
+
+The gates cover different contracts: lint checks references and bindings, tests exercise the
+profile × backend × harness render matrix, and check proves this repository's generated copy still
+matches its sources.
+
+Tests create temporary git repositories and spawn child processes. If a restricted sandbox rejects
+those operations with `EPERM`, rerun the same gate in an environment that permits them; do not
+weaken or skip the test.
+
+Useful read-only render diagnostics are:
+
+```sh
+node bin/cycle.mjs render [filter]
+node bin/cycle.mjs update --dry-run
+```
+
+## Repository layout
+
+```text
+.github/workflows/ci.yml    npm test + cycle check on pull requests and pushes to main
+AGENTS.md                   cross-harness repository entry point
+bin/
+  cycle.mjs                 CLI; Node ESM with zero dependencies plus lazy lint.mjs import
+install.sh                  links bin/cycle onto PATH and installs the personal setup skill
+skills/
+  cycle-setup/              guided setup skill linked by install.sh
+templates/
+  DOCTRINE.md.tmpl          shared rule spine
+  skills/*.md.tmpl          one source template per generated skill
+  overlays.jsonc            overlay registry and contracts
+backends/*.jsonc            tracker verb bindings
+harnesses/*.jsonc           discovery paths, tool names, and capability flags
+profiles/*.jsonc            skills installed by each profile
+eval/                       isolated behavioral comparison runner and fixtures
+test/                       exhaustive render, coexistence, CLI, and package tests
+docs/
+  AUTHORING.md              template and overlay authoring
+  BACKENDS.md               tracker vocabulary and backend implementation
+  DEVELOPMENT.md            local gates and this layout
+  EVALUATION.md             behavioral comparison procedure
+  HARNESSES.md              harness vocabulary and implementation
+  INSTALLING.md             bootstrap and durable setup paths
+  PATTERNS.md               reviewer, hook, and scoped-instruction patterns
+  RELEASING.md              package preflight and explicit publish gate
+```
+
+Publishing is a separate external action. Follow [`RELEASING.md`](RELEASING.md); a merged pull
+request never authorizes `npm publish`.

--- a/docs/EVALUATION.md
+++ b/docs/EVALUATION.md
@@ -1,0 +1,38 @@
+# Behavioral evaluation
+
+The deterministic repository gates prove that skills render and remain internally consistent.
+They cannot prove that a workflow instruction changes agent behavior. The on-demand evaluator
+compares a baseline the-cycle snapshot with a candidate while holding the fixture, task, model,
+permissions, gates, and assertions constant.
+
+From a clone of this repository:
+
+```sh
+node eval/run.mjs \
+  --baseline HEAD \
+  --candidate . \
+  --model MODEL_ID \
+  --output /tmp/cycle-eval-run
+```
+
+`HEAD` is a git ref in this repository; `.` may include uncommitted template work. Each arm is
+rendered into its own physical repository and uses a local `gh` double, so scenarios do not write
+to GitHub. Codex must already be authenticated through its `CODEX_HOME` login; ambient credential
+variables are not forwarded.
+
+The runner uses
+[`codex exec --json`](https://developers.openai.com/codex/noninteractive) and records the event
+stream, tracker and gate commands, token usage when Codex reports it, the final diff,
+source/skill/fixture hashes, and deterministic assertions in the requested output directory. It
+does not copy authentication into the fixtures: the Codex launcher retains its existing login,
+while model-generated commands receive a core-only environment, an empty evaluation home, no
+network access, and no approval path out of the workspace sandbox.
+
+Start with the default single matched run. If the arms differ, or the result will justify a
+meaningful instruction change, add `--repeat 3` to repeat both arms. `--scenario <id>` narrows the
+run to one targeted behavior.
+
+Model-backed runs are externally metered and intentionally absent from `npm test` and CI.
+Ordinary tests exercise fixture isolation, the tracker double, JSONL parsing, assertions, and
+result formatting with a fake Codex executable. A behavioral FAIL is evidence in `results.jsonl`,
+not a merge-gate exit code; invalid runner or harness execution exits 2.

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -1,0 +1,99 @@
+# Installing the-cycle
+
+The quick bootstrap renders the pipeline once without requiring a clone. A durable installation
+adds the `cycle` command and the personal `/cycle-setup` skill so the installed pipeline can be
+checked and updated later.
+
+## Requirements
+
+- Node.js 20 or newer
+- git
+- bash for the durable installer
+- an authenticated `gh` CLI before tracker operations
+
+Rendering, linting, and drift checks work without network access.
+
+## Bootstrap a first render
+
+Run this from the repository you want to configure:
+
+```sh
+npx --yes @brndnsh/the-cycle install
+```
+
+`npx` downloads the published package into its ephemeral cache and runs the guided installer.
+`--yes` accepts npm's package-download prompt. The rendered skills stand alone after that first
+run, but later `cycle update` and `cycle check` commands need the durable clone below.
+
+## Install for everyday use
+
+Clone the canonical GitHub repository into a durable location and run its installer. These
+examples use `~/code/the-cycle`; another stable path works equally well.
+
+```sh
+git clone https://github.com/brndnsh-labs/the-cycle ~/code/the-cycle
+~/code/the-cycle/install.sh
+```
+
+`install.sh` links `bin/cycle` into `~/.local/bin` and links `/cycle-setup` into the personal skills
+directories used by Claude Code, Codex CLI, Copilot CLI, OpenCode, and Pi. Follow the installer's
+instruction if `~/.local/bin` is not already on `PATH`, then restart or reload a running harness if
+it does not discover the newly linked skill.
+
+Verify the command before setting up a repository:
+
+```sh
+cycle --version
+```
+
+## Set up a repository
+
+The personal skill is the preferred path because it reads the repository before answering setup
+questions:
+
+```sh
+/cycle-setup
+```
+
+To drive the same process by hand:
+
+```sh
+cycle install --plan                 # show detected values and every open question
+cycle install --profile lean         # interview, write config, and render
+cycle check                          # report drift; non-zero exit when drift exists
+cycle update                         # re-render and show the resulting diff
+```
+
+`cycle install` can detect a repository's name, remote, and likely gate commands. It cannot infer
+what would break that repository irreversibly or what “ready” means there. Setup is guided so
+those risk and workflow decisions remain explicit.
+
+## Ask a coding agent to install it
+
+Give an agent this prompt when you want it to bootstrap the durable install and set up the
+repository it is already working in:
+
+> Install the-cycle for durable use, then set it up in this repository. Verify Node.js 20 or
+> newer, git, and bash first; `gh` must be authenticated before tracker operations. Before cloning
+> or changing anything under my home directory, show me the paths and ask for approval. Once
+> approved, clone `https://github.com/brndnsh-labs/the-cycle` to `~/code/the-cycle` (or inspect the
+> existing clone), run `~/code/the-cycle/install.sh`, make sure `~/.local/bin` is on `PATH` as the
+> installer directs, and verify `cycle --version`. Restart or reload the coding harness if it does
+> not discover the newly linked personal skill. Then run `/cycle-setup` in this repository and
+> follow it; do not hand-edit generated harness skill trees.
+
+## Reconcile an existing hand-written pipeline
+
+There used to be a `cycle adopt` command and a `/cycle-adopt` skill that reverse-engineered a
+hand-written pipeline into config and overlays. They were retired after the legacy repositories
+had converged rather than maintained against an empty queue.
+
+If another hand-written pipeline needs converting, recover the old implementation from git
+history (`git log --diff-filter=D -- bin/adopt.mjs`) or reconcile it deliberately:
+
+1. Extract repository facts into `.cycle/config.jsonc`.
+2. Move irreducibly repository-specific guidance into `.cycle/overlays/*.md`.
+3. Diff each existing skill against its rendered replacement.
+4. Only then let `cycle update` replace the hand-written skill tree.
+
+Never render over hand-written agent guidance without comparing it first.


### PR DESCRIPTION
## What shipped

- Reframed the README as the public project overview and first-render quick start.
- Moved durable, manual, and agent-assisted setup into `docs/INSTALLING.md`.
- Moved the behavioral runner procedure into `docs/EVALUATION.md`.
- Moved local gates and the repository layout into `docs/DEVELOPMENT.md`, with the existing agent guidance pointing to the new source.
- Removed private-mirror operations and duplicated maintainer procedures from the README while preserving links to every moved topic.

## Review findings actioned

- Restored the public zero-dependency and no-build-step contract after the initial extraction dropped it.
- Clarified that only generated pipeline prose and bindings follow the template/config/overlay source rule; ordinary CLI, evaluator, test, and documentation work remains in its corresponding source directory.

## Verification

- `node bin/cycle.mjs lint` — PASS
- `npm test` — PASS (274 tests)
- `node bin/cycle.mjs check` — PASS
- Local Markdown link validation and `git diff --check` — PASS

Closes #100

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)
