### PR TITLE
docs(install): lead with durable setup and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,28 +33,21 @@ templates portable:
 - **Drift detection** records provenance in every rendered file. `cycle check` distinguishes a
   locally edited render from a render whose source template has moved upstream.
 
-## Quick start
+## Quick start (recommended)
 
-Run the guided installer from the repository you want to configure:
+Ask the coding agent already working in your repository:
 
-```sh
-npx --yes @brndnsh/the-cycle install
-```
+> Install the-cycle for durable use, then set it up in this repository. Before changing anything
+> under my home directory, show me the exact paths and ask for approval. Use a clean clone at
+> `~/code/the-cycle`, run its `install.sh`, verify `cycle --version`, then run `/cycle-setup` here
+> through its operational readiness receipt. Do not hand-edit rendered harness skill trees.
 
-That command performs a one-off first render without requiring a clone. The rendered skills keep
-working, but `cycle update`, `cycle check`, and the personal `/cycle-setup` skill require a durable
-installation.
+The durable clone keeps the command and personal setup skill available for later checks and
+updates. Setup is complete only when `/cycle-setup` reports **READY** and its exact `.cycle/` and
+configured harness files are committed together. The first everyday command is then `/next`.
 
-After a durable installation, the everyday commands are:
-
-```sh
-/cycle-setup                         # inspect this repository and guide its first setup
-cycle check                          # report local or upstream drift
-cycle update                         # re-render and show the resulting diff
-```
-
-See [Installing the-cycle](docs/INSTALLING.md) for the durable install, the manual setup path, and
-a prompt you can hand to a coding agent.
+See [Installing the-cycle](docs/INSTALLING.md) for the agent handoff, manual alternative, one-off
+`npx` use, and the exact update procedure for one or several computers.
 
 ## Profiles
 
@@ -96,8 +89,8 @@ drift checks work offline.
 
 ## Documentation
 
-- [Installing](docs/INSTALLING.md) — bootstrap, durable installation, agent-assisted setup, and
-  existing-pipeline reconciliation.
+- [Installing](docs/INSTALLING.md) — recommended durable setup, one-off use, updates across
+  computers, and existing-pipeline reconciliation.
 - [Development](docs/DEVELOPMENT.md) — local gates, generated-source rules, and repository layout.
 - [Behavioral evaluation](docs/EVALUATION.md) — compare model behavior against two pipeline
   revisions in isolated fixtures.

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -1,8 +1,8 @@
 # Installing the-cycle
 
-The quick bootstrap renders the pipeline once without requiring a clone. A durable installation
-adds the `cycle` command and the personal `/cycle-setup` skill so the installed pipeline can be
-checked and updated later.
+The recommended setup is agent-assisted and durable: keep one source clone on the computer, let
+its installer link the command and personal setup skill, then let `/cycle-setup` adapt and verify
+each consuming repository. The clone is what makes later checks and updates predictable.
 
 ## Requirements
 
@@ -13,74 +13,168 @@ checked and updated later.
 
 Rendering, linting, and drift checks work without network access.
 
-## Bootstrap a first render
+## Recommended: ask your coding agent
 
-Run this from the repository you want to configure:
+Give this prompt to the agent already working in the repository you want to set up:
 
-```sh
-npx --yes @brndnsh/the-cycle install
-```
+> Install the-cycle for durable use, then set it up in this repository. Verify Node.js 20 or
+> newer, git, and bash first; `gh` must be authenticated before tracker operations. Before cloning
+> or changing anything under my home directory, show me the exact paths and ask for approval. Once
+> approved, use a clean clone of `https://github.com/brndnsh-labs/the-cycle` at
+> `~/code/the-cycle` (update an existing clean clone on `main` with `git pull --ff-only`), run
+> `~/code/the-cycle/install.sh`, confirm `~/.local/bin` is on `PATH`, and verify
+> `cycle --version`. Restart or reload the coding harness if it does not discover the newly linked
+> personal skill. Then run `/cycle-setup` in this repository through its operational readiness
+> receipt. Pause for any approval the skill requires, and never hand-edit a rendered harness tree.
 
-`npx` downloads the published package into its ephemeral cache and runs the guided installer.
-`--yes` accepts npm's package-download prompt. The rendered skills stand alone after that first
-run, but later `cycle update` and `cycle check` commands need the durable clone below.
+The agent should show the home-directory changes before making them, then finish repository setup
+with evidence rather than a generic success message.
 
