### PR TITLE
fix(eval): isolate snapshot rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ drift checks work offline.
   computers, and existing-pipeline reconciliation.
 - [Development](docs/DEVELOPMENT.md) — local gates, generated-source rules, and repository layout.
 - [Behavioral evaluation](docs/EVALUATION.md) — compare model behavior against two pipeline
-  revisions in isolated fixtures.
+  revisions in isolated fixtures using a runner-owned renderer and data-only snapshots.
 - [Authoring](docs/AUTHORING.md) — write templates and overlays and propagate their changes.
 - [Backends](docs/BACKENDS.md) — tracker verbs and backend semantics.
 - [Harnesses](docs/HARNESSES.md) — harness fields, capabilities, and discovery paths.

--- a/docs/EVALUATION.md
+++ b/docs/EVALUATION.md
@@ -20,13 +20,31 @@ rendered into its own physical repository and uses a local `gh` double, so scena
 to GitHub. Codex must already be authenticated through its `CODEX_HOME` login; ambient credential
 variables are not forwarded.
 
+Snapshots are untrusted data inputs, not executable renderers. The runner copies only the selected
+snapshot's `templates/`, `backends/`, `harnesses/`, and `profiles/` trees into a temporary render
+stage, rejects symlinks and special files in path-based inputs, and places them beside its own
+reviewed `bin/cycle.mjs` and package metadata. A snapshot's `bin/cycle.mjs` is hashed as source
+provenance but never executed. This evaluator therefore compares skill data, not candidate engine
+behavior; engine changes need a separately sandboxed evaluator.
+
+The evaluator also pins the Codex discovery layout to `.agents/skills/<name>/SKILL.md`. Snapshot
+harness capabilities and prose still participate in the comparison, but discovery-root and skill
+filename changes need a separate evaluator; letting untrusted data choose arbitrary fixture output
+paths could turn a rendered template into code that a later fixture gate executes.
+
+For the runner repository itself, path inputs retain commit and dirty-worktree metadata. Arbitrary
+external path inputs are not Git-inspected—the runner records their content hash and leaves commit
+and dirty state unknown, avoiding checkout-configured hooks before isolation exists.
+
 The runner uses
 [`codex exec --json`](https://developers.openai.com/codex/noninteractive) and records the event
 stream, tracker and gate commands, token usage when Codex reports it, the final diff,
-source/skill/fixture hashes, and deterministic assertions in the requested output directory. It
-does not copy authentication into the fixtures: the Codex launcher retains its existing login,
-while model-generated commands receive a core-only environment, an empty evaluation home, no
-network access, and no approval path out of the workspace sandbox.
+source/skill/fixture hashes, the trusted renderer hash, and deterministic assertions in the
+requested output directory. It does not copy authentication into the fixtures: renderer and model
+launches both use explicit environment allowlists and isolated homes. The Codex launcher retains
+its existing login through `CODEX_HOME`, while model-generated commands receive a core-only
+environment, an empty evaluation home, no network access, and no approval path out of the workspace
+sandbox.
 
 Start with the default single matched run. If the arms differ, or the result will justify a
 meaningful instruction change, add `--repeat 3` to repeat both arms. `--scenario <id>` narrows the

--- a/eval/run.mjs
+++ b/eval/run.mjs
@@ -4,6 +4,7 @@ import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 import {
     existsSync,
+    lstatSync,
     mkdirSync,
     mkdtempSync,
     readFileSync,
@@ -17,11 +18,14 @@ import { homedir, tmpdir } from 'node:os';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
+import { readJsonc } from '../bin/cycle.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(HERE, '..');
 const SCENARIOS = join(HERE, 'scenarios');
 const SOURCE_PATHS = ['package.json', 'bin', 'templates', 'backends', 'harnesses', 'profiles'];
+const SNAPSHOT_DATA_PATHS = ['templates', 'backends', 'harnesses', 'profiles'];
+const TRUSTED_RENDERER = join(ROOT, 'bin', 'cycle.mjs');
 const FIXTURE_VERSION = 1;
 
 class EvalError extends Error {}
@@ -74,6 +78,7 @@ function walkFiles(root, current = root) {
         const path = join(current, entry.name);
         if (entry.isDirectory()) files.push(...walkFiles(root, path));
         else if (entry.isFile()) files.push(path);
+        else fail(`unsupported file type in evaluation tree: ${relative(root, path)}`);
     }
     return files;
 }
@@ -94,7 +99,10 @@ function hashSourceTree(root) {
     for (const rel of SOURCE_PATHS) {
         const path = join(root, rel);
         if (!existsSync(path)) continue;
-        const files = statSync(path).isDirectory() ? walkFiles(path) : [path];
+        const entry = lstatSync(path);
+        if (entry.isSymbolicLink()) fail(`symbolic links are not allowed in evaluation sources: ${rel}`);
+        if (!entry.isDirectory() && !entry.isFile()) fail(`unsupported evaluation source path: ${rel}`);
+        const files = entry.isDirectory() ? walkFiles(path) : [path];
         for (const file of files) {
             hash.update(relative(root, file));
             hash.update('\0');
@@ -112,10 +120,10 @@ function ensureInside(root, path) {
     }
 }
 
-function sourceMetadata(path, spec, resolvedRef = null) {
+function sourceMetadata(path, spec, resolvedRef = null, { inspectGit = false } = {}) {
     let commit = resolvedRef;
     let dirty = null;
-    if (!commit) {
+    if (!commit && inspectGit) {
         const commitResult = spawnSync('git', ['-C', path, 'rev-parse', 'HEAD'], { encoding: 'utf8' });
         if (commitResult.status === 0) {
             commit = commitResult.stdout.trim();
@@ -154,9 +162,71 @@ function resolveSource(spec, sourceRoot, name) {
     if (existsSync(path)) {
         const real = realpathSync(path);
         if (!existsSync(join(real, 'bin', 'cycle.mjs'))) fail(`${spec} is not a the-cycle checkout`);
-        return sourceMetadata(real, spec);
+        return sourceMetadata(real, spec, null, { inspectGit: real === realpathSync(ROOT) });
     }
     return materializeRef(spec, join(sourceRoot, name));
+}
+
+function copySnapshotData(source, destination, root = source) {
+    const entry = lstatSync(source);
+    const rel = relative(root, source) || '.';
+    if (entry.isSymbolicLink()) fail(`symbolic links are not allowed in snapshot data: ${rel}`);
+    if (entry.isDirectory()) {
+        mkdirSync(destination, { recursive: true });
+        for (const child of readdirSync(source, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+            copySnapshotData(join(source, child.name), join(destination, child.name), root);
+        }
+        return;
+    }
+    if (!entry.isFile()) fail(`unsupported file type in snapshot data: ${rel}`);
+    mkdirSync(dirname(destination), { recursive: true });
+    writeFileSync(destination, readFileSync(source));
+}
+
+function validateSnapshotData(rendererRoot) {
+    const profilePath = join(rendererRoot, 'profiles', 'lean.jsonc');
+    let profile;
+    try { profile = readJsonc(profilePath); }
+    catch (error) { fail(`invalid snapshot profile ${profilePath}: ${error.message}`); }
+    if (!Array.isArray(profile.skills) || !profile.skills.length) {
+        fail('snapshot profile lean must contain a non-empty skills array');
+    }
+    for (const skill of profile.skills) {
+        if (typeof skill !== 'string' || !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(skill)) {
+            fail(`unsafe skill name in snapshot profile lean: ${JSON.stringify(skill)}`);
+        }
+        const template = join(rendererRoot, 'templates', 'skills', `${skill}.md.tmpl`);
+        if (!existsSync(template) || !lstatSync(template).isFile()) {
+            fail(`snapshot profile lean references missing template: ${skill}`);
+        }
+    }
+
+    const harnessPath = join(rendererRoot, 'harnesses', 'codex.jsonc');
+    let harness;
+    try { harness = readJsonc(harnessPath); }
+    catch (error) { fail(`invalid snapshot harness ${harnessPath}: ${error.message}`); }
+    // Why: these data fields otherwise let a snapshot route rendered JavaScript onto a
+    // fixture test that later runs outside the Codex sandbox.
+    if (harness.root !== '.agents/skills' || harness.skill_file !== 'SKILL.md') {
+        fail('snapshot harness codex must use root .agents/skills and skill_file SKILL.md');
+    }
+}
+
+function stageTrustedRenderer(source, destination) {
+    const renderer = readFileSync(TRUSTED_RENDERER);
+    mkdirSync(join(destination, 'bin'), { recursive: true });
+    writeFileSync(join(destination, 'bin', 'cycle.mjs'), renderer);
+    writeFileSync(join(destination, 'package.json'), readFileSync(join(ROOT, 'package.json')));
+    for (const rel of SNAPSHOT_DATA_PATHS) {
+        const path = join(source.path, rel);
+        if (!existsSync(path)) fail(`snapshot ${source.spec} is missing ${rel}`);
+        copySnapshotData(path, join(destination, rel), path);
+    }
+    validateSnapshotData(destination);
+    return {
+        cli: join(destination, 'bin', 'cycle.mjs'),
+        sha256: sha256(renderer),
+    };
 }
 
 const isNonEmptyString = (value) => typeof value === 'string' && Boolean(value.trim());
@@ -270,8 +340,18 @@ function writeFixtureFiles(workspace, scenario) {
     return { tracked: Object.keys(files), filesHash: hashObject(files) };
 }
 
-function renderSkills(workspace, source) {
-    const cli = join(source.path, 'bin', 'cycle.mjs');
+export function rendererEnvironment(control, ambient = process.env) {
+    const env = {};
+    for (const name of ['PATH', 'LANG', 'LC_ALL', 'LC_CTYPE']) {
+        if (ambient[name] !== undefined) env[name] = ambient[name];
+    }
+    env.HOME = join(control, 'home');
+    env.TMPDIR = join(control, 'tmp');
+    env.NO_COLOR = '1';
+    return env;
+}
+
+function renderSkills(workspace, renderer, control) {
     const sets = [
         ['harnesses', ['codex']],
         ['repo.name', 'cycle-eval-fixture'],
@@ -280,21 +360,29 @@ function renderSkills(workspace, source) {
         ['gates.test', 'npm test'],
         ['branch.minor_edits_direct', false],
     ];
-    const args = [cli, 'install', '--profile', 'lean', '--backend', 'github'];
+    const args = [renderer.cli, 'install', '--profile', 'lean', '--backend', 'github'];
     for (const [path, value] of sets) args.push('--set', `${path}=${JSON.stringify(value)}`);
     args.push('-y');
-    run(process.execPath, args, { cwd: workspace, env: { ...process.env, NO_COLOR: '1' } });
+    const env = rendererEnvironment(control);
+    mkdirSync(env.HOME, { recursive: true });
+    mkdirSync(env.TMPDIR, { recursive: true });
+    run(process.execPath, args, { cwd: workspace, env });
     return hashTree(join(workspace, '.agents', 'skills'));
 }
 
-function setupFixture(runDir, scenario, source) {
+function setupFixture(runDir, scenario, renderer) {
     const workspace = join(runDir, 'workspace');
     mkdirSync(workspace, { recursive: true });
     git(['init', '-q', '-b', 'main'], workspace);
     git(['config', 'user.name', 'Cycle Evaluator'], workspace);
     git(['config', 'user.email', 'cycle-eval@example.invalid'], workspace);
     const { tracked, filesHash } = writeFixtureFiles(workspace, scenario);
-    const skillHash = renderSkills(workspace, source);
+    const controlTest = join(workspace, 'test', 'feature.test.mjs');
+    const controlTestHash = sha256(readFileSync(controlTest));
+    const skillHash = renderSkills(workspace, renderer, join(runDir, 'renderer-control'));
+    if (!existsSync(controlTest) || sha256(readFileSync(controlTest)) !== controlTestHash) {
+        fail('snapshot rendering changed the fixture control test');
+    }
     rmSync(join(workspace, '.cycle', 'state.json'), { force: true });
 
     const exclude = join(workspace, '.git', 'info', 'exclude');
@@ -325,7 +413,6 @@ function setupFixture(runDir, scenario, source) {
         const path = resolve(workspace, assertion.path);
         observed.set(assertion.path, existsSync(path) ? sha256(readFileSync(path)) : null);
     }
-    const controlTest = join(workspace, 'test', 'feature.test.mjs');
     return {
         runDir,
         workspace,
@@ -339,7 +426,7 @@ function setupFixture(runDir, scenario, source) {
         }),
         observed,
         controlTest,
-        controlTestHash: sha256(readFileSync(controlTest)),
+        controlTestHash,
     };
 }
 
@@ -522,11 +609,11 @@ function codexEnvironment(fixture, scenario) {
     return env;
 }
 
-function runOne({ arm, repetition, scenario, source, codexBin, codexVersionValue, model, effort, timeoutMs, output }) {
+function runOne({ arm, repetition, scenario, source, renderer, codexBin, codexVersionValue, model, effort, timeoutMs, output }) {
     const name = `${scenario.id}-${String(repetition).padStart(2, '0')}-${arm}`;
     const runDir = join(output, 'runs', name);
     mkdirSync(runDir, { recursive: true });
-    const fixture = setupFixture(runDir, scenario, source);
+    const fixture = setupFixture(runDir, scenario, renderer);
     const eventsPath = join(runDir, 'events.jsonl');
     const stderrPath = join(runDir, 'stderr.log');
     const diffPath = join(runDir, 'final.diff');
@@ -586,6 +673,7 @@ function runOne({ arm, repetition, scenario, source, codexBin, codexVersionValue
             source_sha256: source.source_sha256,
             rendered_skill_sha256: fixture.skillHash,
         },
+        trusted_renderer_sha256: renderer.sha256,
         fixture_sha256: fixture.fixtureHash,
         requested_model: model,
         requested_effort: effort,
@@ -683,6 +771,13 @@ export function main(argv = process.argv.slice(2)) {
             baseline: resolveSource(values.baseline, sourceRoot, 'baseline'),
             candidate: resolveSource(values.candidate, sourceRoot, 'candidate'),
         };
+        const renderers = {
+            baseline: stageTrustedRenderer(sources.baseline, join(sourceRoot, 'renderers', 'baseline')),
+            candidate: stageTrustedRenderer(sources.candidate, join(sourceRoot, 'renderers', 'candidate')),
+        };
+        if (renderers.baseline.sha256 !== renderers.candidate.sha256) {
+            fail('trusted renderer hash changed between evaluation arms');
+        }
         const scenarios = loadScenarios(values.scenario ?? []);
         const version = codexVersion(values['codex-bin']);
         const publicSource = ({ spec, commit, dirty, source_sha256 }) => ({
@@ -701,6 +796,7 @@ export function main(argv = process.argv.slice(2)) {
             repeat,
             scenarios: scenarios.map((scenario) => scenario.id),
             codex_version: version,
+            trusted_renderer_sha256: renderers.baseline.sha256,
         };
         writeFileSync(join(output, 'experiment.json'), `${JSON.stringify(experiment, null, 2)}\n`);
 
@@ -715,6 +811,7 @@ export function main(argv = process.argv.slice(2)) {
                         repetition,
                         scenario,
                         source: sources[arm],
+                        renderer: renderers[arm],
                         codexBin: values['codex-bin'],
                         codexVersionValue: version,
                         model: values.model,

--- a/test/eval.test.mjs
+++ b/test/eval.test.mjs
@@ -1,14 +1,32 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import {
+    chmodSync,
+    cpSync,
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    statSync,
+    writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { parseExecEvents, validateScenario } from '../eval/run.mjs';
+import { parseExecEvents, rendererEnvironment, validateScenario } from '../eval/run.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const RUNNER = join(ROOT, 'eval', 'run.mjs');
+const SNAPSHOT_PATHS = ['package.json', 'bin', 'templates', 'backends', 'harnesses', 'profiles'];
+
+function copySnapshot(destination) {
+    mkdirSync(destination, { recursive: true });
+    for (const rel of SNAPSHOT_PATHS) {
+        cpSync(join(ROOT, rel), join(destination, rel), { recursive: true });
+    }
+}
 
 function fakeCodexSource() {
     return `#!/usr/bin/env node
@@ -158,6 +176,138 @@ test('scenario assertion schemas fail during preflight with precise locations', 
     }
 });
 
+test('snapshot executables stay inert while snapshot template data still changes the result', { timeout: 120_000 }, () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-eval-untrusted-snapshot-'));
+    try {
+        const candidate = join(scratch, 'candidate');
+        const fakeCodex = join(scratch, 'codex');
+        const output = join(scratch, 'results');
+        const secretCopy = join(scratch, 'copied-secret.txt');
+        const outsideWrite = join(scratch, 'outside-fixture.txt');
+        const networkMarker = join(scratch, 'network-attempted.txt');
+        copySnapshot(candidate);
+        writeFileSync(fakeCodex, fakeCodexSource());
+        chmodSync(fakeCodex, 0o755);
+
+        writeFileSync(join(candidate, 'bin', 'cycle.mjs'), [
+            "import { writeFileSync } from 'node:fs';",
+            `writeFileSync(${JSON.stringify(secretCopy)}, process.env.CYCLE_EVAL_TEST_SECRET ?? 'missing');`,
+            `writeFileSync(${JSON.stringify(outsideWrite)}, 'candidate renderer executed\\n');`,
+            `writeFileSync(${JSON.stringify(networkMarker)}, 'candidate attempted network\\n');`,
+            "await fetch('http://127.0.0.1:9/evaluator-probe');",
+            '',
+        ].join('\n'));
+        const candidateTemplate = join(candidate, 'templates', 'skills', 'implement.md.tmpl');
+        writeFileSync(candidateTemplate, `${readFileSync(candidateTemplate, 'utf8').trimEnd()}\n\nCandidate data marker.\n`);
+
+        const rendererEnv = rendererEnvironment(join(scratch, 'renderer-control'), {
+            PATH: process.env.PATH ?? '',
+            LANG: 'C',
+            CYCLE_EVAL_TEST_SECRET: 'must-not-be-forwarded',
+            NODE_OPTIONS: '--inspect',
+        });
+        assert.equal(rendererEnv.CYCLE_EVAL_TEST_SECRET, undefined);
+        assert.equal(rendererEnv.NODE_OPTIONS, undefined);
+
+        execFileSync(process.execPath, [
+            RUNNER,
+            '--baseline', ROOT,
+            '--candidate', candidate,
+            '--model', 'fake-model',
+            '--output', output,
+            '--codex-bin', fakeCodex,
+            '--scenario', 'safe-bounded',
+            '--timeout-ms', '30000',
+        ], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            stdio: 'pipe',
+            env: { ...process.env, CYCLE_EVAL_TEST_SECRET: 'must-not-be-forwarded' },
+        });
+
+        assert.equal(existsSync(secretCopy), false);
+        assert.equal(existsSync(outsideWrite), false);
+        assert.equal(existsSync(networkMarker), false);
+        const results = readFileSync(join(output, 'results.jsonl'), 'utf8')
+            .trim()
+            .split('\n')
+            .map((line) => JSON.parse(line));
+        assert.equal(results.length, 2);
+        const baseline = results.find((result) => result.arm === 'baseline');
+        const changed = results.find((result) => result.arm === 'candidate');
+        assert.ok(baseline.passed);
+        assert.ok(changed.passed);
+        assert.notEqual(baseline.snapshot.source_sha256, changed.snapshot.source_sha256);
+        assert.notEqual(baseline.snapshot.rendered_skill_sha256, changed.snapshot.rendered_skill_sha256);
+        assert.equal(baseline.trusted_renderer_sha256, changed.trusted_renderer_sha256);
+
+        for (const result of results) {
+            const codexEnv = JSON.parse(readFileSync(join(
+                output,
+                result.artifacts.workspace,
+                '.cycle-eval',
+                'codex-env.json',
+            ), 'utf8'));
+            assert.equal(codexEnv.forwarded_sentinel, false);
+        }
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
+test('snapshot harness data cannot route executable content onto the fixture control test', { timeout: 120_000 }, () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-eval-hostile-harness-'));
+    try {
+        const candidate = join(scratch, 'candidate');
+        const fakeCodex = join(scratch, 'codex');
+        const output = join(scratch, 'results');
+        const executionMarker = join(scratch, 'snapshot-code-executed.txt');
+        copySnapshot(candidate);
+        writeFileSync(fakeCodex, fakeCodexSource());
+        chmodSync(fakeCodex, 0o755);
+        writeFileSync(join(candidate, 'profiles', 'lean.jsonc'), `${JSON.stringify({
+            name: 'lean',
+            skills: ['implement'],
+        }, null, 2)}\n`);
+        writeFileSync(join(candidate, 'harnesses', 'codex.jsonc'), `${JSON.stringify({
+            name: 'codex',
+            display: 'Codex CLI',
+            root: 'test',
+            skill_file: '../feature.test.mjs',
+            capabilities: { has_menus: false, has_subagents: true },
+            notes: { attribution: 'hostile snapshot', ask: 'plain chat' },
+        }, null, 2)}\n`);
+        writeFileSync(join(candidate, 'templates', 'skills', 'implement.md.tmpl'), [
+            "import { test } from 'node:test';",
+            "import assert from 'node:assert/strict';",
+            "import { writeFileSync } from 'node:fs';",
+            `writeFileSync(${JSON.stringify(executionMarker)}, 'executed outside Codex sandbox\\n');`,
+            "test('hostile replacement', () => assert.ok(true));",
+            '',
+        ].join('\n'));
+
+        const result = spawnSync(process.execPath, [
+            RUNNER,
+            '--baseline', ROOT,
+            '--candidate', candidate,
+            '--model', 'fake-model',
+            '--output', output,
+            '--codex-bin', fakeCodex,
+            '--scenario', 'safe-bounded',
+            '--timeout-ms', '30000',
+        ], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            env: { ...process.env, CYCLE_EVAL_TEST_SECRET: 'must-not-be-forwarded' },
+        });
+        assert.equal(result.status, 2);
+        assert.match(result.stderr, /snapshot harness codex must use root \.agents\/skills and skill_file SKILL\.md/);
+        assert.equal(existsSync(executionMarker), false);
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
 test('behavioral runner compares isolated snapshots without making a model call', { timeout: 120_000 }, () => {
     const scratch = mkdtempSync(join(tmpdir(), 'cycle-eval-test-'));
     try {
@@ -198,6 +348,8 @@ test('behavioral runner compares isolated snapshots without making a model call'
         assert.ok(results.every((result) => result.codex_version === 'fake-codex 1.0'));
         assert.ok(results.every((result) => result.usage.input_tokens === 100));
         assert.ok(results.every((result) => /^[a-f0-9]{64}$/.test(result.snapshot.source_sha256)));
+        assert.ok(results.every((result) => /^[a-f0-9]{64}$/.test(result.trusted_renderer_sha256)));
+        assert.equal(new Set(results.map((result) => result.trusted_renderer_sha256)).size, 1);
 
         for (const scenario of new Set(results.map((result) => result.scenario))) {
             const pair = results.filter((result) => result.scenario === scenario);
@@ -215,6 +367,7 @@ test('behavioral runner compares isolated snapshots without making a model call'
         assert.equal(experiment.codex_version, 'fake-codex 1.0');
         assert.match(experiment.baseline.source_sha256, /^[a-f0-9]{64}$/);
         assert.match(experiment.candidate.source_sha256, /^[a-f0-9]{64}$/);
+        assert.equal(experiment.trusted_renderer_sha256, results[0].trusted_renderer_sha256);
 
         const invocation = JSON.parse(readFileSync(join(
             output,


### PR DESCRIPTION
## Summary

- render baseline and candidate snapshot data with the reviewed runner-owned CLI instead of executing snapshot `bin/cycle.mjs`
- stage only templates, backends, harnesses, and profiles; reject unsafe path inputs; launch the renderer and Codex with explicit environment allowlists
- record the trusted renderer hash separately from snapshot provenance and document that candidate engine behavior is outside this evaluator

## Security review

The mandatory review found that snapshot-controlled harness paths could redirect a rendered template onto the fixture control test. The patch now pins evaluator output to `.agents/skills/<name>/SKILL.md`, fingerprints the control test before rendering, aborts if it changes, and includes the prior exploit as a regression. Focused independent re-review found the execution path closed with no remaining snapshot-data route to host execution, host-external reads or writes, or network access.

## Verification

- `node --test test/eval.test.mjs` — 5 passed
- `node bin/cycle.mjs lint` — passed
- `npm test` — 288 passed
- `node bin/cycle.mjs check` — clean
- `git diff --check` — passed

Closes #102

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)
