### PR TITLE
fix(setup): fail closed on undetected configuration

### DIFF
--- a/bin/cycle.mjs
+++ b/bin/cycle.mjs
@@ -493,10 +493,23 @@ function loadRegistry(dir, name, label) {
 const loadBackend = (name) => loadRegistry('backends', name, 'backend');
 const loadProfile = (name) => loadRegistry('profiles', name, 'profile');
 const loadHarness = (name) => loadRegistry('harnesses', name, 'harness');
+const registryNames = (dir) => readdirSync(join(CYCLE_HOME, dir))
+    .filter((f) => f.endsWith('.jsonc') && !f.startsWith('_'))
+    .map((f) => basename(f, '.jsonc'));
 
-// Which harness trees a render targets. Absent/empty means "just Claude Code" — every
-// config written before this field existed renders exactly as it always did.
-const harnessNames = (cfg) => (cfg.harnesses?.length ? cfg.harnesses : ['claude']);
+// A missing field means "just Claude Code" so configs written before multi-harness
+// support keep rendering as they always did. An explicitly empty field is different:
+// setup knew it had no answer, so later commands must not turn that unknown into a guess.
+const harnessNames = (cfg) => {
+    if (!Object.hasOwn(cfg, 'harnesses')) return ['claude'];
+    if (!Array.isArray(cfg.harnesses) || !cfg.harnesses.length || cfg.harnesses.some((h) => typeof h !== 'string' || !h.trim())) {
+        fail(
+            'config has no harness selected',
+            `set .cycle/config.jsonc's harnesses array (available: ${registryNames('harnesses').join(', ')})`,
+        );
+    }
+    return cfg.harnesses;
+};
 
 /** The `harness.*` object templates branch on — one instance per configured harness. */
 function buildHarnessContext(h) {
@@ -513,7 +526,7 @@ function buildHarnessContext(h) {
 }
 
 /** False for an npm/npx install — CYCLE_HOME has no .git to probe (same signal upstreamSha() uses). */
-const cycleHomeIsClone = () => !!git(['rev-parse', '--short', 'HEAD'], CYCLE_HOME);
+const cycleHomeIsClone = () => existsSync(join(CYCLE_HOME, '.git')) && !!git(['rev-parse', '--short', 'HEAD'], CYCLE_HOME);
 
 /** config + backend semantics, as the object templates resolve paths against. */
 function buildContext(cfg, backend) {
@@ -716,7 +729,7 @@ function printDiff(rel, a, b, { context = 2 } = {}) {
 // ---------------------------------------------------------------------------
 
 const upstreamSha = () => {
-    const sha = git(['rev-parse', '--short', 'HEAD'], CYCLE_HOME);
+    const sha = existsSync(join(CYCLE_HOME, '.git')) ? git(['rev-parse', '--short', 'HEAD'], CYCLE_HOME) : '';
     if (sha) {
         const dirty = git(['status', '--porcelain'], CYCLE_HOME);
         return dirty ? `${sha}-dirty` : sha;
@@ -826,7 +839,11 @@ export function detect(root) {
     }
     out.name ??= basename(root);
 
-    const remote = git(['remote', 'get-url', 'origin'], root);
+    // Listing an empty remote set succeeds; asking Git for a missing named remote
+    // fails noisily. Probe the set first so expected no-origin repos stay quiet while
+    // a genuine failure of either Git operation still reaches stderr.
+    const remotes = git(['remote'], root).split(/\r?\n/).filter(Boolean);
+    const remote = remotes.includes('origin') ? git(['remote', 'get-url', 'origin'], root) : '';
     if (remote) {
         // Remotes configured for CI or convenience routinely embed credentials
         // (https://x-access-token:ghp_…@host/repo.git); detect()'s output reaches the
@@ -1038,7 +1055,7 @@ const DEFAULT_STATUSES = {
 
 /**
  * The config a fresh install starts from: everything `detect` could infer, plus
- * defensible defaults for everything it couldn't. Shared by the interview and by
+ * explicit unknowns for everything it couldn't. Shared by the interview and by
  * `--plan`, so a guided setup and a manual one begin from exactly the same draft.
  */
 function applyConfigSets(cfg, sets = []) {
@@ -1079,10 +1096,10 @@ export function draftConfig(root, { backend: wanted, profile, set } = {}) {
         },
         profile: profile ?? 'lean',
         backend,
-        // Which harness trees to render. Detected from filesystem markers when
-        // present (see `detect`), else Claude Code only. See harnesses/*.jsonc and
-        // docs/HARNESSES.md.
-        harnesses: d.harnesses ?? ['claude'],
+        // Which harness trees to render. Detection can suggest an answer, but an
+        // absent signal cannot honestly choose a user's coding harness for them.
+        // See harnesses/*.jsonc and docs/HARNESSES.md.
+        harnesses: d.harnesses ?? [],
         tracker: {
             description: `**GitHub issues** (\`${d.slug ?? ''}\`)`,
             statuses: DEFAULT_STATUSES[backend] ?? DEFAULT_STATUSES.github,
@@ -1096,7 +1113,7 @@ export function draftConfig(root, { backend: wanted, profile, set } = {}) {
             model: "Use the active harness's default model unless the task explicitly requires another.",
             executor_default: 'orchestrator-inline',
         },
-        gates: Object.keys(d.gates).length ? d.gates : { typecheck: 'npm run typecheck', test: 'npm test' },
+        gates: d.gates,
         // /dep-update's package-manager commands. Detected from an ecosystem marker;
         // blank where the ecosystem has no equivalent (plenty have no audit-fix).
         deps: d.deps ?? NO_DEPENDENCY_WORKFLOW,
@@ -1138,7 +1155,12 @@ async function cmdInstall(args) {
         cfg.repo.name = await ask('Repo display name', cfg.repo.name);
         cfg.repo.human = await ask('Who does this pipeline interrupt?', cfg.repo.human);
         cfg.profile = await ask('Profile (lean/standard/full)', cfg.profile);
-        const harnesses = await ask('Harnesses (comma-separated, from the registry)', cfg.harnesses.join(', '));
+        const availableHarnesses = registryNames('harnesses');
+        let harnesses = await ask(`Harnesses (comma-separated: ${availableHarnesses.join(', ')})`, cfg.harnesses.join(', '));
+        while (!harnesses) {
+            console.log(yellow('Choose at least one harness; setup will not guess.'));
+            harnesses = await ask(`Harnesses (comma-separated: ${availableHarnesses.join(', ')})`, '');
+        }
         cfg.harnesses = harnesses.split(',').map((s) => s.trim()).filter(Boolean);
         // No interactive question for backend itself: github is the only one the-cycle
         // binds today, so asking would be a confirm-the-only-answer prompt. `--backend`
@@ -1149,11 +1171,21 @@ async function cmdInstall(args) {
             const parent = keys.reduce((o, k) => (o[k] ??= {}), cfg);
             parent[leaf] = await ask(`${path} — ${why}`, parent[leaf] ?? '');
         }
-        cfg.gates.typecheck = await ask('Typecheck gate', cfg.gates.typecheck ?? '');
-        cfg.gates.test = await ask('Test gate', cfg.gates.test ?? '');
+        for (const [key, label] of [['typecheck', 'Typecheck gate'], ['test', 'Test gate']]) {
+            const command = await ask(label, cfg.gates[key] ?? '');
+            if (command) cfg.gates[key] = command;
+            else delete cfg.gates[key];
+        }
         const brakes = await ask('Always-brake surfaces (comma-separated)', cfg.brakes.join(', '));
         cfg.brakes = brakes.split(',').map((s) => s.trim()).filter(Boolean);
         rl.close();
+    }
+
+    if (!Array.isArray(cfg.harnesses) || !cfg.harnesses.length || cfg.harnesses.some((h) => typeof h !== 'string' || !h.trim())) {
+        fail(
+            'no harness detected or selected',
+            `choose one in the interview, or pass \`--set 'harnesses=["codex"]'\` (available: ${registryNames('harnesses').join(', ')})`,
+        );
     }
 
     loadProfile(cfg.profile);
@@ -1210,12 +1242,8 @@ async function cmdInstall(args) {
 function cmdPlan(root, values) {
     const { cfg, detected } = draftConfig(root, { backend: values.backend, profile: values.profile, set: values.set });
     const backend = loadBackend(cfg.backend);
-    const profiles = readdirSync(join(CYCLE_HOME, 'profiles'))
-        .filter((f) => f.endsWith('.jsonc'))
-        .map((f) => basename(f, '.jsonc'));
-    const harnesses = readdirSync(join(CYCLE_HOME, 'harnesses'))
-        .filter((f) => f.endsWith('.jsonc'))
-        .map((f) => basename(f, '.jsonc'));
+    const profiles = registryNames('profiles');
+    const harnesses = registryNames('harnesses');
 
     const overlayManifest = existsSync(templatePath('overlays.jsonc')) ? readJsonc(templatePath('overlays.jsonc')) : {};
 
@@ -1605,8 +1633,9 @@ const USAGE = `${bold('cycle')} — render the-cycle's work pipeline into a repo
   ${bold('cycle render')} [filter]
       Print rendered output to stdout without writing. Debugging aid.
 
-  Renders into every harness in .cycle/config.jsonc's "harnesses" array (default
-  ["claude"] — .claude/skills/). See harnesses/*.jsonc and docs/HARNESSES.md.
+  Renders into every harness in .cycle/config.jsonc's "harnesses" array. A fresh
+  install detects existing harness markers or asks you to choose; legacy configs
+  without the field still use ["claude"]. See harnesses/*.jsonc and docs/HARNESSES.md.
 `;
 
 async function main() {

--- a/test/package.test.mjs
+++ b/test/package.test.mjs
@@ -117,7 +117,10 @@ test('the packed artifact contains only the supported product surface and can re
         mkdirSync(repo);
         execFileSync('git', ['init', '-q', '.'], { cwd: repo });
         writeFileSync(join(repo, 'package.json'), '{"name":"packed-smoke"}\n');
-        execFileSync(process.execPath, [join(packageRoot, 'bin', 'cycle.mjs'), 'install', '-y'], {
+        execFileSync(process.execPath, [
+            join(packageRoot, 'bin', 'cycle.mjs'),
+            'install', '-y', '--set', 'harnesses=["claude"]',
+        ], {
             cwd: repo, encoding: 'utf8', env: { ...process.env, NO_COLOR: '1' },
         });
         assert.ok(existsSync(join(repo, '.claude', 'skills', 'DOCTRINE.md')));

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -39,6 +39,18 @@ function scratchRepo() {
         join(dir, 'package.json'),
         JSON.stringify({ name: 'demo', scripts: { typecheck: 'tsc -b', test: 'node --test' } }),
     );
+    // Most render tests exercise the long-standing Claude fixture. Give detection
+    // the same honest signal a real Claude repo has instead of relying on a fallback.
+    mkdirSync(join(dir, '.claude'));
+    return dir;
+}
+
+function emptyGitRepo() {
+    const dir = mkdtempSync(join(tmpdir(), 'cycle-empty-'));
+    const run = (args) => execFileSync('git', args, { cwd: dir, stdio: 'pipe' });
+    run(['init', '-q', '.']);
+    run(['config', 'user.name', 'Brandon Shea']);
+    run(['config', 'user.email', 'b@example.com']);
     return dir;
 }
 
@@ -263,7 +275,57 @@ describe('install --plan', () => {
         assert.deepEqual(plan.detected.gates, { typecheck: 'npm run typecheck', test: 'npm test' });
         assert.equal(plan.existing_config, null);
         assert.equal(existsSync(join(dir, '.cycle')), false, '--plan must not write');
-        assert.equal(existsSync(join(dir, '.claude')), false, '--plan must not write');
+        assert.deepEqual(readdirSync(join(dir, '.claude')), [], '--plan must not write into the detected harness tree');
+    });
+
+    test('an empty repo keeps unknown gates and harnesses empty without a no-origin diagnostic', () => {
+        const dir = emptyGitRepo();
+        dirs.push(dir);
+
+        const result = cycleRaw(dir, ['install', '--plan']);
+        assert.equal(result.status, 0, result.out);
+        assert.doesNotMatch(result.out, /git remote get-url origin failed/);
+        const plan = JSON.parse(result.out);
+        assert.deepEqual(plan.detected.gates, {});
+        assert.deepEqual(plan.draft.gates, {});
+        assert.equal(plan.detected.harnesses, null);
+        assert.deepEqual(plan.draft.harnesses, []);
+    });
+
+    test('non-interactive install requires an explicit harness before writing', () => {
+        const dir = emptyGitRepo();
+        dirs.push(dir);
+
+        const refused = cycleRaw(dir, ['install', '-y']);
+        assert.equal(refused.status, 1, refused.out);
+        assert.match(refused.out, /no harness detected or selected/);
+        assert.match(refused.out, /--set 'harnesses=\["codex"\]'/);
+        assert.equal(existsSync(join(dir, '.cycle')), false, 'refused setup wrote a partial install');
+
+        cycle(dir, ['install', '-y', '--set', 'harnesses=["codex"]']);
+        const cfg = readJsonc(join(dir, '.cycle', 'config.jsonc'));
+        assert.deepEqual(cfg.harnesses, ['codex']);
+        assert.deepEqual(cfg.gates, {});
+        assert.ok(existsSync(join(dir, '.agents', 'skills', 'DOCTRINE.md')));
+
+        const cfgPath = join(dir, '.cycle', 'config.jsonc');
+        writeFileSync(cfgPath, readFileSync(cfgPath, 'utf8').replace(
+            '"harnesses": [\n    "codex"\n  ],',
+            '"harnesses": [],',
+        ));
+        const emptyUpdate = cycleRaw(dir, ['update']);
+        assert.equal(emptyUpdate.status, 1, emptyUpdate.out);
+        assert.match(emptyUpdate.out, /config has no harness selected/);
+    });
+
+    test('a real git repository error remains visible', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'cycle-not-a-repo-'));
+        dirs.push(dir);
+
+        const result = cycleRaw(dir, ['install', '--plan']);
+        assert.equal(result.status, 1, result.out);
+        assert.match(result.out, /git rev-parse --show-toplevel failed/);
+        assert.match(result.out, /not inside a git repository/);
     });
 
     test('a credentialed remote reaches the plan without its userinfo', () => {
@@ -647,7 +709,7 @@ describe('dependency metadata contracts', () => {
         execFileSync('git', ['init', '-q', '.'], { cwd: dir });
         execFileSync('git', ['remote', 'add', 'origin', DEMO_REMOTE], { cwd: dir });
         execFileSync('git', ['config', 'user.name', 'Brandon Shea'], { cwd: dir });
-        cycle(dir, ['install', '--profile', 'standard', '-y']);
+        cycle(dir, ['install', '--profile', 'standard', '--set', 'harnesses=["claude"]', '-y']);
 
         const skill = readFileSync(join(dir, '.claude', 'skills', 'dep-update', 'SKILL.md'), 'utf8');
         assert.match(skill, /## Not configured/);
@@ -1007,20 +1069,21 @@ describe('version stamp — no .git in CYCLE_HOME (an npm/npx install)', () => {
     test('gitless `cycle install` points at the durable clone for cycle update/check and the setup skills', async () => {
         const dir = scratchRepo('github');
         dirs.push(dir);
-        // Exercise the interactive path separately. Every answer is now an accepted
-        // default: with the board gone, github has no binding the interview must ask a
-        // human to supply, so a first install is pure confirmation.
+        // Exercise the interactive path with no harness marker: setup must ask the
+        // human to make that one choice rather than silently guessing Claude.
+        rmSync(join(dir, '.claude'), { recursive: true });
         const child = spawn(process.execPath, [join(gitlessHome, 'bin', 'cycle.mjs'), 'install', '--profile', 'lean'], {
             cwd: dir,
             env: { ...process.env, NO_COLOR: '1' },
         });
         let out = '';
         const waiters = [];
+        const occurrences = (re) => (out.match(new RegExp(re.source, `${re.flags.replace('g', '')}g`)) ?? []).length;
         const pump = (d) => {
             out += d;
             // Re-check every pending waiter against the buffer we have so far.
             for (const w of waiters.slice()) {
-                if (w.re.test(out)) {
+                if (occurrences(w.re) >= w.count) {
                     waiters.splice(waiters.indexOf(w), 1);
                     w.resolve();
                 }
@@ -1028,8 +1091,10 @@ describe('version stamp — no .git in CYCLE_HOME (an npm/npx install)', () => {
         };
         child.stdout.on('data', pump);
         child.stderr.on('data', pump);
-        const awaitPrompt = (re) =>
-            re.test(out) ? Promise.resolve() : new Promise((resolve, reject) => waiters.push({ re, resolve, reject }));
+        const awaitPrompt = (re, count = 1) =>
+            occurrences(re) >= count
+                ? Promise.resolve()
+                : new Promise((resolve, reject) => waiters.push({ re, count, resolve, reject }));
 
         // If the child exits — crash, or finishing before every scripted prompt was
         // seen — nothing will ever satisfy a still-pending waiter, and the `await`
@@ -1051,18 +1116,20 @@ describe('version stamp — no .git in CYCLE_HOME (an npm/npx install)', () => {
             [/Repo display name/, ''],
             [/interrupt\?/, ''],
             [/Profile \(lean/, ''],
-            [/Harnesses \(comma-separated/, ''],
+            [/Harnesses \(comma-separated/, '', 1],
+            [/Harnesses \(comma-separated/, 'claude', 2],
             [/Typecheck gate/, ''],
             [/Test gate/, ''],
             [/Always-brake surfaces/, ''],
         ];
-        for (const [prompt, answer] of script) {
-            await awaitPrompt(prompt);
+        for (const [prompt, answer, count] of script) {
+            await awaitPrompt(prompt, count);
             child.stdin.write(`${answer}\n`);
         }
         child.stdin.end();
         const code = await new Promise((resolve) => child.on('close', resolve));
         assert.equal(code, 0, out);
+        assert.match(out, /setup will not guess/);
         assert.match(out, /npm\/npx install/);
         assert.match(out, /cycle-setup/);
     });


### PR DESCRIPTION
Closes #115

## Summary
- preserve empty gate and harness detection instead of inventing npm or Claude defaults
- require an explicit harness before a fresh setup writes files, with an immediate guided prompt
- keep missing-origin and gitless-package probes quiet while preserving real Git diagnostics and remote credential redaction
- preserve the Claude fallback only for legacy configs where the harnesses field is absent

## Verification
- node bin/cycle.mjs lint
- npm test (277 passing)
- node bin/cycle.mjs check
- inline correctness and credential-handling review: no remaining findings