### PR TITLE
fix(install): preflight personal skill links

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,14 +11,39 @@ set -euo pipefail
 
 CYCLE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BIN_DIR="$HOME/.local/bin"
-SKILL_DIRS=("$HOME/.claude/skills" "$HOME/.agents/skills" "$HOME/.github/skills" "$HOME/.opencode/skills" "$HOME/.pi/skills")
+# These two personal roots cover every supported harness: Claude Code uses its
+# native root, while Codex, Copilot CLI, OpenCode, and Pi discover ~/.agents/skills.
+SKILL_DIRS=("$HOME/.claude/skills" "$HOME/.agents/skills")
 PATH_LINE='export PATH="$HOME/.local/bin:$PATH"'
+
+SKILL_SRCS=()
+for src in "$CYCLE"/skills/*/; do
+    [ -d "$src" ] || continue
+    SKILL_SRCS+=("${src%/}")
+done
+
+refuse_collision() {
+    local target="$1"
+    if [ -e "$target" ] && [ ! -L "$target" ]; then
+        echo "error: refusing to replace existing directory or file: $target" >&2
+        exit 1
+    fi
+}
+
+# Check every destination before the first write. A collision must not leave a
+# half-installed CLI or a skill linked into only one harness root.
+refuse_collision "$BIN_DIR/cycle"
+for skill_dir in "${SKILL_DIRS[@]}"; do
+    for src in "${SKILL_SRCS[@]}"; do
+        refuse_collision "$skill_dir/$(basename "$src")"
+    done
+done
 
 mkdir -p "$BIN_DIR" "${SKILL_DIRS[@]}"
 
 # Only cycle.mjs. The other files in bin/ are subcommand modules it imports on
 # demand — on PATH they would look like commands and do nothing when run.
-ln -sf "$CYCLE/bin/cycle.mjs" "$BIN_DIR/cycle"
+ln -sfn "$CYCLE/bin/cycle.mjs" "$BIN_DIR/cycle"
 echo "Linking the CLI into $BIN_DIR:"
 echo "  cycle -> $CYCLE/bin/cycle.mjs"
 
@@ -29,18 +54,10 @@ echo
 echo "Linking setup skills into personal harness skill directories:"
 for skill_dir in "${SKILL_DIRS[@]}"; do
     echo "  $skill_dir"
-    for src in "$CYCLE"/skills/*/; do
-        [ -d "$src" ] || continue
+    for src in "${SKILL_SRCS[@]}"; do
         name="$(basename "$src")"
         target="$skill_dir/$name"
-        # `ln -sfn source existing-directory` nests the link inside that directory
-        # instead of replacing it. Refuse the collision so a stale hand-installed
-        # skill cannot survive behind a misleading success message.
-        if [ -e "$target" ] && [ ! -L "$target" ]; then
-            echo "error: refusing to replace existing directory or file: $target" >&2
-            exit 1
-        fi
-        ln -sfn "${src%/}" "$target"
+        ln -sfn "$src" "$target"
         echo "    /$name"
     done
 done

--- a/test/package.test.mjs
+++ b/test/package.test.mjs
@@ -1,7 +1,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+    existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, readlinkSync, rmSync,
+    symlinkSync, writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -48,9 +51,19 @@ test('the packed artifact contains only the supported product surface and can re
         execFileSync('bash', [join(packageRoot, 'install.sh')], {
             encoding: 'utf8', env: { ...process.env, HOME: home },
         });
+        execFileSync('bash', [join(packageRoot, 'install.sh')], {
+            encoding: 'utf8', env: { ...process.env, HOME: home },
+        });
         assert.ok(existsSync(join(home, '.local', 'bin', 'cycle')));
         assert.ok(existsSync(join(home, '.claude', 'skills', 'cycle-setup', 'SKILL.md')));
         assert.ok(existsSync(join(home, '.agents', 'skills', 'cycle-setup', 'SKILL.md')));
+        for (const projectOnlyRoot of ['.github', '.opencode', '.pi']) {
+            assert.equal(
+                existsSync(join(home, projectOnlyRoot)),
+                false,
+                `installer created project-only root ${projectOnlyRoot} under HOME`,
+            );
+        }
 
         const collisionHome = join(work, 'collision-home');
         mkdirSync(join(collisionHome, '.agents', 'skills', 'cycle-setup'), { recursive: true });
@@ -59,7 +72,46 @@ test('the packed artifact contains only the supported product surface and can re
         });
         assert.notEqual(collision.status, 0, 'installer silently accepted a real-directory collision');
         assert.match(collision.stderr, /refusing to replace existing directory or file/);