-## Install for everyday use
+### The success boundary
 
-Clone the canonical GitHub repository into a durable location and run its installer. These
-examples use `~/code/the-cycle`; another stable path works equally well.
+Setup is complete when all four statements are true:
+
+1. `cycle --version` works from an ordinary shell.
+2. `/cycle-setup` reports **READY**: configured gates pass, tracker access and required labels are
+   verified, rendered content was read, and `cycle check` is clean.
+3. The receipt's exact `.cycle/` and configured harness paths are reviewed and committed together.
+4. `/next` is available as the first-use handoff.
+
+If the receipt says **NOT READY**, setup is not complete. Clear its named FAIL or UNVERIFIED rows
+and rerun the affected checks.
+
+## What the durable installer changes
+
+`install.sh` creates symlinks, not copies:
+
+- `~/.local/bin/cycle` points into the source clone.
+- `/cycle-setup` is linked under `~/.claude/skills` and `~/.agents/skills`. Together those two
+  personal roots cover every supported harness.
+
+Because the links point into the clone, an ordinary pull updates the command and personal setup
+skill immediately. The installer deliberately does not edit your shell profile; if
+`~/.local/bin` is missing from `PATH`, it prints the exact line to add.
+
+## Manual durable installation
+
+If you prefer to do the durable step yourself, these examples use `~/code/the-cycle`; another
+stable path works equally well.
 
 ```sh
 git clone https://github.com/brndnsh-labs/the-cycle ~/code/the-cycle
 ~/code/the-cycle/install.sh
-```
-
-`install.sh` links `bin/cycle` into `~/.local/bin` and links `/cycle-setup` into the personal skills
-directories used by Claude Code, Codex CLI, Copilot CLI, OpenCode, and Pi. Follow the installer's
-instruction if `~/.local/bin` is not already on `PATH`, then restart or reload a running harness if
-it does not discover the newly linked skill.
-
-Verify the command before setting up a repository:
-
-```sh
 cycle --version
 ```
 
-## Set up a repository
-
-The personal skill is the preferred path because it reads the repository before answering setup
-questions:
+If the clone already exists, use the source-clone update procedure below instead of cloning over
+it. Follow the PATH instruction if one appears, restart or reload a running harness, open the
+consuming repository, and run:
 
 ```sh
 /cycle-setup
 ```
 
-To drive the same process by hand:
+## One-off or manual use
+
+`npx` is useful for inspecting or rendering once without keeping a source clone:
 
 ```sh
-cycle install --plan                 # show detected values and every open question
-cycle install --profile lean         # interview, write config, and render
-cycle check                          # report drift; non-zero exit when drift exists
-cycle update                         # re-render and show the resulting diff
+npx --yes @brndnsh/the-cycle install --plan
+npx --yes @brndnsh/the-cycle install
 ```
 
-`cycle install` can detect a repository's name, remote, and likely gate commands. It cannot infer
-what would break that repository irreversibly or what “ready” means there. Setup is guided so
-those risk and workflow decisions remain explicit.
+`npx` fetches the package into npm's cache and exposes it only for that execution; `--yes` accepts
+the package-download prompt. The rendered repository skills stand alone, but the one-off path does
+not provide the durable clone or personal `/cycle-setup` skill used for later maintenance. Use it
+for deliberate one-off/manual work, not as the recommended everyday installation.
 
-## Ask a coding agent to install it
+To drive a durable setup by hand after installing:
 
-Give an agent this prompt when you want it to bootstrap the durable install and set up the
-repository it is already working in:
+```sh
+cycle install --plan                 # detected facts, open questions, and overlay points
+cycle install --profile lean         # interview, write config, and render
+cycle check                          # non-zero when setup is incomplete or drift exists
+```
 
