### PR TITLE
chore(release): prepare 0.2.0 package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brndnsh/the-cycle",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "description": "An installable, self-updating work pipeline for AI coding harnesses",
   "license": "MIT",

--- a/test/package.test.mjs
+++ b/test/package.test.mjs
@@ -69,7 +69,7 @@ test('the packed artifact contains only the supported product surface and can re
             execFileSync(process.execPath, [join(packageRoot, 'bin', 'cycle.mjs'), '--version'], {
                 encoding: 'utf8', env: { ...process.env, NO_COLOR: '1' },
             }).trim(),
-            'v0.1.0',
+            'v0.2.0',
         );
 
         const home = join(work, 'home');


### PR DESCRIPTION
Closes #122

## Summary
- set package metadata to 0.2.0
- update the packed CLI version assertion to v0.2.0
- create no Git tag and perform no npm registry write

## Verification
- npm pack --dry-run --json: @brndnsh/the-cycle@0.2.0, 45 supported files, repository-only trees/tests/CI excluded
- node bin/cycle.mjs lint
- npm test (277 passing)
- node bin/cycle.mjs check
- inline release-diff review: exactly two version lines, no remaining findings

Publication of exact package @brndnsh/the-cycle version 0.2.0 to the public npm registry remains a separate explicit approval.