-        assert.ok(!existsSync(join(collisionHome, '.agents', 'skills', 'cycle-setup', 'cycle-setup')));
+        assert.equal(existsSync(join(collisionHome, '.local', 'bin', 'cycle')), false, 'CLI linked before skill preflight failed');
+        assert.equal(
+            existsSync(join(collisionHome, '.claude', 'skills', 'cycle-setup')),
+            false,
+            'Claude skill linked before agent-skill preflight failed',
+        );
+
+        const cliCollisionHome = join(work, 'cli-collision-home');
+        mkdirSync(join(cliCollisionHome, '.local', 'bin'), { recursive: true });
+        writeFileSync(join(cliCollisionHome, '.local', 'bin', 'cycle'), 'owned by another install\n');
+        const cliCollision = spawnSync('bash', [join(packageRoot, 'install.sh')], {
+            encoding: 'utf8', env: { ...process.env, HOME: cliCollisionHome },
+        });
+        assert.notEqual(cliCollision.status, 0, 'installer silently replaced a real CLI file');
+        assert.match(cliCollision.stderr, /refusing to replace existing directory or file/);
+        assert.equal(
+            readFileSync(join(cliCollisionHome, '.local', 'bin', 'cycle'), 'utf8'),
+            'owned by another install\n',
+            'installer changed the colliding CLI file before refusing it',
+        );
+        assert.equal(
+            existsSync(join(cliCollisionHome, '.claude', 'skills', 'cycle-setup')),
+            false,
+            'skill linked before CLI preflight failed',
+        );
+
+        const directoryLinkHome = join(work, 'directory-link-home');
+        const unexpectedDirectory = join(directoryLinkHome, 'unexpected-directory');
+        mkdirSync(join(directoryLinkHome, '.local', 'bin'), { recursive: true });
+        mkdirSync(unexpectedDirectory);
+        symlinkSync(unexpectedDirectory, join(directoryLinkHome, '.local', 'bin', 'cycle'), 'dir');
+        execFileSync('bash', [join(packageRoot, 'install.sh')], {
+            encoding: 'utf8', env: { ...process.env, HOME: directoryLinkHome },
+        });
+        assert.equal(
+            readlinkSync(join(directoryLinkHome, '.local', 'bin', 'cycle')),
+            join(packageRoot, 'bin', 'cycle.mjs'),
+            'installer followed a directory symlink instead of replacing it',
+        );
+        assert.deepEqual(readdirSync(unexpectedDirectory), [], 'installer wrote through a directory symlink');
 
         const repo = join(work, 'consumer');
         mkdirSync(repo);


### PR DESCRIPTION
## What shipped

- link the personal setup skill through the two user-level roots that cover every supported harness
- preflight the CLI and all skill destinations before the installer makes its first write
- keep repeat installs idempotent and refuse real-file or real-directory collisions

## Review findings actioned

- changed the CLI link to `ln -sfn` so an existing directory symlink is replaced rather than followed
- added regression coverage for idempotence, collision preservation, and partial-install prevention

## Verification

- `node bin/cycle.mjs lint`
- `npm test` — 274 passing
- `node bin/cycle.mjs check`

Closes #114

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)