-> Install the-cycle for durable use, then set it up in this repository. Verify Node.js 20 or
-> newer, git, and bash first; `gh` must be authenticated before tracker operations. Before cloning
-> or changing anything under my home directory, show me the paths and ask for approval. Once
-> approved, clone `https://github.com/brndnsh-labs/the-cycle` to `~/code/the-cycle` (or inspect the
-> existing clone), run `~/code/the-cycle/install.sh`, make sure `~/.local/bin` is on `PATH` as the
-> installer directs, and verify `cycle --version`. Restart or reload the coding harness if it does
-> not discover the newly linked personal skill. Then run `/cycle-setup` in this repository and
-> follow it; do not hand-edit generated harness skill trees.
+This route exposes the mechanism but does not replace `/cycle-setup`'s repository reading or
+operational readiness checks.
+
+## Updating
+
+There are two repositories in the update story: the local **the-cycle source clone**, which owns
+the renderer, and each **consuming repository**, which commits the generated pipeline.
+
+### 1. Update the source clone
+
+The source clone should be clean. Review anything printed by the first command before continuing:
+
+```sh
+git -C ~/code/the-cycle status --short
+git -C ~/code/the-cycle switch main
+git -C ~/code/the-cycle pull --ff-only
+cycle --version
+```
+
+`--ff-only` refuses to invent a merge when local history has diverged. A normal pull does **not**
+require another `install.sh` run: the existing symlinks already point into this clone.
+
+**One-time 0.1.x upgrade note:** after the first pull to 0.2.0 or newer, rerun
+`~/code/the-cycle/install.sh` once because the personal skill destinations were corrected. Later
+ordinary pulls use the normal no-rerun rule.
+
+### 2. Update one consuming repository
+
+Start from its clean, current default branch:
+
+```sh
+cd /path/to/consuming-repo
+git status --short
+git switch main
+git pull --ff-only
+cycle check
+cycle update --dry-run
+cycle update
+```
+
+Review a non-zero pre-update `cycle check` or `cycle update --dry-run` as an expected indication
+that reviewed upstream changes are pending, not permission to skip the diff. `cycle update` must
+stop rather than use `--force` if it finds a hand-edited render.
+
+Next, run every non-empty gate configured in `.cycle/config.jsonc`, then finish with:
+
+```sh
+cycle check
+git status --short -- .cycle .claude/skills .agents/skills .github/skills .opencode/skills .pi/skills
+git diff -- .cycle .claude/skills .agents/skills .github/skills .opencode/skills .pi/skills
+```
+
+Review the exact changed setup paths, stage only those paths, and commit config, state, overlays,
+and every configured harness tree together. Run `git add -- path/one path/two ...`, replacing the
+example paths with the exact reviewed paths from status, then finish with:
+
+```sh
+git commit -m "chore(cycle): update rendered pipeline"
+git push
+```
+
+Do not stage unrelated work. If the repository has its own review or pull-request policy, follow
+that policy for this commit.
+
+### More than one computer
+
+- The source clone is local installation state. Pull `~/code/the-cycle` on each computer that
+  should run the latest `cycle` command.
+- The consuming repository's `.cycle/` and harness trees are shared history. One computer runs
+  `cycle update`, verifies, and commits the result; the others only pull that consuming-repository
+  commit. They should not independently regenerate the same update.
+
+### When to rerun `install.sh`
+
+Rerun it after the first clone, for the one-time 0.1.x-to-0.2.x link correction described above,
+after moving the source clone, after a symlink was removed or replaced, or when later release
+notes explicitly say the link layout changed. Do not rerun it after an ordinary source-clone
+pull. It is idempotent for links it owns and fails before writing if another file or directory
+occupies a destination.
 
 ## Reconcile an existing hand-written pipeline
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,9 +1,9 @@
 # Releasing the-cycle
 
-The durable installation is a clone plus `./install.sh`. The README's `npx --yes
-@brndnsh/the-cycle install` command is the bootstrap path for a first render. It fetches the
-published package from npm into npx's ephemeral cache, so follow-up `cycle update` / `cycle check`
-work still need the durable clone.
+The public docs lead with the durable installation: a source clone plus `./install.sh`, followed by
+`/cycle-setup` in the consuming repository. `npx` is a published-package smoke path and a
+deliberate one-off/manual option, not the recommended installation. Keep README and
+`docs/INSTALLING.md` aligned with that distinction.
 
 `@brndnsh/the-cycle` is publicly published. Publishing a new version remains an explicit external
 release gate: making a commit or merging a pull request does not authorize `npm publish`.
@@ -28,5 +28,14 @@ checks the same boundary and exercises the packed artifact.
 
 Before publishing a new version, obtain explicit approval for the exact version and registry.
 Publish using the normal npm authentication flow, then verify the registry package with fresh
-one-off `npx --yes @brndnsh/the-cycle --version` and `npx --yes @brndnsh/the-cycle install`
-invocations.
+one-off commands:
+
+```sh
+npx --yes @brndnsh/the-cycle --version
+npx --yes @brndnsh/the-cycle install --plan   # run inside a deliberately temporary Git repo
+```
+
+The version output must equal the approved release, and the plan must be valid JSON. This verifies
+the one-off surface without presenting it as the durable user path. If a release changes the
+installer's link layout, its release notes must explicitly name the one-time `install.sh` rerun;
+0.2.0 requires that note for users upgrading from 0.1.x.

--- a/install.sh
+++ b/install.sh
@@ -72,5 +72,10 @@ else
 fi
 
 echo
-echo "Next: run /cycle-setup inside a repo (guided), or 'cycle install' for the"
-echo "      seven-question version."
+echo "Next: restart or reload a running harness, open the repository you want to"
+echo "      configure, and run /cycle-setup. Setup is done when its readiness"
+echo "      receipt says READY and its exact generated paths are committed."
+echo
+echo "Updates: git pull --ff-only on main updates these symlinks; do not"
+echo "         rerun install.sh unless the clone moves, a link breaks, or release"
+echo "         notes say the link layout changed."

--- a/test/package.test.mjs
+++ b/test/package.test.mjs
@@ -39,6 +39,17 @@ test('the packed artifact contains only the supported product surface and can re
         mkdirSync(unpacked);
         execFileSync('tar', ['-xzf', join(work, metadata.filename), '-C', unpacked]);
         const packageRoot = join(unpacked, 'package');
+        const readme = readFileSync(join(packageRoot, 'README.md'), 'utf8');
+        const installing = readFileSync(join(packageRoot, 'docs', 'INSTALLING.md'), 'utf8');
+        const releasing = readFileSync(join(packageRoot, 'docs', 'RELEASING.md'), 'utf8');
+        assert.match(readme, /Quick start \(recommended\)/);
+        assert.match(readme, /reports \*\*READY\*\*/);
+        assert.match(installing, /git -C ~\/code\/the-cycle pull --ff-only/);
+        assert.match(installing, /One computer runs\s+`cycle update`, verifies, and commits/);
+        assert.match(installing, /Do not rerun it after an\s+ordinary source-clone\s+pull/);
+        assert.match(installing, /One-time 0\.1\.x upgrade note/);
+        assert.match(releasing, /`npx` is a published-package smoke path/);
+        assert.match(releasing, /0\.2\.0 requires that note for users upgrading from 0\.1\.x/);
         const setupSkill = readFileSync(join(packageRoot, 'skills', 'cycle-setup', 'SKILL.md'), 'utf8');
         assert.match(setupSkill, /run every non-empty command/i, 'setup omits configured gate execution');
         assert.match(setupSkill, /gh repo view --json nameWithOwner,url/, 'setup omits repository access proof');
@@ -63,13 +74,15 @@ test('the packed artifact contains only the supported product surface and can re
 
         const home = join(work, 'home');
         mkdirSync(home);
-        execFileSync('bash', [join(packageRoot, 'install.sh')], {
+        const installOutput = execFileSync('bash', [join(packageRoot, 'install.sh')], {
             encoding: 'utf8', env: { ...process.env, HOME: home },
         });
         execFileSync('bash', [join(packageRoot, 'install.sh')], {
             encoding: 'utf8', env: { ...process.env, HOME: home },
         });
         assert.ok(existsSync(join(home, '.local', 'bin', 'cycle')));
+        assert.match(installOutput, /readiness\s+receipt says READY/);
+        assert.match(installOutput, /git pull --ff-only on main updates these symlinks/);
         assert.ok(existsSync(join(home, '.claude', 'skills', 'cycle-setup', 'SKILL.md')));
         assert.ok(existsSync(join(home, '.agents', 'skills', 'cycle-setup', 'SKILL.md')));
         for (const projectOnlyRoot of ['.github', '.opencode', '.pi']) {


### PR DESCRIPTION
Closes #117

## Summary
- make agent-assisted durable installation the single recommended quick start and define READY as the setup boundary
- move npx to explicit one-off or manual use
- document the source-clone pull, consuming-repository check/dry-run/update/gates/commit sequence
- explain the one-computer generation rule and when other computers should only pull
- state when install.sh must be rerun, including the one-time 0.1.x to 0.2.x link correction
- align release guidance and installer handoff text, with packed-artifact assertions

## Verification
- Git and npm command semantics checked against current Context7 documentation
- node bin/cycle.mjs lint
- npm test (277 passing)
- node bin/cycle.mjs check
- inline editorial and correctness review: no remaining findings