### PR TITLE
feat(eval): freeze isolated review protocol

### DIFF
--- a/docs/EVALUATION.md
+++ b/docs/EVALUATION.md
@@ -54,3 +54,105 @@ Model-backed runs are externally metered and intentionally absent from `npm test
 Ordinary tests exercise fixture isolation, the tracker double, JSONL parsing, assertions, and
 result formatting with a fake Codex executable. A behavioral FAIL is evidence in `results.jsonl`,
 not a merge-gate exit code; invalid runner or harness execution exits 2.
+
+## Release Relay review study
+
+`eval/review/` is a separate preregistered retrospective study for one narrower public claim:
+pre-existing repository-specific review guidance helps one strong model find consequential edge
+cases and give more actionable review evidence than the same model with a strong generic prompt.
+The [case census](../eval/review/CENSUS.md) is purposive and illustrative; it is not a defect-rate
+or prevalence sample.
+
+The frozen protocol contains four flawed Release Relay changes, two named-target-clean controls,
+two arms, and three repetitions. That is 18 matched pairs and 36 valid scored cells. Model, effort,
+timeout, prompt, schema, permissions, ordering seed, fixture commit time, invalid-pair rule, captured
+original tasks, normalized tasks, guidance, source trees, candidate patches, repairs, hidden
+oracles, census, and score schema are all hashed before scoring.
+
+### Model-free validation
+
+Use a local Release Relay checkout containing the pinned public commits. Historical lockfiles must
+be present in pnpm's store so verification can remain offline. If the cache is incomplete, populate
+it explicitly:
+
+```sh
+node eval/review/run.mjs fetch-cache \
+  --source ../release-relay \
+  --allow-network
+```
+
+That is the only dependency-network step. It uses a private temporary home, does not inherit npm
+credentials, fetches from the public npm registry, runs no package lifecycle scripts, and does not
+invoke a model. It is never called automatically by preflight or scoring.
+
+Then run both model-free checks:
+
+```sh
+node eval/review/run.mjs dry-run --output /tmp/review-eval-dry
+
+node eval/review/run.mjs preflight \
+  --source ../release-relay \
+  --output /tmp/review-eval-preflight
+```
+
+The fake run exercises the complete seeded schedule, a deliberately invalid cell and paired retry,
+successful content-backed reads of both guidance files, normalization, blinded scoring input, and
+private artifact writing. Preflight
+reconstructs all six one-commit repositories, checks the artifact lock and history truncation,
+probes filesystem isolation, and proves every hidden oracle is green before insertion, red on the
+flaw, and green after repair. It records `scored_model_calls: 0`.
+
+Every scored `run` repeats the full preflight before authenticating or invoking the model. A red
+artifact, oracle, history, or filesystem-isolation check therefore stops before the first scored
+cell. Review commands run through Codex's Linux sandbox with root denied, only the exact fixture and
+Codex runtime readable, and command network disabled. Source/evaluator repositories, sibling temp
+trees, memory, and hidden-oracle sentinels are not mounted. Fixtures have no remotes, tags,
+alternates, reflogs, or later objects.
+
+### Scored run brake
+
+A scored run is metered and permanently burns these published cases for future model/workflow
+comparisons. It also uses the caller's existing Codex login through an outer-client symlink, so it
+is a separate manual security/cost decision. After reviewing the model-free artifacts, calculate
+and explicitly confirm the exact protocol bytes:
+
+```sh
+sha256sum eval/review/protocol.json
+
+node eval/review/run.mjs run \
+  --source ../release-relay \
+  --output /tmp/review-eval-scored \
+  --confirm-protocol-sha256 EXACT_HASH_FROM_ABOVE
+```
+
+Do not commit scored output. Authentication remains only in a mode-0700 disposable Codex home and
+is never copied into candidate fixtures. Reviewer commands inherit no shell environment, cannot
+read that home, and receive no credentials. Before any reviewer stream is persisted, the runner
+fails closed if it contains a long value from `auth.json`. The home and symlink are removed after
+each cell.
+
+### Scoring and reporting
+
+Give only `scoring/scoring-input.json`, `scoring/score.schema.json`, and its opaque fixture diffs to
+two independent scorers. The input contains normalized finding fields and deterministic A/B labels;
+it omits summaries, plans, arm/case identifiers, tool traces, usage, and timing. Each scorer locks a
+separate schema-valid file before seeing the private map. Preserve both originals, then adjudicate
+disagreements with written evidence from the frozen fixture.
+
+Score each frozen target as `caught`, `partial`, or `missed`. Separately record whether the finding
+gives a bounded repair direction and a regression test that would fail on the flawed fixture and
+pass after repair. Count a finding as unsupported only when independent inspection disproves it;
+absence from the historical repair is not evidence. Named-target recall is not applicable on clean
+controls, while every finding on a control is still independently adjudicated.
+
+Report target-level arm counts, paired wins/ties/losses, both actionability rates, and disproved
+finding counts. Report controls, tokens, elapsed time, reviewer count, and guidance-read lifecycle
+evidence separately. Do not combine them into one score, claim statistical significance, or infer
+population prevalence from repeated samples of six fixed changes.
+
+Raw `private/runs/`, `private/results.jsonl`, `private/experiment.json`, the blinding map,
+per-cell measures, stderr, and event streams remain mode-0700/0600 private because they contain arm
+mappings, tool traces, and possibly host-local metadata. Public artifacts are limited to the frozen
+protocol/census, path-scrubbed preflight summary, normalized scoring packets and locked score files,
+and a reviewed aggregate report. The requested output root is also mode 0700 by default; copy only
+the allowlisted artifacts when sharing them.

--- a/docs/EVALUATION.md
+++ b/docs/EVALUATION.md
@@ -97,17 +97,27 @@ node eval/review/run.mjs preflight \
 
 The fake run exercises the complete seeded schedule, a deliberately invalid cell and paired retry,
 successful content-backed reads of both guidance files, normalization, blinded scoring input, and
-private artifact writing. Preflight
+private artifact writing. `dry-run-batch` exercises the same path one matched pair at a time and
+resumes from the same output directory:
+
+```sh
+node eval/review/run.mjs dry-run-batch --output /tmp/review-eval-dry-batched
+```
+
+Repeat that command 18 times; each successful invocation prints a receipt with reviewer calls,
+invalid attempts, reported token usage, elapsed time, and completed/remaining pairs. The first fake
+pair deliberately retries both arms, so its receipt shows four calls; ordinary pairs show two.
+Preflight
 reconstructs all six one-commit repositories, checks the artifact lock and history truncation,
 probes filesystem isolation, and proves every hidden oracle is green before insertion, red on the
 flaw, and green after repair. It records `scored_model_calls: 0`.
 
-Every scored `run` repeats the full preflight before authenticating or invoking the model. A red
-artifact, oracle, history, or filesystem-isolation check therefore stops before the first scored
-cell. Review commands run through Codex's Linux sandbox with root denied, only the exact fixture and
-Codex runtime readable, and command network disabled. Source/evaluator repositories, sibling temp
-trees, memory, and hidden-oracle sentinels are not mounted. Fixtures have no remotes, tags,
-alternates, reflogs, or later objects.
+Every scored `run` or `run-batch` repeats the full preflight before authenticating or invoking the
+model. A red artifact, oracle, history, or filesystem-isolation check therefore stops before the
+first scored cell. Review commands run through Codex's Linux sandbox with root denied, only the
+exact fixture and Codex runtime readable, and command network disabled. Source/evaluator
+repositories, sibling temp trees, memory, and hidden-oracle sentinels are not mounted. Fixtures
+have no remotes, tags, alternates, reflogs, or later objects.
 
 ### Scored run brake
 
@@ -124,6 +134,26 @@ node eval/review/run.mjs run \
   --output /tmp/review-eval-scored \
   --confirm-protocol-sha256 EXACT_HASH_FROM_ABOVE
 ```
+
+For quota-monitored execution, use `run-batch` with the same output directory and exact hash. Each
+invocation completes exactly one matched pair, including both arms of its single allowed retry, and
+then stops with a receipt:
+
+```sh
+node eval/review/run.mjs run-batch \
+  --source ../release-relay \
+  --output /tmp/review-eval-scored \
+  --confirm-protocol-sha256 EXACT_HASH_FROM_ABOVE
+```
+
+Resume validates an exact completed prefix of the frozen schedule plus the protocol bytes, model,
+effort, Codex version, result index, private per-cell results, artifact paths, and artifact hashes
+before another reviewer call. A lock prevents concurrent batches. An `active-pair.json` marker is
+written before either arm starts and removed only after the complete pair is persisted; if a process
+dies mid-pair, later invocations fail closed so no model call is silently duplicated. Inspect the
+private artifacts and quota state before manually removing a stale marker or lock. Preflight-only
+state from a batch that never reached its first checkpoint can be reused safely with the same
+command and output directory.
 
 Do not commit scored output. Authentication remains only in a mode-0700 disposable Codex home and
 is never copied into candidate fixtures. Reviewer commands inherit no shell environment, cannot

--- a/eval/review/CENSUS.md
+++ b/eval/review/CENSUS.md
@@ -1,0 +1,92 @@
+# Release Relay review-evaluation census
+
+This is a purposive retrospective suite, not a prevalence sample. Its bounded claim is whether the
+already-existing Release Relay review guidance improves review of these reconstructable changes.
+It does not estimate how often the-cycle finds defects in general.
+
+## Pool and eligibility
+
+The candidate era starts at the earliest selected base (`674f4d4`) and ends at the last selected
+repair (`dfa1467`). The census contains every mainline commit in that interval whose subject starts
+with `fix(`, plus `c930975`, the pre-squash review correction attached to PR #31. This subject-based
+pool can miss repairs labeled another way; that is a stated selection limitation.
+
+A case is eligible only when all five conditions hold:
+
+1. the original public task context exists;
+2. the introducing flawed change can be reconstructed as an uncommitted diff over its base;
+3. the candidate and tests can run offline with injected or local doubles;
+4. a later committed regression test fails on the flaw and passes with the production repair; and
+5. the defect is reviewable from the introducing diff rather than requiring later operational data.
+
+The suite is capped at four flawed cases. Eligible cases beyond that cap remain named reserves,
+not hidden degrees of freedom. Selection favors distinct consequential API-boundary mechanisms:
+source boundary validation, provenance grounding, event ordering, and pagination/idempotency.
+
+## Included cases
+
+| Repair | Original task / flawed change | Why included |
+| --- | --- | --- |
+| `c930975` | issue #30 / `57d1b37` | A pre-merge second-model review correction with two separable GitHub comparison-boundary targets and a committed injected-client oracle. |
+| `17e47ab` | issue #9 / `38e5748` | An OpenAI grounding postcondition accepted citations to candidates excluded from provider input; the repair supplies an offline regression oracle. |
+| `7d57564` | issue #11 / `d5b8bf3` | Same-second distinct Stripe events were collapsed by timestamp ordering; the pure core-domain oracle applies without provider access. |
+| `dfa1467` | issue #12 / `9d29ef7` | First-page-only Stripe catalog resolution could duplicate or ambiguously bind resources; injected fakes reproduce it offline. |
+
+The GitHub and pagination cases also have target-clean controls made by applying only the named
+production repair to the same candidate. “Clean” means only that the named target is repaired;
+other findings must still be independently checked.
+
+## Eligible reserves
+
+These passed the five criteria but were not selected after the four-case cap and mechanism balance
+were frozen.
+
+| Repair | Mechanism | Disposition |
+| --- | --- | --- |
+| `f08b1ec` (#68) | Conflicting mock-runtime operation-ID reuse | Reserve: overlaps the selected idempotency family. |
+| `0db76a6` (#69) | Case-sensitive GitHub repository identity | Reserve: overlaps the selected GitHub identity-boundary family. |
+| `80194d8` (#74) | Unbounded webhook raw body before signature verification | Reserve: distinct security/resource-bound case for a later, separately preregistered suite. |
+
+## Excluded census entries
+
+| Repair | Reason for exclusion |
+| --- | --- |
+| `5ba6137` (#31) | Final squash of the same PR represented by the more informative flawed `57d1b37` → review correction `c930975`; duplicate family/observation. |
+| `5c64094` (#33) | Follow-up GitHub comparison-boundary hardening overlaps the selected #30 case rather than adding an independent family. |
+| `2ac65db` (#49) | Coverage-oracle manifest pin: evaluator/process infrastructure, not an application candidate review. |
+| `67e2ff1` (#57) | Coverage-oracle source-checkout separation: evaluator isolation/process failure, not an application diff. |
+| `cb40449` (#64) | Static typed-construction cleanup with no distinct runtime regression oracle. |
+| `f08fd97` (#65) | SDK parameter and CLI cast hygiene with no distinct runtime regression oracle. |
+| `33175b8` (#73) | Type-narrowing cleanup with no independently failing runtime oracle. |
+| `8aaf7fc` (#75) | Coverage-oracle typed-construction cleanup, not an application candidate review. |
+| `98f4097` (#81) | Workflow routing correction; outside the code-review edge-case claim. |
+| `7938406` (#86) | Test-discovery gate correction; it changes which oracle runs instead of supplying an application defect case. |
+| `ef014b3` (#93) | Dead oracle-validator fallback; no reachable application behavior or distinct regression oracle. |
+| `112f6eb` (#95) | Deleted-customer webhook repair has no committed regression test in the repair, so criterion 4 fails. |
+| `e2a5c1f` (#96) | Architectural ownership/coupling move, not a bounded defect with an isolated fail/pass oracle. |
+| `23b68b4` (#112) | The later safe-integer test does not apply to the introducing publisher diff without manual adaptation, so criterion 4 fails for a frozen historical reconstruction. |
+
+## Task normalization record
+
+The four files in `original-prompts/` capture the public issue bodies for Release Relay issues
+#30, #9, #11, and #12 as observed on 2026-08-29. The corresponding files in `prompts/` are
+normalized from those frozen originals. The normalization is intentionally semantic, not verbatim:
+
+- `Fix (drafted)` became `Requested change` and “using current official documentation” was removed;
+- tracker dependencies, milestone/process language, and Breakscope-specific comparison wording were
+  removed or generalized;
+- non-goals were shortened to the external-action boundary relevant to the review; and
+- approval/brake wording became a neutral statement that no live provider call is authorized.
+
+Why, touched code, requested behavior, acceptance semantics, and the no-live-call boundary remain.
+Both the captured original and normalized file are hashed in `protocol.json`; changing even one
+byte invalidates preflight. The original issue numbers and immutable source commits remain in the
+protocol for auditability.
+
+## Selection limitations
+
+The cases come from one repository and a short development period, three of four concern external
+API boundaries, and one was already caught during an actual second-model review. Repetitions are
+multiple samples from the same model over the same diffs, not independent repositories. Once any
+scored output is produced, all six published fixtures are burned for future model/workflow
+comparisons; later use may be labeled only as replication or demonstration.

--- a/eval/review/common-prompt.md
+++ b/eval/review/common-prompt.md
@@ -1,0 +1,24 @@
+Review the current uncommitted diff against the task context below.
+
+This is a review-only evaluation. Do not modify files. Do not use the network, inspect paths
+outside this repository, or attempt to recover later history. Inspect the implementation, tests,
+and relevant repository documentation closely enough to identify consequential correctness,
+contract, safety, and edge-case defects.
+
+Before reviewing, read `.agents/skills/review/SKILL.md` if that repository-local guide exists.
+Otherwise perform a strong general code review using the same output contract.
+
+Return only findings that are actionable and caused by the uncommitted change. For each finding,
+provide:
+
+- severity: `P0`, `P1`, or `P2`;
+- the precise file and line;
+- the concrete mechanism;
+- a plausible consequence;
+- a repair direction; and
+- a regression test that would demonstrate the defect.
+
+Do not treat absence from an expected historical patch as evidence that a finding is false. If no
+actionable defect is present, return an empty findings array.
+
+Task context follows:

--- a/eval/review/fake-codex.cjs
+++ b/eval/review/fake-codex.cjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+const { existsSync, readFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+const args = process.argv.slice(2);
+
+if (args[0] === '--version') {
+    console.log('fake-review-codex 1.0');
+    process.exit(0);
+}
+
+if (args[0] !== 'exec') {
+    console.error('fake reviewer expected codex exec');
+    process.exit(2);
+}
+
+const cdIndex = args.indexOf('--cd');
+if (cdIndex < 0 || !args[cdIndex + 1]) {
+    console.error('fake reviewer requires --cd');
+    process.exit(2);
+}
+
+const workspace = args[cdIndex + 1];
+const guidancePaths = [
+    '.agents/skills/review/SKILL.md',
+    '.agents/skills/DOCTRINE.md',
+];
+const fakeMode = process.env.CYCLE_REVIEW_FAKE_MODE || 'default';
+let item = 0;
+
+console.log(JSON.stringify({ type: 'thread.started', thread_id: `fake-${process.env.CYCLE_REVIEW_CELL ?? 'cell'}` }));
+console.log(JSON.stringify({ type: 'turn.started' }));
+
+for (const path of guidancePaths) {
+    const guidance = join(workspace, path);
+    if (!existsSync(guidance)) continue;
+    const content = readFileSync(guidance, 'utf8');
+    console.log(JSON.stringify({
+        type: 'item.completed',
+        item: {
+            id: `item-${++item}`,
+            type: 'command_execution',
+            command: `cat ${path}`,
+            aggregated_output: fakeMode === 'guidance-mention-only'
+                ? 'mentioned a path without returning its contents\n'
+                : content,
+            exit_code: 0,
+            status: 'completed',
+        },
+    }));
+}
+
+const firstPair = process.env.CYCLE_REVIEW_PAIR_INDEX === '1';
+const exerciseInvalidRetry = fakeMode === 'default'
+    ? firstPair && process.env.CYCLE_REVIEW_ARM === 'baseline'
+        && process.env.CYCLE_REVIEW_ATTEMPT === '1'
+    : fakeMode === 'split-retry' && firstPair
+        && ((process.env.CYCLE_REVIEW_ARM === 'baseline' && process.env.CYCLE_REVIEW_ATTEMPT === '1')
+            || (process.env.CYCLE_REVIEW_ARM === 'treatment' && process.env.CYCLE_REVIEW_ATTEMPT === '2'));
+
+console.log(JSON.stringify({
+    type: 'item.completed',
+    item: {
+        id: `item-${++item}`,
+        type: 'agent_message',
+        text: exerciseInvalidRetry
+            ? 'deliberately invalid fake response'
+            : JSON.stringify({ findings: [], summary: 'No actionable findings in deterministic fake review.' }),
+    },
+}));
+console.log(JSON.stringify({
+    type: 'turn.completed',
+    usage: {
+        input_tokens: 100,
+        cached_input_tokens: 25,
+        output_tokens: 20,
+        reasoning_output_tokens: 5,
+    },
+}));

--- a/eval/review/findings.schema.json
+++ b/eval/review/findings.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["findings", "summary"],
+  "properties": {
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "severity",
+          "file",
+          "line",
+          "mechanism",
+          "consequence",
+          "recommendation",
+          "regression_test"
+        ],
+        "properties": {
+          "severity": { "enum": ["P0", "P1", "P2"] },
+          "file": { "type": "string", "minLength": 1 },
+          "line": { "type": "integer", "minimum": 1 },
+          "mechanism": { "type": "string", "minLength": 1 },
+          "consequence": { "type": "string", "minLength": 1 },
+          "recommendation": { "type": "string", "minLength": 1 },
+          "regression_test": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "summary": { "type": "string", "minLength": 1 }
+  }
+}

--- a/eval/review/original-prompts/issue-11.md
+++ b/eval/review/original-prompts/issue-11.md
@@ -1,0 +1,18 @@
+**Why:** Stripe behavior needs provider-independent sponsor truth before SDK objects or webhook payloads enter the domain. Money and membership state are too costly to infer from loose primitives.
+
+**Touches:** `packages/core/**`, pure domain tests, mock runtime billing responses, and sponsor sections of the spec/security docs.
+
+**Fix (drafted):** Add strict values and transitions for sponsor tiers, integer minor-unit money with currency, customer references, membership identity, and `pending | active | past_due | canceled | unknown` projection. Distinguish configured tiers from synchronized provider resources and browser-session results from verified membership state.
+
+**Acceptance:**
+- Amounts reject floats, negative values, unsupported/invalid currency shapes, and accidental unit conversion.
+- A Checkout or portal URL cannot transition membership to active.
+- Membership transitions preserve provider event identity and ordering metadata.
+- Unknown/incomplete input yields `unknown`, not optimistic active or canceled state.
+- Tests cover duplicate, stale, and out-of-order transition inputs.
+- Core imports no Stripe SDK types, environment access, network, or web framework.
+- All gates pass.
+
+**Dependencies:** M1 core contracts and mock runtime are complete.
+
+**Non-goals:** Stripe SDK usage, tax/accounting, entitlements, discounts, invoices UI, persistence, or real money.

--- a/eval/review/original-prompts/issue-12.md
+++ b/eval/review/original-prompts/issue-12.md
@@ -1,0 +1,21 @@
+**Why:** Sponsor memberships need realistic Stripe-hosted flows without handling card data. Resource creation must be explicit and idempotent so retries do not create duplicate products, prices, customers, or sessions.
+
+**Touches:** `packages/stripe-integration/**`, dependency manifests, injected-client tests, mock composition, billing/security docs, and reviewed oracle expectations.
+
+**Fix (drafted):** Using current official documentation, implement the sponsor-billing port for product/price synchronization, Checkout Session creation, and customer portal session creation. Use explicit idempotency keys, immutable price handling, fixed allowlisted return routes, safe result mapping, and SDK construction only in an explicit live-billing composition root.
+
+**Acceptance:**
+- Product/price synchronization reuses matching resources and never silently mutates an active price into a different amount/currency.
+- Checkout and portal operations use Stripe-hosted surfaces and return typed session references without treating redirects as membership truth.
+- Reusing an operation ID cannot create a second intended resource.
+- Tests cover duplicate retry, changed tier configuration, missing customer, provider refusal, rate limit, and ambiguous timeout through injected fakes.
+- No card data, raw SDK error, secret, full URL with token, or request body reaches logs.
+- Mock mode and tests perform no live call or DNS work.
+- Oracle expectations cover product-shaped Stripe calls independently of detector output.
+- All gates pass.
+
+**Dependencies:** Sponsor/money contracts and M1 operation results are merged.
+
+**Non-goals:** Running a live Stripe call, creating real resources, tax, discounts, metered billing, custom payment UI, or deployment.
+
+**Approval note:** Adding this live-capable adapter and every future live mutation are separate brake decisions.

--- a/eval/review/original-prompts/issue-30.md
+++ b/eval/review/original-prompts/issue-30.md
@@ -1,0 +1,26 @@
+**Why:** The live GitHub reader accepts a comparison range but currently discards the comparison payload and returns repository-wide closed pull requests, issues, contributors, and releases. A reproduced identical `main...main` range with no commits still returned an unrelated old merged pull request. That violates `docs/spec.md`'s source-grounded range workflow and can put unrelated historical work into a release candidate.
+
+**Evidence:** In `packages/github-integration/src/live.ts`, `compare()` only validates that `compareCommits` returned an object, then independently pages `pulls.list`, `issues.listForRepo`, `repos.listContributors`, and `repos.listReleases` without filtering their results through the selected comparison. The live mapper also hard-codes empty PR/issue links and `reverted: false`, so the product assembler's deduplication and reverted-work behavior cannot be grounded from live data.
+
+**Touches:** `packages/github-integration/src/live.ts`, its injected-client tests, GitHub read DTOs in `packages/core/**` if the range evidence needs a stricter shape, `docs/architecture.md`, `docs/spec.md` only if the reviewed contract needs clarification, and the source-derived oracle expectations.
+
+**Fix (drafted):** Using current official Octokit documentation, make the comparison response the authoritative boundary for candidate source selection. Derive a bounded set of merged pull requests and contributors from comparison evidence and approved read endpoints; derive linked issue and reverted-work metadata under an explicit tested rule; keep prior releases as clearly separated context. Reject provider responses whose repository identity conflicts with configured scope, and classify conflict responses as conflicts rather than authorization failures. Do not replace the bug with date-only repository-wide filtering or unbounded per-commit fan-out.
+
+**Acceptance:**
+- An identical or empty comparison yields no pull-request or issue candidates even when repository-wide endpoints contain old closed work.
+- A merged pull request evidenced by the selected range is retained; an unrelated merged pull request is excluded.
+- Linked issue metadata lets `assembleCandidates` avoid duplicating one change, and the derivation rule is documented and tested.
+- Reverted work is either grounded and marked excluded or reported under an explicit conservative fallback; it is never silently hard-coded non-reverted.
+- Contributor identities are grounded in the selected range rather than the repository's all-time contributor list.
+- Prior releases remain contextual and cannot become candidates.
+- Repository identity mismatches are rejected safely; HTTP 409/422 responses map to `conflict`, not `authorization`.
+- API fan-out and pagination are bounded with tests for maximum work, partial responses, authorization, rate limits, and empty ranges.
+- Tests use injected fakes and perform no live request or DNS work.
+- Oracle changes are derived from the intended source/API surface before any Breakscope comparison.
+- `pnpm check`, `pnpm build`, and applicable workflow checks pass.
+
+**Dependencies:** M1 and the shipped M2 contracts are complete. This is the M2 retrospective repair and should land before M3 is promoted.
+
+**Non-goals:** Running a live GitHub call, changing authentication, adding webhooks or writes, choosing hosted persistence, per-file repository reads, unbounded commit fan-out, UI work, or changing Breakscope.
+
+**Approval note:** Adding or changing the live-capable GitHub read surface is a repository brake. The cycle must present the exact SDK endpoints and bounds before implementation proceeds.

--- a/eval/review/original-prompts/issue-9.md
+++ b/eval/review/original-prompts/issue-9.md
@@ -1,0 +1,20 @@
+**Why:** OpenAI is one useful drafting provider and a major Breakscope coverage surface. Its adapter must stay narrow, structured, mock-testable, and visibly separate from any authorization to send maintainer content.
+
+**Touches:** `packages/openai-integration/**`, dependency manifests, injected-client contract tests, mock composition, AI/security docs, and reviewed oracle expectations.
+
+**Fix (drafted):** Using current official documentation, implement a structured OpenAI Responses adapter for the release-draft contract. Build bounded input from selected candidate fields, request a strict schema, disable storage where supported, validate the response through core postconditions, classify refusals/errors safely, and construct the SDK only in an explicit live-AI composition root.
+
+**Acceptance:**
+- The request includes only selected candidate content documented by a testable input builder.
+- Structured output and source-reference postconditions are both enforced.
+- Refusal, truncation, invalid structure, invented source identity, rate limit, and safe provider failure have injected-client tests.
+- Provider request/response bodies, prompts, credentials, and raw errors are never logged.
+- Default mock mode and all tests perform no live call or DNS work.
+- The oracle records product-shaped SDK/model/call-site expectations independently of Breakscope output.
+- All gates pass.
+
+**Dependencies:** The draft/provenance contract is merged and M1 mock mode is available.
+
+**Non-goals:** Running a live evaluation, choosing production models, tools/function calling, streaming UI, persistence, or automatic provider fallback.
+
+**Approval note:** Adding the live-capable adapter and any later live evaluation are separate brake decisions.

--- a/eval/review/prompts/rr-a7f2.md
+++ b/eval/review/prompts/rr-a7f2.md
@@ -1,0 +1,45 @@
+## Why
+
+The live GitHub reader accepts a comparison range but currently discards the comparison payload
+and returns repository-wide closed pull requests, issues, contributors, and releases. A reproduced
+identical `main...main` range with no commits still returned an unrelated old merged pull request.
+That violates the source-grounded range workflow and can put unrelated historical work into a
+release candidate.
+
+## Evidence
+
+In `packages/github-integration/src/live.ts`, `compare()` only validates that `compareCommits`
+returned an object, then independently pages repository-wide endpoints without filtering their
+results through the selected comparison. The live mapper also hard-codes empty PR/issue links and
+`reverted: false`, so assembler deduplication and reverted-work behavior cannot be grounded from
+live data.
+
+## Touches
+
+`packages/github-integration/src/live.ts`, its injected-client tests, GitHub read DTOs in
+`packages/core/**` if range evidence needs a stricter shape, architecture/spec documentation only
+if the reviewed contract needs clarification, and source-derived oracle expectations.
+
+## Requested change
+
+Make the comparison response the authoritative boundary for candidate source selection. Derive a
+bounded set of merged pull requests and contributors from comparison evidence and approved read
+endpoints; derive linked issue and reverted-work metadata under an explicit tested rule; keep prior
+releases as separated context. Reject provider responses whose repository identity conflicts with
+configured scope, and classify conflict responses as conflicts rather than authorization failures.
+Do not replace the bug with date-only filtering or unbounded per-commit fan-out.
+
+## Acceptance
+
+- An identical or empty comparison yields no pull-request or issue candidates even when
+  repository-wide endpoints contain old closed work.
+- A merged pull request evidenced by the range is retained; an unrelated one is excluded.
+- Linked issue metadata lets the assembler avoid duplicating one change, under a documented rule.
+- Reverted work is grounded or reported under an explicit conservative fallback.
+- Contributor identities are grounded in the selected range.
+- Prior releases remain contextual and cannot become candidates.
+- Repository identity mismatches are rejected safely; HTTP 409/422 map to `conflict`.
+- API fan-out and pagination are bounded and tested.
+- Tests use injected fakes with no live request or DNS work.
+
+No live GitHub call is authorized as part of this task.

--- a/eval/review/prompts/rr-k3m8.md
+++ b/eval/review/prompts/rr-k3m8.md
@@ -1,0 +1,30 @@
+## Why
+
+OpenAI is one useful drafting provider. Its adapter must stay narrow, structured, mock-testable,
+and visibly separate from any authorization to send maintainer content.
+
+## Touches
+
+`packages/openai-integration/**`, dependency manifests, injected-client contract tests, mock
+composition, AI/security documentation, and reviewed oracle expectations.
+
+## Requested change
+
+Implement a structured OpenAI Responses adapter for the release-draft contract. Build bounded
+input from selected candidate fields, request a strict schema, disable storage where supported,
+validate the response through core postconditions, classify refusals/errors safely, and construct
+the SDK only in an explicit live-AI composition root.
+
+## Acceptance
+
+- The request includes only selected candidate content documented by a testable input builder.
+- Structured output and source-reference postconditions are both enforced.
+- Refusal, truncation, invalid structure, invented source identity, rate limit, and safe provider
+  failure have injected-client tests.
+- Provider request/response bodies, prompts, credentials, and raw errors are never logged.
+- Default mock mode and all tests perform no live call or DNS work.
+- The oracle records product-shaped SDK/model/call-site expectations independently of detector
+  output.
+- All gates pass.
+
+No live evaluation or provider call is authorized as part of this task.

--- a/eval/review/prompts/rr-p9v4.md
+++ b/eval/review/prompts/rr-p9v4.md
@@ -1,0 +1,29 @@
+## Why
+
+Stripe behavior needs provider-independent sponsor truth before SDK objects or webhook payloads
+enter the domain. Money and membership state are too costly to infer from loose primitives.
+
+## Touches
+
+`packages/core/**`, pure domain tests, mock runtime billing responses, and sponsor sections of the
+specification and security documentation.
+
+## Requested change
+
+Add strict values and transitions for sponsor tiers, integer minor-unit money with currency,
+customer references, membership identity, and `pending | active | past_due | canceled | unknown`
+projection. Distinguish configured tiers from synchronized provider resources and browser-session
+results from verified membership state.
+
+## Acceptance
+
+- Amounts reject floats, negative values, unsupported/invalid currency shapes, and accidental unit
+  conversion.
+- A Checkout or portal URL cannot transition membership to active.
+- Membership transitions preserve provider event identity and ordering metadata.
+- Unknown or incomplete input yields `unknown`, not optimistic active or canceled state.
+- Tests cover duplicate, stale, and out-of-order transition inputs.
+- Core imports no Stripe SDK types, environment access, network, or web framework.
+- All gates pass.
+
+Stripe SDK usage, persistence, and real money are out of scope.

--- a/eval/review/prompts/rr-w5c1.md
+++ b/eval/review/prompts/rr-w5c1.md
@@ -1,0 +1,33 @@
+## Why
+
+Sponsor memberships need realistic Stripe-hosted flows without handling card data. Resource
+creation must be explicit and idempotent so retries do not create duplicate products, prices,
+customers, or sessions.
+
+## Touches
+
+`packages/stripe-integration/**`, dependency manifests, injected-client tests, mock composition,
+billing/security documentation, and reviewed oracle expectations.
+
+## Requested change
+
+Implement the sponsor-billing port for product/price synchronization, Checkout Session creation,
+and customer portal session creation. Use explicit idempotency keys, immutable price handling,
+fixed allowlisted return routes, safe result mapping, and SDK construction only in an explicit
+live-billing composition root.
+
+## Acceptance
+
+- Product/price synchronization reuses matching resources and never silently mutates an active
+  price into a different amount/currency.
+- Checkout and portal operations use Stripe-hosted surfaces and return typed session references
+  without treating redirects as membership truth.
+- Reusing an operation ID cannot create a second intended resource.
+- Tests cover duplicate retry, changed tier configuration, missing customer, provider refusal,
+  rate limit, and ambiguous timeout through injected fakes.
+- No card data, raw SDK error, secret, full URL with token, or request body reaches logs.
+- Mock mode and tests perform no live call or DNS work.
+- Oracle expectations cover product-shaped Stripe calls independently of detector output.
+- All gates pass.
+
+No live Stripe call or resource creation is authorized as part of this task.

--- a/eval/review/protocol.json
+++ b/eval/review/protocol.json
@@ -37,6 +37,9 @@
     "seed": "release-relay-review-v1-2026-08-29",
     "repetitions": 3,
     "invalid_pair_retry_limit": 1,
+    "pairs_per_batch": 1,
+    "batch_unit": "matched_pair",
+    "resume_rule": "Each batch invocation completes exactly one matched pair, including its paired retry if needed. Resume only from an exact validated prefix of the frozen schedule; a mid-pair marker or state drift stops before another reviewer call.",
     "invalid_run_rule": "Invalidate and rerun both arms for the same case and repetition; preserve the invalid attempt."
   },
   "execution": {
@@ -81,6 +84,7 @@
       "fixture history or remote leakage",
       "filesystem-isolation probe failure",
       "hidden-oracle fail/pass preflight failure",
+      "resume state, artifact content, model, effort, Codex version, protocol, or schedule mismatch",
       "authentication path or material in a fixture, reviewer command environment, or captured public artifact"
     ],
     "pair_rule": "If either cell is invalid, retain both attempts and rerun the pair once. If either retry is invalid, stop incomplete and score neither attempt from that pair."
@@ -208,7 +212,7 @@
     }
   ],
   "artifact_lock": {
-    "runner_sha256": "30096df14e4f696ceb8227915d9b80a1b64f24991a3660d2255da29f6661d653",
+    "runner_sha256": "75a1174e31bae8ecfe0d76dcb98a8bbae31451b2d5b4ceb4654e801c203e93c5",
     "fake_reviewer_sha256": "ab8ae64aa52dec26608af0196711d89fb7cae0134df53e9b86c8f71d6b9ccc06",
     "census_sha256": "1eb2272dfdb5110663f277cf70d661dbbc487e73f0b71d6f3e9e8b3b7f20e603",
     "common_prompt_sha256": "98bae734100e4316267052c0f466f8f75658be1ef4702edf1d6b1fc31076353e",

--- a/eval/review/protocol.json
+++ b/eval/review/protocol.json
@@ -1,0 +1,257 @@
+{
+  "version": 1,
+  "study_id": "release-relay-review-v1",
+  "claim": "Pre-existing repository-specific review guidance helps a single model identify consequential edge cases and produce more actionable review evidence than a strong generic review prompt.",
+  "census_path": "CENSUS.md",
+  "source": {
+    "repository": "https://github.com/brndnsh-labs/release-relay.git",
+    "review_guidance_commit": "674f4d4a4f1588e7e8345dd7019142b41b255339",
+    "review_guidance_paths": [
+      ".agents/skills/review/SKILL.md",
+      ".agents/skills/DOCTRINE.md"
+    ],
+    "excluded_fixture_paths": [
+      ".agents",
+      ".claude",
+      ".codex",
+      ".cycle",
+      "AGENTS.md",
+      "CLAUDE.md"
+    ]
+  },
+  "prompt": {
+    "common_path": "common-prompt.md",
+    "output_schema_path": "findings.schema.json"
+  },
+  "arms": [
+    {
+      "id": "baseline",
+      "description": "Strong generic single-model review with neutral repository instructions"
+    },
+    {
+      "id": "treatment",
+      "description": "The same review plus the pinned pre-case Release Relay review guidance"
+    }
+  ],
+  "schedule": {
+    "seed": "release-relay-review-v1-2026-08-29",
+    "repetitions": 3,
+    "invalid_pair_retry_limit": 1,
+    "invalid_run_rule": "Invalidate and rerun both arms for the same case and repetition; preserve the invalid attempt."
+  },
+  "execution": {
+    "model": "gpt-5.6-sol",
+    "reasoning_effort": "high",
+    "timeout_ms": 900000,
+    "fixture_commit_time": "2026-08-29T12:00:00Z",
+    "reviewers_per_arm": 1,
+    "fresh_session_per_cell": true,
+    "subagents": false,
+    "command_network": false,
+    "reviewer_workspace": "read-only"
+  },
+  "scoring": {
+    "schema_path": "score.schema.json",
+    "recall": {
+      "caught": "A finding identifies the frozen target's concrete mechanism and a plausible consequence.",
+      "partial": "A finding identifies the relevant risk but omits or materially weakens either the mechanism or consequence.",
+      "missed": "No finding gives target-specific evidence; generic concern alone is missed."
+    },
+    "actionability": "Score repair direction and regression test as separate booleans for each target. Direction must be bounded enough to implement; the proposed test must fail on the flawed fixture and pass when the named behavior is repaired.",
+    "unsupported_findings": "Count only independently disproved claims; absence from the historical repair is insufficient.",
+    "controls": "Recall is not applicable for the named repaired target. Independently verify every reported finding; a named-target claim is unsupported only when the frozen repaired fixture disproves it.",
+    "separate_measures": ["token_usage", "elapsed_time", "reviewer_count", "lifecycle_evidence"],
+    "composite_score": false,
+    "blinding": "Normalize finding fields without summaries, plans, arm labels, case names, or tool traces. Randomize A/B labels deterministically within each pair.",
+    "scorers": 2,
+    "adjudication": "Scorers lock schema-valid files independently. Preserve both originals, then resolve target or disproval disagreements by documented consensus with evidence from the frozen fixture; never infer falsity from absence in the historical repair.",
+    "analysis": "Report each arm's target-level recall categories, paired treatment-versus-baseline wins/ties/losses, the two actionability rates, and independently disproved finding counts. Report controls, token usage, elapsed time, and lifecycle evidence separately. Do not produce a composite score, significance claim, or prevalence estimate."
+  },
+  "invalidation": {
+    "cell": [
+      "nonzero exit or timeout",
+      "malformed JSONL or missing turn.completed",
+      "missing or schema-invalid final findings",
+      "candidate mutation",
+      "treatment did not read pinned guidance",
+      "baseline discovered treatment guidance"
+    ],
+    "experiment": [
+      "artifact-lock mismatch",
+      "fixture history or remote leakage",
+      "filesystem-isolation probe failure",
+      "hidden-oracle fail/pass preflight failure",
+      "authentication path or material in a fixture, reviewer command environment, or captured public artifact"
+    ],
+    "pair_rule": "If either cell is invalid, retain both attempts and rerun the pair once. If either retry is invalid, stop incomplete and score neither attempt from that pair."
+  },
+  "privacy": {
+    "public_allowlist": [
+      "protocol and census",
+      "preflight summary without host paths",
+      "normalized scoring input and locked score files",
+      "aggregate report"
+    ],
+    "private_only": [
+      "raw events and stderr",
+      "private blinding map and per-cell measures",
+      "Codex home and authentication symlink",
+      "host source paths"
+    ],
+    "credential_rule": "Codex authentication remains an outer-client symlink in a disposable private home. It is never copied into a fixture, inherited by reviewer commands, or written to experiment artifacts."
+  },
+  "cases": [
+    {
+      "id": "rr-a7f2",
+      "title": "GitHub comparison boundary",
+      "original_issue": 30,
+      "original_task_path": "original-prompts/issue-30.md",
+      "task_path": "prompts/rr-a7f2.md",
+      "base": "674f4d4a4f1588e7e8345dd7019142b41b255339",
+      "candidate": "57d1b3733421e6961ec1441c6fea8ed4936a4e2d",
+      "repair": "c930975d355cffbce1295eb39cf3899c9258bee6",
+      "repair_paths": ["packages/github-integration/src/live.ts"],
+      "oracle_paths": ["packages/github-integration/src/live.test.ts"],
+      "oracle_commands": [
+        "pnpm build",
+        "pnpm --filter @release-relay/github-integration test"
+      ],
+      "targets": [
+        {
+          "id": "comparison-repository-unverifiable",
+          "credit": "Identify that comparison responses whose repository identity cannot be established are accepted, with a plausible cross-repository consequence."
+        },
+        {
+          "id": "positive-total-without-commits",
+          "credit": "Identify that total_commits greater than zero with no parseable commit list is silently accepted, with a plausible empty or incomplete candidate consequence."
+        }
+      ]
+    },
+    {
+      "id": "rr-k3m8",
+      "title": "OpenAI excluded-source grounding",
+      "original_issue": 9,
+      "original_task_path": "original-prompts/issue-9.md",
+      "task_path": "prompts/rr-k3m8.md",
+      "base": "909d523bb90757b153164db98c4f2b25a6a5f42e",
+      "candidate": "38e5748c2b633a9957bfb9a142db650999855062",
+      "repair": "17e47abc5948b10aeeca403a16642c47b16d341e",
+      "repair_paths": ["packages/openai-integration/src/draft.ts"],
+      "oracle_paths": ["packages/openai-integration/src/draft.test.ts"],
+      "oracle_commands": [
+        "pnpm build",
+        "pnpm --filter @release-relay/openai-integration test"
+      ],
+      "targets": [
+        {
+          "id": "excluded-source-citation",
+          "credit": "Identify that validation accepts a citation to an excluded candidate that was not sent to the provider, with a plausible provenance consequence."
+        }
+      ]
+    },
+    {
+      "id": "rr-p9v4",
+      "title": "Stripe same-second ordering",
+      "original_issue": 11,
+      "original_task_path": "original-prompts/issue-11.md",
+      "task_path": "prompts/rr-p9v4.md",
+      "base": "441aee1cc7c0eb9bc7b1b8d7d9df107e3ec17f45",
+      "candidate": "d5b8bf34668c10b9caa0a541fffd021df319b6df",
+      "repair": "7d5756408de076cbd77614dc06493485537feda9",
+      "repair_paths": ["packages/core/src/billing.ts"],
+      "oracle_paths": ["packages/core/src/billing.test.ts"],
+      "oracle_commands": [
+        "pnpm build",
+        "pnpm --filter @release-relay/core build",
+        "node --test packages/core/dist/billing.test.js"
+      ],
+      "targets": [
+        {
+          "id": "same-second-distinct-events",
+          "credit": "Identify the timestamp-tie ambiguity for distinct events and its membership-state consequence; any safe, explicit, testable resolution receives credit."
+        }
+      ]
+    },
+    {
+      "id": "rr-w5c1",
+      "title": "Stripe catalog pagination",
+      "original_issue": 12,
+      "original_task_path": "original-prompts/issue-12.md",
+      "task_path": "prompts/rr-w5c1.md",
+      "base": "d5b8bf34668c10b9caa0a541fffd021df319b6df",
+      "candidate": "9d29ef71192d4a36f19977af9104798aecb67ee0",
+      "repair": "dfa146789e1cf372038bf992402f1f89a6b79f2a",
+      "repair_paths": ["packages/stripe-integration/src/billing.ts"],
+      "oracle_paths": ["packages/stripe-integration/src/billing.test.ts"],
+      "oracle_commands": [
+        "pnpm build",
+        "pnpm --filter @release-relay/stripe-integration test"
+      ],
+      "targets": [
+        {
+          "id": "catalog-first-page-only",
+          "credit": "Identify that product or price lookup ignores has_more and can create duplicate resources or bind nondeterministically; any bounded safe, testable resolution receives credit."
+        }
+      ]
+    },
+    {
+      "id": "rr-f0d6",
+      "title": "Target-clean GitHub comparison control",
+      "variant_of": "rr-a7f2",
+      "variant": "target-clean"
+    },
+    {
+      "id": "rr-y2n9",
+      "title": "Target-clean Stripe pagination control",
+      "variant_of": "rr-w5c1",
+      "variant": "target-clean"
+    }
+  ],
+  "artifact_lock": {
+    "runner_sha256": "30096df14e4f696ceb8227915d9b80a1b64f24991a3660d2255da29f6661d653",
+    "fake_reviewer_sha256": "ab8ae64aa52dec26608af0196711d89fb7cae0134df53e9b86c8f71d6b9ccc06",
+    "census_sha256": "1eb2272dfdb5110663f277cf70d661dbbc487e73f0b71d6f3e9e8b3b7f20e603",
+    "common_prompt_sha256": "98bae734100e4316267052c0f466f8f75658be1ef4702edf1d6b1fc31076353e",
+    "output_schema_sha256": "8e3a76201d5a942e80a62245f6bb48bac06b97f6a9a55209eef1a7aaf96fee5d",
+    "score_schema_sha256": "917bf21114333358b025ef55e9b2eeb9e2b26be29e4ba4c4c431950fd581b198",
+    "review_guidance_sha256": "21dda26d26949cea99effd704c8c6b7fa7bfc8c1632d214f02a4146505a83178",
+    "cases": {
+      "rr-a7f2": {
+        "original_task_sha256": "86af9ead9197dc6bb1bd6d7e76993ec9ce7cba8702e6b030bea91046f4311d2c",
+        "task_sha256": "33887527a0eb96b431c553800417e1d5e3c3be42c4e2ba40daeadc9ed07f4276",
+        "base_tree_sha256": "c7228ea8cb5e5dda086030f45e1f976104264cac9e441fe2e6360bd7d97dd1f7",
+        "candidate_patch_sha256": "e1cac88691d85e1db1c6165d00c1f4e2a0fde2306e438e22534853002944e0d2",
+        "repair_patch_sha256": "e49fadfc615efc4db36ba52b7e8ce79286645231217a118e7610f14260f384e8",
+        "oracle_patch_sha256": "88a90533280b3b00a1de852dfd1700a7ee6243f454bbc1159e0e030896a6dfc7",
+        "target_clean_patch_sha256": "00d741818b70fef15ca7abf187fba09e03be5cafce73e82399e1d913b1c4e03d"
+      },
+      "rr-k3m8": {
+        "original_task_sha256": "c5f0ccd08575ad1ad8a7edb5347b08aff617e18f88ae2e678ef92b6a2ef20527",
+        "task_sha256": "85c118fba9e1ea16e770a42b1d014b82e71a526bdfcfd367601b99105332fbb7",
+        "base_tree_sha256": "bfbb15fccaaa08145f954d885eae6bc15864c16c5cc4b690ebd612d93ec70b51",
+        "candidate_patch_sha256": "2b0ebb2579b02b700259f78319a1e2e1840f32787c248d0cf290316b2d0c16d3",
+        "repair_patch_sha256": "7c8ca0c42f5b3ef43d2e1c974f859835c85cd8031cde3add2b7d433b4868d903",
+        "oracle_patch_sha256": "4cb37363610838b878e4e4cd56d4b7fa430ca8d94951029e582b2663ea99bbc7",
+        "target_clean_patch_sha256": "bd8ce6947a0ce9838a871aa9b26d09e2db1b6407476905633dbd6526bbdb5a7a"
+      },
+      "rr-p9v4": {
+        "original_task_sha256": "f27b0191d7af03dd06cc02023665ed9ea23a3e7ef536f96f3ffdfec0015322cd",
+        "task_sha256": "ec079fe515eeb40f2a46fa67efe35e3c16372b45394b50414265dbf9fdf94fe4",
+        "base_tree_sha256": "d36adb34722265c09080aa09ed9a0223c36b0e9ffcdcc2696d5b1f08f81bb10d",
+        "candidate_patch_sha256": "f23df70d7a0f46f9be5d7a5aeb23e518d117728338302e55603316b497651e0a",
+        "repair_patch_sha256": "5dfd5899a74127b31576561ceaca12af02175c5ae03586a78648edb6b9b37b92",
+        "oracle_patch_sha256": "70d99945099b04af9209d8ac43c599d22dc0c3bc06e9928f38a4ac85b9d8e715",
+        "target_clean_patch_sha256": "ac43d53dab4d04398cdcb99fe56c3b5e3aef63a25780f1d6472f31c93249a24b"
+      },
+      "rr-w5c1": {
+        "original_task_sha256": "08930ba0a1f1dfb135aaf9bb44138d7dcb6ce5fb83e4d1bb8f8e79964e899489",
+        "task_sha256": "35675fcfd2a53e1175f096e9ddd2a0f02ae3d3548e77c80059a2b64c6d57e0d9",
+        "base_tree_sha256": "a40b39b73aa1b832f54863e8e5e5565fe588d1c28b9cfc606c784fe8f844c5e8",
+        "candidate_patch_sha256": "e61b37dabbcc50e929e659147abc99951bb252e4eb24382d558cd239b7667876",
+        "repair_patch_sha256": "07fab658573cbce3a61fbbbf5295326bcda28d3019cc1c2f8129f02b25e6ff9b",
+        "oracle_patch_sha256": "75d7785770471aaca5772607cd89db818519f0ed797d5b7e48f4543da925086d",
+        "target_clean_patch_sha256": "22cfb1074003d1daae66ab8341d07a1634957839583725dee2d602d412b263a6"
+      }
+    }
+  }
+}

--- a/eval/review/run.mjs
+++ b/eval/review/run.mjs
@@ -1,0 +1,1588 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { spawn, spawnSync } from 'node:child_process';
+import {
+    chmodSync,
+    existsSync,
+    lstatSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    readdirSync,
+    realpathSync,
+    rmSync,
+    statSync,
+    symlinkSync,
+    writeFileSync,
+} from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { parseArgs } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '..', '..');
+const DEFAULT_PROTOCOL = join(HERE, 'protocol.json');
+const DEFAULT_FAKE_CODEX = join(HERE, 'fake-codex.cjs');
+const MAX_BUFFER = 128 * 1024 * 1024;
+const TREE_CACHE = new Map();
+const PATCH_CACHE = new Map();
+
+export class ReviewEvalError extends Error {}
+
+function fail(message) {
+    throw new ReviewEvalError(message);
+}
+
+function run(command, args, {
+    cwd = ROOT,
+    env = process.env,
+    input,
+    encoding = 'utf8',
+    timeout,
+    allowFailure = false,
+} = {}) {
+    const started = Date.now();
+    const result = spawnSync(command, args, {
+        cwd,
+        env,
+        input,
+        encoding,
+        timeout,
+        maxBuffer: MAX_BUFFER,
+    });
+    const elapsedMs = Date.now() - started;
+    if (result.error && !allowFailure) {
+        fail(`${command} failed to start: ${result.error.message}`);
+    }
+    if (result.status !== 0 && !allowFailure) {
+        const stderr = encoding === null ? result.stderr?.toString('utf8') : result.stderr;
+        const stdout = encoding === null ? result.stdout?.toString('utf8') : result.stdout;
+        fail(`${command} ${args.join(' ')} failed (${result.status})\n${stderr || stdout || ''}`.trimEnd());
+    }
+    return { ...result, elapsedMs };
+}
+
+function git(source, args, options = {}) {
+    return run('git', ['-C', source, ...args], options);
+}
+
+export function sha256(value) {
+    return createHash('sha256').update(value).digest('hex');
+}
+
+function stable(value) {
+    if (Array.isArray(value)) return value.map(stable);
+    if (value && typeof value === 'object') {
+        return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stable(value[key])]));
+    }
+    return value;
+}
+
+function stableJson(value) {
+    return JSON.stringify(stable(value));
+}
+
+function ensureInside(root, path) {
+    const rel = relative(root, path);
+    if (!rel || rel === '..' || rel.startsWith(`..${sep}`)) {
+        fail(`unsafe path outside ${root}: ${path}`);
+    }
+}
+
+function resolveProtocolAsset(protocolPath, rel) {
+    if (typeof rel !== 'string' || !rel || rel.includes('\0')) fail(`invalid protocol asset path: ${rel}`);
+    const root = dirname(protocolPath);
+    const path = resolve(root, rel);
+    ensureInside(root, path);
+    if (!existsSync(path) || !lstatSync(path).isFile()) fail(`missing protocol asset: ${rel}`);
+    return path;
+}
+
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function validateProtocol(protocol, { requireLock = true } = {}) {
+    if (!protocol || typeof protocol !== 'object' || Array.isArray(protocol)) {
+        fail('review protocol must be an object');
+    }
+    if (protocol.version !== 1 || !isNonEmptyString(protocol.study_id) || !isNonEmptyString(protocol.claim)
+        || !isNonEmptyString(protocol.census_path)) {
+        fail('review protocol requires version 1, study_id, claim, and census_path');
+    }
+    if (!protocol.source || !isNonEmptyString(protocol.source.repository)
+        || !/^[0-9a-f]{40}$/.test(protocol.source.review_guidance_commit)
+        || !Array.isArray(protocol.source.review_guidance_paths)
+        || !Array.isArray(protocol.source.excluded_fixture_paths)) {
+        fail('review protocol has an invalid source definition');
+    }
+    if (!protocol.prompt || !isNonEmptyString(protocol.prompt.common_path)
+        || !isNonEmptyString(protocol.prompt.output_schema_path)) {
+        fail('review protocol has an invalid prompt definition');
+    }
+    if (!Array.isArray(protocol.arms) || stableJson(protocol.arms.map((arm) => arm.id).sort())
+        !== stableJson(['baseline', 'treatment'])) {
+        fail('review protocol must define baseline and treatment arms');
+    }
+    if (!protocol.schedule || protocol.schedule.repetitions !== 3
+        || protocol.schedule.invalid_pair_retry_limit !== 1
+        || !isNonEmptyString(protocol.schedule.seed)) {
+        fail('review protocol must freeze three repetitions and a seed');
+    }
+    if (!protocol.execution || !isNonEmptyString(protocol.execution.model)
+        || !isNonEmptyString(protocol.execution.reasoning_effort)
+        || !Number.isSafeInteger(protocol.execution.timeout_ms) || protocol.execution.timeout_ms < 1
+        || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(protocol.execution.fixture_commit_time ?? '')
+        || protocol.execution.reviewers_per_arm !== 1
+        || protocol.execution.fresh_session_per_cell !== true
+        || protocol.execution.subagents !== false
+        || protocol.execution.command_network !== false
+        || protocol.execution.reviewer_workspace !== 'read-only') {
+        fail('review protocol has an invalid execution definition');
+    }
+    if (!protocol.scoring || !isNonEmptyString(protocol.scoring.schema_path)
+        || protocol.scoring.scorers !== 2 || protocol.scoring.composite_score !== false
+        || !protocol.scoring.recall || !isNonEmptyString(protocol.scoring.recall.caught)
+        || !isNonEmptyString(protocol.scoring.recall.partial)
+        || !isNonEmptyString(protocol.scoring.recall.missed)
+        || !isNonEmptyString(protocol.scoring.actionability)
+        || !isNonEmptyString(protocol.scoring.unsupported_findings)
+        || !isNonEmptyString(protocol.scoring.controls)
+        || !isNonEmptyString(protocol.scoring.adjudication)
+        || !isNonEmptyString(protocol.scoring.analysis)) {
+        fail('review protocol has an invalid scoring definition');
+    }
+    if (!Array.isArray(protocol.cases) || protocol.cases.length !== 6) {
+        fail('review protocol must define four flawed cases and two controls');
+    }
+    const ids = new Set();
+    let controls = 0;
+    for (const item of protocol.cases) {
+        if (!isNonEmptyString(item.id) || ids.has(item.id)) fail(`invalid or duplicate case id: ${item.id}`);
+        ids.add(item.id);
+        if (item.variant === 'target-clean') {
+            controls += 1;
+            if (!isNonEmptyString(item.variant_of)) fail(`control ${item.id} is missing variant_of`);
+            continue;
+        }
+        for (const key of ['base', 'candidate', 'repair']) {
+            if (!/^[0-9a-f]{40}$/.test(item[key] ?? '')) fail(`case ${item.id} has invalid ${key}`);
+        }
+        if (!Number.isSafeInteger(item.original_issue) || !isNonEmptyString(item.original_task_path)
+            || !isNonEmptyString(item.task_path)
+            || !Array.isArray(item.repair_paths) || !item.repair_paths.length
+            || !Array.isArray(item.oracle_paths) || !item.oracle_paths.length
+            || !Array.isArray(item.oracle_commands) || !item.oracle_commands.length
+            || !Array.isArray(item.targets) || !item.targets.length) {
+            fail(`case ${item.id} is incomplete`);
+        }
+    }
+    if (controls !== 2) fail('review protocol must define exactly two target-clean controls');
+    for (const item of protocol.cases.filter((entry) => entry.variant === 'target-clean')) {
+        const source = protocol.cases.find((entry) => entry.id === item.variant_of);
+        if (!source || source.variant) fail(`control ${item.id} references an invalid source case`);
+    }
+    if (!protocol.artifact_lock || typeof protocol.artifact_lock !== 'object') {
+        fail('review protocol is missing artifact_lock');
+    }
+    if (requireLock && stableJson(protocol.artifact_lock).includes('PENDING')) {
+        fail('review protocol artifact lock is not frozen');
+    }
+    return protocol;
+}
+
+export function loadProtocol(path = DEFAULT_PROTOCOL, options) {
+    const protocolPath = resolve(path);
+    let protocol;
+    try {
+        protocol = JSON.parse(readFileSync(protocolPath, 'utf8'));
+    } catch (error) {
+        fail(`cannot read protocol ${protocolPath}: ${error.message}`);
+    }
+    validateProtocol(protocol, options);
+    return { protocol, protocolPath };
+}
+
+function sourceCase(protocol, item) {
+    if (!item.variant) return { ...item, targetClean: false, publicCase: item };
+    const original = protocol.cases.find((entry) => entry.id === item.variant_of);
+    return {
+        ...original,
+        id: item.id,
+        title: item.title,
+        targetClean: true,
+        publicCase: item,
+        sourceId: original.id,
+    };
+}
+
+function isExcluded(path, excluded) {
+    return excluded.some((entry) => path === entry || path.startsWith(`${entry}/`));
+}
+
+function treeEntries(source, revision, excluded) {
+    const cacheKey = stableJson([resolve(source), revision, excluded]);
+    if (TREE_CACHE.has(cacheKey)) return TREE_CACHE.get(cacheKey);
+    const listing = git(source, ['ls-tree', '-r', '-z', '--full-tree', revision], { encoding: 'utf8' }).stdout;
+    const entries = [];
+    for (const record of listing.split('\0').filter(Boolean)) {
+        const match = /^(\d{6}) (\w+) ([0-9a-f]{40})\t(.+)$/.exec(record);
+        if (!match) fail(`cannot parse git tree record at ${revision}`);
+        const [, mode, type, object, path] = match;
+        if (isExcluded(path, excluded)) continue;
+        if (type !== 'blob' || mode === '120000') {
+            fail(`unsupported ${type} or symlink in source tree: ${path}`);
+        }
+        const content = git(source, ['show', `${revision}:${path}`], { encoding: null }).stdout;
+        entries.push({ mode, object, path, content });
+    }
+    TREE_CACHE.set(cacheKey, entries);
+    return entries;
+}
+
+function treeDigest(entries) {
+    const hash = createHash('sha256');
+    for (const entry of entries) {
+        hash.update(entry.mode);
+        hash.update('\0');
+        hash.update(entry.path);
+        hash.update('\0');
+        hash.update(entry.content);
+        hash.update('\0');
+    }
+    return hash.digest('hex');
+}
+
+function excludedPathspecs(excluded) {
+    return excluded.flatMap((entry) => [
+        `:(exclude)${entry}`,
+        `:(exclude)${entry}/**`,
+    ]);
+}
+
+function patchBetween(source, from, to, paths = null, excluded = []) {
+    const cacheKey = stableJson([resolve(source), from, to, paths, excluded]);
+    if (PATCH_CACHE.has(cacheKey)) return PATCH_CACHE.get(cacheKey);
+    const pathspecs = paths?.length ? paths : ['.', ...excludedPathspecs(excluded)];
+    const patch = git(source, [
+        'diff', '--binary', '--full-index', '--no-ext-diff', '--no-renames', from, to, '--', ...pathspecs,
+    ], { encoding: null }).stdout;
+    if (!patch.length) fail(`empty patch from ${from} to ${to}`);
+    PATCH_CACHE.set(cacheKey, patch);
+    return patch;
+}
+
+function repairParent(source, revision) {
+    const parents = git(source, ['show', '-s', '--format=%P', revision]).stdout.trim().split(/\s+/).filter(Boolean);
+    if (parents.length !== 1) fail(`repair ${revision} must have exactly one parent`);
+    return parents[0];
+}
+
+function hashNamedFiles(source, revision, paths) {
+    const hash = createHash('sha256');
+    for (const path of [...paths].sort()) {
+        const content = git(source, ['show', `${revision}:${path}`], { encoding: null }).stdout;
+        hash.update(path);
+        hash.update('\0');
+        hash.update(content);
+        hash.update('\0');
+    }
+    return hash.digest('hex');
+}
+
+function verifySource(source, protocol) {
+    const root = resolve(source);
+    if (!existsSync(root) || !statSync(root).isDirectory()) fail(`source is not a directory: ${source}`);
+    if (git(root, ['rev-parse', '--is-inside-work-tree'], { allowFailure: true }).status !== 0) {
+        fail(`source is not a Git repository: ${source}`);
+    }
+    const refs = new Set([
+        protocol.source.review_guidance_commit,
+        ...protocol.cases.filter((item) => !item.variant).flatMap((item) => [item.base, item.candidate, item.repair]),
+    ]);
+    for (const revision of refs) {
+        const result = git(root, ['cat-file', '-e', `${revision}^{commit}`], { allowFailure: true });
+        if (result.status !== 0) fail(`source is missing required commit ${revision}`);
+    }
+    return root;
+}
+
+export function computeArtifactLock(protocol, protocolPath, source) {
+    const root = verifySource(source, protocol);
+    const lock = {
+        runner_sha256: sha256(readFileSync(fileURLToPath(import.meta.url))),
+        fake_reviewer_sha256: sha256(readFileSync(DEFAULT_FAKE_CODEX)),
+        census_sha256: sha256(readFileSync(resolveProtocolAsset(protocolPath, protocol.census_path))),
+        common_prompt_sha256: sha256(readFileSync(resolveProtocolAsset(protocolPath, protocol.prompt.common_path))),
+        output_schema_sha256: sha256(readFileSync(resolveProtocolAsset(protocolPath, protocol.prompt.output_schema_path))),
+        score_schema_sha256: sha256(readFileSync(resolveProtocolAsset(protocolPath, protocol.scoring.schema_path))),
+        review_guidance_sha256: hashNamedFiles(
+            root,
+            protocol.source.review_guidance_commit,
+            protocol.source.review_guidance_paths,
+        ),
+        cases: {},
+    };
+    for (const item of protocol.cases.filter((entry) => !entry.variant)) {
+        const parent = repairParent(root, item.repair);
+        const candidatePatch = patchBetween(
+            root,
+            item.base,
+            item.candidate,
+            null,
+            protocol.source.excluded_fixture_paths,
+        );
+        const repairPatch = patchBetween(root, parent, item.repair, item.repair_paths);
+        const oraclePatch = patchBetween(root, parent, item.repair, item.oracle_paths);
+        lock.cases[item.id] = {
+            original_task_sha256: sha256(readFileSync(resolveProtocolAsset(protocolPath, item.original_task_path))),
+            task_sha256: sha256(readFileSync(resolveProtocolAsset(protocolPath, item.task_path))),
+            base_tree_sha256: treeDigest(treeEntries(root, item.base, protocol.source.excluded_fixture_paths)),
+            candidate_patch_sha256: sha256(candidatePatch),
+            repair_patch_sha256: sha256(repairPatch),
+            oracle_patch_sha256: sha256(oraclePatch),
+            target_clean_patch_sha256: sha256(Buffer.concat([candidatePatch, repairPatch])),
+        };
+    }
+    return lock;
+}
+
+export function assertArtifactLock(protocol, protocolPath, source) {
+    const actual = computeArtifactLock(protocol, protocolPath, source);
+    if (stableJson(actual) !== stableJson(protocol.artifact_lock)) {
+        fail(`artifact lock mismatch\nexpected ${stableJson(protocol.artifact_lock)}\nactual   ${stableJson(actual)}`);
+    }
+    return actual;
+}
+
+function writeTree(destination, entries) {
+    for (const entry of entries) {
+        const path = resolve(destination, entry.path);
+        ensureInside(destination, path);
+        mkdirSync(dirname(path), { recursive: true });
+        writeFileSync(path, entry.content);
+        chmodSync(path, entry.mode === '100755' ? 0o755 : 0o644);
+    }
+}
+
+const NEUTRAL_AGENTS = `# Review evaluation fixture
+
+This repository is an isolated historical review fixture.
+
+- Review the current uncommitted diff against the task under \`.review-eval/task.md\`.
+- Do not modify files or use the network.
+- Do not inspect paths outside this repository or attempt to recover later history.
+- If \`.agents/skills/review/SKILL.md\` exists, read it before reviewing.
+- Return findings using the requested structured output contract.
+`;
+
+function writeFixtureMetadata(destination, protocol, protocolPath, item) {
+    writeFileSync(join(destination, 'AGENTS.md'), NEUTRAL_AGENTS);
+    mkdirSync(join(destination, '.review-eval'), { recursive: true });
+    writeFileSync(
+        join(destination, '.review-eval', 'task.md'),
+        readFileSync(resolveProtocolAsset(protocolPath, item.task_path)),
+    );
+    writeFileSync(
+        join(destination, '.review-eval', 'findings.schema.json'),
+        readFileSync(resolveProtocolAsset(protocolPath, protocol.prompt.output_schema_path)),
+    );
+}
+
+function writeTreatmentGuidance(destination, protocol, source) {
+    for (const rel of protocol.source.review_guidance_paths) {
+        const path = resolve(destination, rel);
+        ensureInside(destination, path);
+        mkdirSync(dirname(path), { recursive: true });
+        writeFileSync(path, git(source, [
+            'show', `${protocol.source.review_guidance_commit}:${rel}`,
+        ], { encoding: null }).stdout);
+    }
+}
+
+function initializeFixtureRepository(destination, commitTime) {
+    const template = privateDirectory('cycle-review-git-template-');
+    const env = {
+        PATH: sanitizedPath(),
+        LANG: 'C.UTF-8',
+        HOME: '/nonexistent',
+        GIT_CONFIG_NOSYSTEM: '1',
+        GIT_CONFIG_GLOBAL: '/dev/null',
+        GIT_ATTR_NOSYSTEM: '1',
+        GIT_AUTHOR_DATE: commitTime,
+        GIT_COMMITTER_DATE: commitTime,
+    };
+    try {
+        // Why: fixture commit identity must not depend on a caller's hooks, templates, signing, or timestamps.
+        run('git', ['init', '-q', '--template', template, '-b', 'main'], { cwd: destination, env });
+        run('git', ['config', 'user.name', 'Review Evaluation'], { cwd: destination, env });
+        run('git', ['config', 'user.email', 'review-eval@example.invalid'], { cwd: destination, env });
+        run('git', ['config', 'core.logAllRefUpdates', 'false'], { cwd: destination, env });
+        run('git', ['config', 'core.hooksPath', '/dev/null'], { cwd: destination, env });
+        run('git', ['config', 'core.autocrlf', 'false'], { cwd: destination, env });
+        run('git', ['config', 'commit.gpgSign', 'false'], { cwd: destination, env });
+        run('git', ['add', '--', '.'], { cwd: destination, env });
+        run('git', ['commit', '-q', '--no-verify', '-m', 'fixture: historical base'], { cwd: destination, env });
+    } finally {
+        rmSync(template, { recursive: true, force: true });
+    }
+}
+
+function applyPatch(workspace, patch) {
+    run('git', ['apply', '--check', '--whitespace=nowarn', '-'], { cwd: workspace, input: patch, encoding: null });
+    run('git', ['apply', '--whitespace=nowarn', '-'], { cwd: workspace, input: patch, encoding: null });
+}
+
+export function assertHistoryTruncated(workspace) {
+    const count = run('git', ['rev-list', '--all', '--count'], { cwd: workspace }).stdout.trim();
+    if (count !== '1') fail(`fixture has ${count} reachable commits instead of one`);
+    const remotes = run('git', ['remote'], { cwd: workspace }).stdout.trim();
+    if (remotes) fail(`fixture unexpectedly has remotes: ${remotes}`);
+    const refs = run('git', ['for-each-ref', '--format=%(refname)'], { cwd: workspace })
+        .stdout.trim().split('\n').filter(Boolean);
+    if (stableJson(refs) !== stableJson(['refs/heads/main'])) {
+        fail(`fixture has unexpected refs: ${refs.join(', ')}`);
+    }
+    if (run('git', ['tag', '--list'], { cwd: workspace }).stdout.trim()) fail('fixture unexpectedly has tags');
+    for (const rel of ['.git/objects/info/alternates', '.git/shallow', '.git/logs']) {
+        if (existsSync(join(workspace, rel))) fail(`fixture unexpectedly contains ${rel}`);
+    }
+    const status = run('git', ['status', '--porcelain=v1', '-z'], { cwd: workspace, encoding: null }).stdout;
+    if (!status.length) fail('fixture candidate diff is empty');
+    const diff = run('git', [
+        'diff', '--binary', '--full-index', '--no-ext-diff', '--no-renames',
+    ], { cwd: workspace, encoding: null }).stdout;
+    const changedPaths = run('git', ['diff', '--name-only', '-z'], {
+        cwd: workspace,
+        encoding: null,
+    }).stdout.toString('utf8').split('\0').filter(Boolean);
+    return {
+        commit: run('git', ['rev-parse', 'HEAD'], { cwd: workspace }).stdout.trim(),
+        changed_paths: changedPaths,
+        diff_sha256: sha256(diff),
+    };
+}
+
+export function materializeFixture({
+    protocol,
+    protocolPath,
+    source,
+    caseId,
+    arm,
+    destination,
+}) {
+    if (!['baseline', 'treatment'].includes(arm)) fail(`invalid arm: ${arm}`);
+    const publicCase = protocol.cases.find((entry) => entry.id === caseId);
+    if (!publicCase) fail(`unknown case: ${caseId}`);
+    const item = sourceCase(protocol, publicCase);
+    const root = verifySource(source, protocol);
+    const workspace = resolve(destination);
+    if (existsSync(workspace) && (!statSync(workspace).isDirectory() || readdirSync(workspace).length)) {
+        fail(`fixture destination must be new or empty: ${workspace}`);
+    }
+    mkdirSync(workspace, { recursive: true });
+    writeTree(workspace, treeEntries(root, item.base, protocol.source.excluded_fixture_paths));
+    writeFixtureMetadata(workspace, protocol, protocolPath, item);
+    if (arm === 'treatment') writeTreatmentGuidance(workspace, protocol, root);
+    initializeFixtureRepository(workspace, protocol.execution.fixture_commit_time);
+    const candidatePatch = patchBetween(
+        root,
+        item.base,
+        item.candidate,
+        null,
+        protocol.source.excluded_fixture_paths,
+    );
+    applyPatch(workspace, candidatePatch);
+    if (item.targetClean) {
+        const parent = repairParent(root, item.repair);
+        applyPatch(workspace, patchBetween(root, parent, item.repair, item.repair_paths));
+    }
+    run('git', ['add', '--intent-to-add', '--', '.'], { cwd: workspace });
+    const history = assertHistoryTruncated(workspace);
+    return { workspace, item, history };
+}
+
+function seededRank(seed, value) {
+    return sha256(`${seed}\0${value}`);
+}
+
+export function buildSchedule(protocol) {
+    const pairs = [];
+    for (const item of protocol.cases) {
+        for (let repetition = 1; repetition <= protocol.schedule.repetitions; repetition += 1) {
+            pairs.push({ case_id: item.id, repetition });
+        }
+    }
+    pairs.sort((a, b) => seededRank(protocol.schedule.seed, `${a.case_id}:${a.repetition}`)
+        .localeCompare(seededRank(protocol.schedule.seed, `${b.case_id}:${b.repetition}`)));
+    return pairs.map((pair, index) => {
+        const arms = index % 2 === 0 ? ['baseline', 'treatment'] : ['treatment', 'baseline'];
+        return {
+            ...pair,
+            pair_index: index + 1,
+            arms,
+            cells: arms.map((arm) => ({
+                ...pair,
+                arm,
+                cell_id: sha256(`${protocol.study_id}\0${pair.case_id}\0${pair.repetition}\0${arm}`).slice(0, 12),
+            })),
+        };
+    });
+}
+
+function sanitizedPath(pathValue = process.env.PATH ?? '/usr/bin:/bin') {
+    return pathValue.split(':').filter((entry) => entry && !entry.includes('\n') && !entry.includes('\0')).join(':');
+}
+
+export function reviewerConfig(pathValue = process.env.PATH, readablePaths = []) {
+    const readableRules = [...new Set(readablePaths)].sort()
+        .map((path) => `${JSON.stringify(path)} = "read"`)
+        .join('\n');
+    return `approval_policy = "never"
+default_permissions = "review-fixture"
+allow_login_shell = false
+web_search = "disabled"
+check_for_update_on_startup = false
+file_opener = "none"
+
+[history]
+persistence = "none"
+
+[feedback]
+enabled = false
+
+[features]
+goals = false
+hooks = false
+memories = false
+multi_agent = false
+network_proxy = false
+shell_snapshot = false
+skill_mcp_dependency_install = false
+
+[tools]
+view_image = false
+
+[permissions.review-fixture.filesystem]
+":root" = "deny"
+":minimal" = "read"
+${readableRules}
+
+[permissions.review-fixture.network]
+enabled = false
+
+[shell_environment_policy]
+inherit = "none"
+ignore_default_excludes = false
+
+[shell_environment_policy.set]
+HOME = "/nonexistent"
+PATH = ${JSON.stringify(sanitizedPath(pathValue))}
+LANG = "C.UTF-8"
+`;
+}
+
+function resolveExecutable(command, pathValue = process.env.PATH ?? '') {
+    const candidates = command.includes(sep)
+        ? [resolve(command)]
+        : pathValue.split(':').filter(Boolean).map((entry) => resolve(entry, command));
+    const path = candidates.find((candidate) => existsSync(candidate));
+    if (!path) fail(`cannot resolve executable: ${command}`);
+    const realPath = realpathSync(path);
+    if (!statSync(realPath).isFile()) fail(`resolved executable is not a file: ${realPath}`);
+    return realPath;
+}
+
+function privateDirectory(prefix) {
+    const path = mkdtempSync(join(tmpdir(), prefix));
+    chmodSync(path, 0o700);
+    return path;
+}
+
+function privateMkdir(path) {
+    mkdirSync(path, { recursive: true, mode: 0o700 });
+    chmodSync(path, 0o700);
+    return path;
+}
+
+function privateWrite(path, data) {
+    privateMkdir(dirname(path));
+    writeFileSync(path, data, { mode: 0o600 });
+    chmodSync(path, 0o600);
+}
+
+function resolveAuthPath(codexHome) {
+    return resolve(codexHome ?? process.env.CODEX_HOME ?? join(homedir(), '.codex'), 'auth.json');
+}
+
+export function assertNoCredentialMaterial(values, authPath) {
+    if (!authPath) return;
+    const raw = readFileSync(authPath, 'utf8');
+    const fingerprints = new Set();
+    const add = (value) => {
+        if (typeof value === 'string' && value.length >= 24) fingerprints.add(value);
+    };
+    add(raw.trim());
+    try {
+        const visit = (value) => {
+            if (typeof value === 'string') add(value);
+            else if (Array.isArray(value)) value.forEach(visit);
+            else if (value && typeof value === 'object') Object.values(value).forEach(visit);
+        };
+        visit(JSON.parse(raw));
+    } catch {
+        // A non-JSON auth file is still protected by the full-file fingerprint above.
+    }
+    for (const value of values) {
+        const text = Buffer.isBuffer(value) ? value.toString('utf8') : String(value ?? '');
+        if ([...fingerprints].some((fingerprint) => text.includes(fingerprint))) {
+            fail('reviewer output contained authentication material; raw output was not written');
+        }
+    }
+}
+
+function startLoopbackProbe(root) {
+    const portFile = join(root, 'loopback-port');
+    const server = spawn(process.execPath, [
+        '-e',
+        [
+            "const { writeFileSync } = require('node:fs');",
+            "const { createServer } = require('node:net');",
+            'const server = createServer();',
+            "server.listen(0, '127.0.0.1', () => writeFileSync(process.argv[1], String(server.address().port)));",
+            'setTimeout(() => process.exit(0), 30000);',
+        ].join(' '),
+        portFile,
+    ], { stdio: 'ignore' });
+    const wait = new Int32Array(new SharedArrayBuffer(4));
+    const deadline = Date.now() + 5_000;
+    while (!existsSync(portFile) && Date.now() < deadline && server.exitCode === null) {
+        Atomics.wait(wait, 0, 0, 10);
+    }
+    if (!existsSync(portFile)) {
+        server.kill('SIGTERM');
+        fail('could not start loopback isolation probe');
+    }
+    const port = Number(readFileSync(portFile, 'utf8'));
+    if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
+        server.kill('SIGTERM');
+        fail('loopback isolation probe returned an invalid port');
+    }
+    return { port, stop: () => server.kill('SIGTERM') };
+}
+
+export function createReviewerHome({ codexHome, includeAuth, codexBin = 'codex', workspace }) {
+    const home = privateDirectory('cycle-review-codex-home-');
+    const readablePaths = [resolveExecutable(codexBin)];
+    if (workspace) readablePaths.push(realpathSync(workspace));
+    writeFileSync(
+        join(home, 'config.toml'),
+        reviewerConfig(process.env.PATH, readablePaths),
+        { mode: 0o600 },
+    );
+    if (includeAuth) {
+        const source = resolveAuthPath(codexHome);
+        if (!existsSync(source) || !lstatSync(source).isFile()) {
+            rmSync(home, { recursive: true, force: true });
+            fail(`Codex authentication is unavailable at ${source}`);
+        }
+        symlinkSync(source, join(home, 'auth.json'));
+    }
+    return home;
+}
+
+export function reviewerEnvironment({
+    reviewerHome,
+    scratch,
+    cellId = '',
+    arm = '',
+    caseId = '',
+    repetition = '',
+    pairIndex = '',
+    attempt = '',
+    fakeMode = '',
+}, ambient = process.env) {
+    const env = {};
+    for (const key of ['PATH', 'LANG', 'LC_ALL', 'SSL_CERT_FILE', 'SSL_CERT_DIR']) {
+        if (ambient[key]) env[key] = ambient[key];
+    }
+    env.PATH = sanitizedPath(env.PATH);
+    env.HOME = reviewerHome;
+    env.CODEX_HOME = reviewerHome;
+    env.TMPDIR = scratch;
+    env.NO_COLOR = '1';
+    env.CYCLE_REVIEW_CELL = cellId;
+    env.CYCLE_REVIEW_ARM = arm;
+    env.CYCLE_REVIEW_CASE = caseId;
+    env.CYCLE_REVIEW_REPETITION = String(repetition);
+    env.CYCLE_REVIEW_PAIR_INDEX = String(pairIndex);
+    env.CYCLE_REVIEW_ATTEMPT = String(attempt);
+    env.CYCLE_REVIEW_FAKE_MODE = fakeMode;
+    return env;
+}
+
+export function parseExecEvents(text) {
+    const events = [];
+    const malformed = [];
+    const invalid = [];
+    for (const [index, line] of text.split('\n').entries()) {
+        if (!line.trim()) continue;
+        try {
+            const event = JSON.parse(line);
+            if (!event || typeof event !== 'object' || Array.isArray(event)) invalid.push(index + 1);
+            else events.push(event);
+        } catch {
+            malformed.push(index + 1);
+        }
+    }
+    const reasons = [];
+    if (malformed.length) reasons.push(`malformed JSONL at line(s) ${malformed.join(', ')}`);
+    if (invalid.length) reasons.push(`invalid JSONL event at line(s) ${invalid.join(', ')}`);
+    const completed = events.findLast((event) => event.type === 'turn.completed');
+    return { events, invalid: reasons.length ? reasons.join('; ') : null, usage: completed?.usage ?? null };
+}
+
+function guidanceMarkers(content) {
+    const lines = content.split('\n').map((line) => line.trim()).filter((line) => line.length >= 24);
+    if (!lines.length) return [content.trim()];
+    return [...new Set([lines[0], lines[Math.floor(lines.length / 2)], lines.at(-1)])];
+}
+
+function guidanceEvidence(events, paths, workspace) {
+    const completed = events
+        .filter((event) => event.type === 'item.completed'
+            && event.item?.type === 'command_execution'
+            && event.item?.status === 'completed'
+            && event.item?.exit_code === 0);
+    const touched = events.some((event) => event.type === 'item.completed'
+        && event.item?.type === 'command_execution'
+        && paths.some((path) => String(event.item.command ?? '').includes(path)));
+    const read = paths.every((path) => {
+        const guidancePath = join(workspace, path);
+        if (!existsSync(guidancePath)) return false;
+        const output = completed
+            .filter((event) => String(event.item.command ?? '').includes(path))
+            .map((event) => String(event.item.aggregated_output ?? ''))
+            .join('\n');
+        if (!output) return false;
+        return guidanceMarkers(readFileSync(guidancePath, 'utf8'))
+            .every((marker) => output.includes(marker));
+    });
+    return { read, touched };
+}
+
+function finalAgentText(events) {
+    return events
+        .filter((event) => event.type === 'item.completed' && event.item?.type === 'agent_message')
+        .map((event) => event.item.text ?? event.item.message ?? '')
+        .filter(Boolean)
+        .at(-1) ?? null;
+}
+
+function validateFindingsText(text) {
+    if (!text) return 'missing final structured response';
+    let value;
+    try { value = JSON.parse(text); }
+    catch { return 'final response is not JSON'; }
+    if (!value || !Array.isArray(value.findings) || !isNonEmptyString(value.summary)) {
+        return 'final response does not match findings schema';
+    }
+    const required = [
+        'severity', 'file', 'line', 'mechanism', 'consequence', 'recommendation', 'regression_test',
+    ];
+    for (const finding of value.findings) {
+        if (!finding || typeof finding !== 'object' || Array.isArray(finding)
+            || !['P0', 'P1', 'P2'].includes(finding.severity)
+            || !Number.isSafeInteger(finding.line) || finding.line < 1
+            || required.filter((key) => key !== 'line' && key !== 'severity')
+                .some((key) => !isNonEmptyString(finding[key]))) {
+            return 'final response does not match findings schema';
+        }
+    }
+    return null;
+}
+
+function blindText(value) {
+    return value.trim()
+        .replace(/\.agents\/skills\/(?:review\/SKILL\.md|DOCTRINE\.md)/giu, '[review guidance]')
+        .replace(/\brepository-specific review guidance\b/giu, '[review guidance]')
+        .replace(/\b(?:baseline|treatment)\b/giu, '[arm]')
+        .replace(/\bthe-cycle\b/giu, '[workflow]');
+}
+
+function normalizedFindings(text) {
+    const value = JSON.parse(text);
+    return value.findings.map((finding) => ({
+        severity: finding.severity,
+        file: blindText(finding.file),
+        line: finding.line,
+        mechanism: blindText(finding.mechanism),
+        consequence: blindText(finding.consequence),
+        recommendation: blindText(finding.recommendation),
+        regression_test: blindText(finding.regression_test),
+    }));
+}
+
+function commonPrompt(protocol, protocolPath, item) {
+    return `${readFileSync(resolveProtocolAsset(protocolPath, protocol.prompt.common_path), 'utf8')}${
+        readFileSync(resolveProtocolAsset(protocolPath, item.task_path), 'utf8')
+    }`;
+}
+
+function setupDryFixture(protocol, protocolPath, publicCase, arm, destination) {
+    mkdirSync(destination, { recursive: true });
+    const item = sourceCase(protocol, publicCase);
+    writeFileSync(join(destination, 'AGENTS.md'), NEUTRAL_AGENTS);
+    mkdirSync(join(destination, '.review-eval'), { recursive: true });
+    writeFileSync(join(destination, '.review-eval', 'task.md'), readFileSync(resolveProtocolAsset(protocolPath, item.task_path)));
+    writeFileSync(join(destination, '.review-eval', 'findings.schema.json'), readFileSync(resolveProtocolAsset(protocolPath, protocol.prompt.output_schema_path)));
+    if (arm === 'treatment') {
+        mkdirSync(join(destination, '.agents', 'skills', 'review'), { recursive: true });
+        writeFileSync(join(destination, '.agents', 'skills', 'review', 'SKILL.md'), '# Frozen review guidance\n');
+        mkdirSync(join(destination, '.agents', 'skills'), { recursive: true });
+        writeFileSync(join(destination, '.agents', 'skills', 'DOCTRINE.md'), '# Frozen doctrine\n');
+    }
+    writeFileSync(join(destination, 'candidate.txt'), 'historical base\n');
+    initializeFixtureRepository(destination, protocol.execution.fixture_commit_time);
+    writeFileSync(join(destination, 'candidate.txt'), `uncommitted candidate for ${item.id}\n`);
+    return { workspace: destination, item, history: assertHistoryTruncated(destination) };
+}
+
+function codexVersion(codexBin, env) {
+    const result = run(codexBin, ['--version'], { env, allowFailure: true });
+    if (result.status !== 0) fail(`cannot run ${codexBin} --version`);
+    return result.stdout.trim();
+}
+
+function ensureNewOutput(path) {
+    const output = resolve(path);
+    if (existsSync(output) && (!statSync(output).isDirectory() || readdirSync(output).length)) {
+        fail(`output path must be new or empty: ${output}`);
+    }
+    privateMkdir(output);
+    return output;
+}
+
+function installOffline(workspace) {
+    return run('pnpm', ['install', '--offline', '--frozen-lockfile', '--ignore-scripts'], {
+        cwd: workspace,
+        timeout: 180_000,
+    });
+}
+
+function prepareOfflineCache({ protocol, protocolPath, source }) {
+    assertArtifactLock(protocol, protocolPath, source);
+    const storePath = run('pnpm', ['store', 'path']).stdout.trim();
+    if (!storePath.startsWith(sep)) fail(`pnpm returned a non-absolute store path: ${storePath}`);
+    const cacheHome = privateDirectory('cycle-review-pnpm-home-');
+    const env = {};
+    for (const key of ['PATH', 'LANG', 'LC_ALL', 'SSL_CERT_FILE', 'SSL_CERT_DIR']) {
+        if (process.env[key]) env[key] = process.env[key];
+    }
+    env.HOME = cacheHome;
+    env.NO_COLOR = '1';
+    env.npm_config_registry = 'https://registry.npmjs.org/';
+    env.npm_config_userconfig = '/dev/null';
+    try {
+        const fetched = [];
+        for (const item of protocol.cases.filter((entry) => !entry.variant)) {
+            const root = privateDirectory(`cycle-review-cache-${item.id}-`);
+            try {
+                const workspace = join(root, 'workspace');
+                materializeFixture({
+                    protocol,
+                    protocolPath,
+                    source,
+                    caseId: item.id,
+                    arm: 'baseline',
+                    destination: workspace,
+                });
+                run('pnpm', ['fetch', '--store-dir', storePath], {
+                    cwd: workspace,
+                    env,
+                    timeout: 180_000,
+                });
+                fetched.push(item.id);
+            } finally {
+                rmSync(root, { recursive: true, force: true });
+            }
+        }
+        return { store: storePath, fetched_cases: fetched };
+    } finally {
+        rmSync(cacheHome, { recursive: true, force: true });
+    }
+}
+
+function executeCell({
+    protocol,
+    protocolPath,
+    source,
+    output,
+    cell,
+    attempt,
+    codexBin,
+    codexVersionValue,
+    model,
+    effort,
+    timeoutMs,
+    dryRun,
+    codexHome,
+}) {
+    const publicCase = protocol.cases.find((entry) => entry.id === cell.case_id);
+    const privateRoot = privateDirectory('cycle-review-cell-');
+    const workspace = join(privateRoot, 'workspace');
+    const reviewerScratch = join(privateRoot, 'reviewer-tmp');
+    mkdirSync(reviewerScratch, { recursive: true });
+    const runName = `${String(cell.pair_index ?? 0).padStart(2, '0')}-${cell.cell_id}-a${attempt}`;
+    const runDir = join(output, 'private', 'runs', runName);
+    privateMkdir(runDir);
+    let reviewerHome;
+    try {
+        const fixture = dryRun
+            ? setupDryFixture(protocol, protocolPath, publicCase, cell.arm, workspace)
+            : materializeFixture({ protocol, protocolPath, source, caseId: cell.case_id, arm: cell.arm, destination: workspace });
+        if (!dryRun) installOffline(workspace);
+        const before = run('git', [
+            'diff', '--binary', '--full-index', '--no-ext-diff', '--no-renames',
+        ], { cwd: workspace, encoding: null }).stdout;
+        const statusBefore = run('git', ['status', '--porcelain=v1', '-z'], {
+            cwd: workspace,
+            encoding: null,
+        }).stdout;
+        privateWrite(join(runDir, 'candidate.diff'), before);
+        const authPath = dryRun ? null : resolveAuthPath(codexHome);
+        reviewerHome = createReviewerHome({ codexHome, includeAuth: !dryRun, codexBin, workspace });
+        const env = reviewerEnvironment({
+            reviewerHome,
+            scratch: reviewerScratch,
+            cellId: cell.cell_id,
+            arm: cell.arm,
+            caseId: cell.case_id,
+            repetition: cell.repetition,
+            pairIndex: cell.pair_index,
+            attempt,
+            fakeMode: dryRun ? process.env.CYCLE_REVIEW_FAKE_MODE ?? '' : '',
+        });
+        const args = [
+            'exec', '--json', '--ephemeral', '--strict-config', '--ignore-rules',
+            '--cd', workspace,
+            '--model', model,
+            '-c', `model_reasoning_effort=${JSON.stringify(effort)}`,
+            '--output-schema', join(workspace, '.review-eval', 'findings.schema.json'),
+            '--color', 'never',
+            commonPrompt(protocol, protocolPath, fixture.item),
+        ];
+        const startedAt = new Date().toISOString();
+        const processResult = run(codexBin, args, {
+            cwd: workspace,
+            env,
+            timeout: timeoutMs,
+            allowFailure: true,
+        });
+        const finishedAt = new Date().toISOString();
+        const stdout = processResult.stdout ?? '';
+        const stderr = processResult.stderr ?? '';
+        // Why: the outer client needs auth, but any accidental echo must fail closed before persistence.
+        assertNoCredentialMaterial([stdout, stderr], authPath);
+        privateWrite(join(runDir, 'events.jsonl'), stdout);
+        privateWrite(join(runDir, 'stderr.txt'), stderr);
+        const parsed = parseExecEvents(stdout);
+        const finalText = finalAgentText(parsed.events);
+        if (finalText) privateWrite(join(runDir, 'final.json'), `${finalText}\n`);
+        const after = run('git', [
+            'diff', '--binary', '--full-index', '--no-ext-diff', '--no-renames',
+        ], { cwd: workspace, encoding: null }).stdout;
+        const statusAfter = run('git', ['status', '--porcelain=v1', '-z'], {
+            cwd: workspace,
+            encoding: null,
+        }).stdout;
+        const invalid = [];
+        if (processResult.status !== 0) invalid.push(`reviewer exited ${processResult.status}`);
+        if (parsed.invalid) invalid.push(parsed.invalid);
+        if (!parsed.events.some((event) => event.type === 'turn.completed')) invalid.push('missing turn.completed');
+        const schemaInvalid = validateFindingsText(finalText);
+        if (schemaInvalid) invalid.push(schemaInvalid);
+        const guidance = guidanceEvidence(
+            parsed.events,
+            protocol.source.review_guidance_paths,
+            workspace,
+        );
+        if (cell.arm === 'treatment' && !guidance.read) invalid.push('treatment did not read pinned review guidance');
+        if (cell.arm === 'baseline' && guidance.touched) invalid.push('baseline discovered treatment review guidance');
+        if (!before.equals(after) || !statusBefore.equals(statusAfter)) {
+            invalid.push('reviewer mutated the candidate fixture');
+        }
+        const result = {
+            study_id: protocol.study_id,
+            case_id: cell.case_id,
+            repetition: cell.repetition,
+            arm: cell.arm,
+            cell_id: cell.cell_id,
+            attempt,
+            valid: invalid.length === 0,
+            invalid_reasons: invalid,
+            model,
+            reasoning_effort: effort,
+            codex_version: codexVersionValue,
+            started_at: startedAt,
+            finished_at: finishedAt,
+            elapsed_ms: processResult.elapsedMs,
+            usage: parsed.usage,
+            fixture: fixture.history,
+            treatment_guidance_read: guidance.read,
+            artifacts: {
+                events: relative(output, join(runDir, 'events.jsonl')),
+                stderr: relative(output, join(runDir, 'stderr.txt')),
+                candidate_diff: relative(output, join(runDir, 'candidate.diff')),
+                final: finalText ? relative(output, join(runDir, 'final.json')) : null,
+            },
+        };
+        privateWrite(join(runDir, 'result.json'), `${JSON.stringify(result, null, 2)}\n`);
+        return result;
+    } finally {
+        if (reviewerHome) rmSync(reviewerHome, { recursive: true, force: true });
+        rmSync(privateRoot, { recursive: true, force: true });
+    }
+}
+
+export function acceptedResults(protocol, results) {
+    const latestValid = new Map();
+    for (const item of protocol.cases) {
+        for (let repetition = 1; repetition <= protocol.schedule.repetitions; repetition += 1) {
+            const attempts = results
+                .filter((result) => result.case_id === item.id && result.repetition === repetition)
+                .map((result) => result.attempt);
+            if (!attempts.length) continue;
+            const latestAttempt = Math.max(...attempts);
+            const pair = results.filter((result) => result.case_id === item.id
+                && result.repetition === repetition && result.attempt === latestAttempt);
+            const arms = new Set(pair.map((result) => result.arm));
+            // Why: retry validity belongs to the matched pair, never to compatible cells from different attempts.
+            if (pair.length !== 2 || arms.size !== 2 || !arms.has('baseline') || !arms.has('treatment')
+                || pair.some((result) => !result.valid)) continue;
+            for (const result of pair) {
+                latestValid.set(`${result.case_id}:${result.repetition}:${result.arm}`, result);
+            }
+        }
+    }
+    return latestValid;
+}
+
+function writeScoringArtifacts({ protocol, protocolPath, output, results }) {
+    const latestValid = acceptedResults(protocol, results);
+    if (latestValid.size !== 36) fail('cannot normalize an incomplete experiment');
+
+    const scoringRoot = join(output, 'scoring');
+    const fixtureRoot = join(scoringRoot, 'fixtures');
+    const privateRoot = join(output, 'private');
+    privateMkdir(fixtureRoot);
+    privateMkdir(privateRoot);
+
+    const fixtures = [];
+    const packets = [];
+    const blindingMap = [];
+    const measures = [];
+    for (const publicCase of protocol.cases) {
+        const item = sourceCase(protocol, publicCase);
+        const fixtureId = sha256(`${protocol.schedule.seed}\0fixture\0${publicCase.id}`).slice(0, 16);
+        const caseResults = [...latestValid.values()].filter((result) => result.case_id === publicCase.id);
+        const diffs = caseResults.map((result) => readFileSync(join(output, result.artifacts.candidate_diff)));
+        const diffHashes = new Set(diffs.map(sha256));
+        if (diffHashes.size !== 1) fail(`candidate diff drifted between cells for ${publicCase.id}`);
+        const diffPath = join('fixtures', `${fixtureId}.diff`);
+        privateWrite(join(scoringRoot, diffPath), diffs[0]);
+        fixtures.push({
+            fixture_id: fixtureId,
+            expected_state: item.targetClean ? 'named-defect-repaired' : 'defect-present',
+            task: readFileSync(resolveProtocolAsset(protocolPath, item.task_path), 'utf8'),
+            candidate_diff: diffPath,
+            candidate_diff_sha256: [...diffHashes][0],
+            targets: item.targets.map((target, index) => ({
+                target_label: `T${index + 1}`,
+                credit: target.credit,
+            })),
+        });
+
+        for (let repetition = 1; repetition <= protocol.schedule.repetitions; repetition += 1) {
+            const pair = ['baseline', 'treatment'].map((arm) => latestValid.get(
+                `${publicCase.id}:${repetition}:${arm}`,
+            ));
+            if (pair.some((result) => !result)) fail(`missing valid pair for ${publicCase.id}:${repetition}`);
+            const ordered = pair.sort((a, b) => seededRank(
+                protocol.schedule.seed,
+                `blind:${publicCase.id}:${repetition}:${a.arm}`,
+            ).localeCompare(seededRank(
+                protocol.schedule.seed,
+                `blind:${publicCase.id}:${repetition}:${b.arm}`,
+            )));
+            const packetId = sha256(
+                `${protocol.schedule.seed}\0packet\0${publicCase.id}\0${repetition}`,
+            ).slice(0, 16);
+            const reviews = ordered.map((result, index) => {
+                const outputLabel = String.fromCharCode(65 + index);
+                const finalPath = result.artifacts.final && join(output, result.artifacts.final);
+                if (!finalPath || !existsSync(finalPath)) fail(`missing final output for ${result.cell_id}`);
+                const finalText = readFileSync(finalPath, 'utf8');
+                const invalid = validateFindingsText(finalText);
+                if (invalid) fail(`cannot normalize ${result.cell_id}: ${invalid}`);
+                blindingMap.push({
+                    packet_id: packetId,
+                    fixture_id: fixtureId,
+                    case_id: publicCase.id,
+                    repetition,
+                    output_label: outputLabel,
+                    arm: result.arm,
+                    cell_id: result.cell_id,
+                    attempt: result.attempt,
+                });
+                measures.push({
+                    case_id: publicCase.id,
+                    repetition,
+                    arm: result.arm,
+                    cell_id: result.cell_id,
+                    attempt: result.attempt,
+                    elapsed_ms: result.elapsed_ms,
+                    usage: result.usage,
+                    lifecycle_evidence: {
+                        treatment_guidance_read: result.treatment_guidance_read,
+                        reviewer_count: protocol.execution.reviewers_per_arm,
+                    },
+                });
+                return {
+                    output_label: outputLabel,
+                    findings: normalizedFindings(finalText),
+                };
+            });
+            packets.push({ packet_id: packetId, fixture_id: fixtureId, trial: repetition, reviews });
+        }
+    }
+
+    const scoringInput = {
+        version: 1,
+        instructions: {
+            independence: 'Two scorers complete separate schema-valid files before adjudication.',
+            recall: protocol.scoring.recall,
+            actionability: protocol.scoring.actionability,
+            unsupported_findings: protocol.scoring.unsupported_findings,
+            controls: protocol.scoring.controls,
+            composite_score: false,
+        },
+        fixtures,
+        packets,
+    };
+    const scoringBytes = Buffer.from(`${JSON.stringify(scoringInput, null, 2)}\n`);
+    privateWrite(join(scoringRoot, 'scoring-input.json'), scoringBytes);
+    const scoreSchema = readFileSync(resolveProtocolAsset(protocolPath, protocol.scoring.schema_path));
+    privateWrite(join(scoringRoot, 'score.schema.json'), scoreSchema);
+    privateWrite(join(privateRoot, 'blinding-map.json'), `${JSON.stringify(blindingMap, null, 2)}\n`);
+    privateWrite(
+        join(privateRoot, 'measures.jsonl'),
+        `${measures.map((measure) => JSON.stringify(measure)).join('\n')}\n`,
+    );
+    privateWrite(join(scoringRoot, 'manifest.json'), `${JSON.stringify({
+        scoring_input_sha256: sha256(scoringBytes),
+        score_schema_sha256: sha256(scoreSchema),
+        fixture_diffs: fixtures.map((fixture) => ({
+            fixture_id: fixture.fixture_id,
+            sha256: fixture.candidate_diff_sha256,
+        })),
+        packet_count: packets.length,
+        normalized_review_count: packets.length * 2,
+    }, null, 2)}\n`);
+}
+
+function runExperiment({
+    protocol,
+    protocolPath,
+    source,
+    output,
+    codexBin,
+    model,
+    effort,
+    timeoutMs,
+    dryRun,
+    codexHome,
+}) {
+    const reviewerHome = createReviewerHome({ codexHome, includeAuth: false, codexBin });
+    const versionEnv = reviewerEnvironment({ reviewerHome, scratch: privateDirectory('cycle-review-version-') });
+    let version;
+    try { version = codexVersion(codexBin, versionEnv); }
+    finally {
+        rmSync(versionEnv.TMPDIR, { recursive: true, force: true });
+        rmSync(reviewerHome, { recursive: true, force: true });
+    }
+    const schedule = buildSchedule(protocol);
+    const experiment = {
+        study_id: protocol.study_id,
+        protocol_sha256: sha256(readFileSync(protocolPath)),
+        mode: dryRun ? 'dry-run' : 'scored',
+        model,
+        reasoning_effort: effort,
+        codex_version: version,
+        schedule,
+    };
+    privateWrite(join(output, 'private', 'experiment.json'), `${JSON.stringify(experiment, null, 2)}\n`);
+    const results = [];
+    for (const pair of schedule) {
+        let pairResults = pair.cells.map((cell) => executeCell({
+            protocol,
+            protocolPath,
+            source,
+            output,
+            cell: { ...cell, pair_index: pair.pair_index },
+            attempt: 1,
+            codexBin,
+            codexVersionValue: version,
+            model,
+            effort,
+            timeoutMs,
+            dryRun,
+            codexHome,
+        }));
+        results.push(...pairResults);
+        if (pairResults.some((result) => !result.valid)) {
+            pairResults = pair.cells.map((cell) => executeCell({
+                protocol,
+                protocolPath,
+                source,
+                output,
+                cell: { ...cell, pair_index: pair.pair_index },
+                attempt: 2,
+                codexBin,
+                codexVersionValue: version,
+                model,
+                effort,
+                timeoutMs,
+                dryRun,
+                codexHome,
+            }));
+            results.push(...pairResults);
+            if (pairResults.some((result) => !result.valid)) break;
+        }
+    }
+    privateWrite(
+        join(output, 'private', 'results.jsonl'),
+        `${results.map((result) => JSON.stringify(result)).join('\n')}\n`,
+    );
+    const latestValid = acceptedResults(protocol, results);
+    const complete = latestValid.size === 36;
+    privateWrite(join(output, 'summary.json'), `${JSON.stringify({
+        complete,
+        valid_cells: latestValid.size,
+        attempts: results.length,
+        invalid_attempts: results.filter((result) => !result.valid).length,
+    }, null, 2)}\n`);
+    if (!complete) fail(`experiment stopped with ${latestValid.size}/36 valid cells`);
+    writeScoringArtifacts({ protocol, protocolPath, output, results });
+    return results;
+}
+
+function runOracleCommands(workspace, commands) {
+    const outputs = [];
+    for (const command of commands) {
+        const result = run('/bin/sh', ['-c', command], {
+            cwd: workspace,
+            timeout: 180_000,
+            allowFailure: true,
+        });
+        outputs.push({ command, status: result.status, stdout: result.stdout, stderr: result.stderr });
+        if (result.status !== 0) return { status: result.status, outputs };
+    }
+    return { status: 0, outputs };
+}
+
+function oracleFailure(result) {
+    const failed = result.outputs.find((entry) => entry.status !== 0);
+    if (!failed) return 'unknown oracle failure';
+    return [
+        `command: ${failed.command}`,
+        failed.stderr?.trim(),
+        failed.stdout?.trim(),
+    ].filter(Boolean).join('\n');
+}
+
+function verifyOracle({ protocol, protocolPath, source, item }) {
+    const privateRoot = privateDirectory(`cycle-review-oracle-${item.id}-`);
+    const workspace = join(privateRoot, 'workspace');
+    try {
+        materializeFixture({ protocol, protocolPath, source, caseId: item.id, arm: 'baseline', destination: workspace });
+        installOffline(workspace);
+        const original = runOracleCommands(workspace, item.oracle_commands);
+        if (original.status !== 0) {
+            fail(`case ${item.id} original tests are red before hidden oracle\n${oracleFailure(original)}`);
+        }
+        const parent = repairParent(source, item.repair);
+        applyPatch(workspace, patchBetween(source, parent, item.repair, item.oracle_paths));
+        const flawed = runOracleCommands(workspace, item.oracle_commands);
+        if (flawed.status === 0) fail(`case ${item.id} hidden oracle did not fail against flawed candidate`);
+        applyPatch(workspace, patchBetween(source, parent, item.repair, item.repair_paths));
+        const repaired = runOracleCommands(workspace, item.oracle_commands);
+        if (repaired.status !== 0) {
+            fail(`case ${item.id} hidden oracle stayed red after repair\n${oracleFailure(repaired)}`);
+        }
+        return {
+            case_id: item.id,
+            original_tests: 'pass',
+            hidden_oracle_on_flawed: 'fail',
+            hidden_oracle_after_repair: 'pass',
+        };
+    } finally {
+        rmSync(privateRoot, { recursive: true, force: true });
+    }
+}
+
+function verifyControl({ protocol, protocolPath, source, item }) {
+    const privateRoot = privateDirectory(`cycle-review-control-${item.id}-`);
+    const workspace = join(privateRoot, 'workspace');
+    try {
+        const fixture = materializeFixture({ protocol, protocolPath, source, caseId: item.id, arm: 'baseline', destination: workspace });
+        installOffline(workspace);
+        const parent = repairParent(source, fixture.item.repair);
+        applyPatch(workspace, patchBetween(source, parent, fixture.item.repair, fixture.item.oracle_paths));
+        const result = runOracleCommands(workspace, fixture.item.oracle_commands);
+        if (result.status !== 0) {
+            fail(`control ${item.id} is not target-clean\n${oracleFailure(result)}`);
+        }
+        return { case_id: item.id, hidden_oracle: 'pass' };
+    } finally {
+        rmSync(privateRoot, { recursive: true, force: true });
+    }
+}
+
+export function probeIsolation(codexBin = 'codex') {
+    const root = privateDirectory('cycle-review-isolation-');
+    const workspace = join(root, 'workspace');
+    const scratch = privateDirectory('cycle-review-isolation-tmp-');
+    let reviewerHome;
+    let loopback;
+    try {
+        mkdirSync(workspace, { recursive: true });
+        reviewerHome = createReviewerHome({ includeAuth: false, codexBin, workspace });
+        writeFileSync(join(workspace, 'allowed.txt'), 'allowed\n');
+        const deniedNames = ['source', 'evaluator', 'sibling', 'memory', 'oracle'];
+        const denied = deniedNames.map((name) => {
+            const path = join(root, `${name}.sentinel`);
+            writeFileSync(path, `${name}\n`);
+            return path;
+        });
+        const authHomeSentinel = join(reviewerHome, 'auth-home.sentinel');
+        writeFileSync(authHomeSentinel, 'auth-home\n', { mode: 0o600 });
+        denied.push(authHomeSentinel);
+        const env = reviewerEnvironment({ reviewerHome, scratch });
+        loopback = startLoopbackProbe(root);
+        const script = [
+            'test -r allowed.txt || exit 10',
+            'rg -q "^allowed$" allowed.txt || exit 11',
+            'test "$(sed -n 1p allowed.txt)" = allowed || exit 12',
+            'git --version >/dev/null || exit 13',
+            `if /bin/bash -c 'exec 3<>/dev/tcp/127.0.0.1/${loopback.port}' 2>/dev/null; then exit 30; fi`,
+            'shift',
+            'for path do test ! -r "$path" || exit 20; done',
+        ].join('; ');
+        const result = run(codexBin, [
+            'sandbox', '--permission-profile', 'review-fixture', '--cd', workspace,
+            '/bin/sh', '-c', script, 'probe', ...denied,
+        ], { cwd: workspace, env, allowFailure: true, timeout: 30_000 });
+        if (result.status !== 0) {
+            fail(`Codex permission-profile isolation probe failed (${result.status})\n${result.stderr || result.stdout || ''}`.trimEnd());
+        }
+        return {
+            allowed_fixture_read: true,
+            required_review_tools: ['git', 'rg', 'sed'],
+            denied_host_loopback_listener: true,
+            denied_host_sentinels: [...deniedNames, 'auth-home'],
+            command_network: false,
+            filesystem_profile_sha256: sha256(reviewerConfig('/usr/bin:/bin', ['/fixture', '/runtime/codex'])),
+        };
+    } finally {
+        if (loopback) loopback.stop();
+        rmSync(root, { recursive: true, force: true });
+        if (reviewerHome) rmSync(reviewerHome, { recursive: true, force: true });
+        rmSync(scratch, { recursive: true, force: true });
+    }
+}
+
+function preflight({ protocol, protocolPath, source, output, codexBin, skipOracles }) {
+    assertArtifactLock(protocol, protocolPath, source);
+    const fixtures = [];
+    for (const item of protocol.cases) {
+        const root = privateDirectory(`cycle-review-preflight-${item.id}-`);
+        try {
+            const fixture = materializeFixture({
+                protocol,
+                protocolPath,
+                source,
+                caseId: item.id,
+                arm: 'baseline',
+                destination: join(root, 'workspace'),
+            });
+            fixtures.push({ case_id: item.id, ...fixture.history });
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    }
+    const isolation = probeIsolation(codexBin);
+    const oracles = skipOracles ? null : [
+        ...protocol.cases.filter((item) => !item.variant).map((item) => verifyOracle({
+            protocol, protocolPath, source, item,
+        })),
+        ...protocol.cases.filter((item) => item.variant === 'target-clean').map((item) => verifyControl({
+            protocol, protocolPath, source, item,
+        })),
+    ];
+    const result = {
+        study_id: protocol.study_id,
+        protocol_sha256: sha256(readFileSync(protocolPath)),
+        artifact_lock: 'pass',
+        fixtures,
+        isolation,
+        oracles,
+        scored_model_calls: 0,
+    };
+    privateWrite(join(output, 'preflight.json'), `${JSON.stringify(result, null, 2)}\n`);
+    return result;
+}
+
+function usage() {
+    return `Usage:
+  node eval/review/run.mjs lock --source <release-relay-checkout>
+  node eval/review/run.mjs plan
+  node eval/review/run.mjs fetch-cache --source <checkout> --allow-network
+  node eval/review/run.mjs dry-run --output <new-directory>
+  node eval/review/run.mjs preflight --source <checkout> --output <new-directory> [--skip-oracles]
+  node eval/review/run.mjs run --source <checkout> --output <new-directory>
+       --confirm-protocol-sha256 <sha256> [--codex-home <path>]
+
+Options:
+  --protocol <path>       Protocol file, default: eval/review/protocol.json
+  --codex-bin <path>      Codex executable; dry-run defaults to the bundled fake
+  --timeout-ms <number>   Dry-run override; scored runs must match the frozen protocol
+`;
+}
+
+export function main(argv = process.argv.slice(2)) {
+    const { values, positionals } = parseArgs({
+        args: argv,
+        allowPositionals: true,
+        strict: true,
+        options: {
+            protocol: { type: 'string', default: DEFAULT_PROTOCOL },
+            source: { type: 'string' },
+            output: { type: 'string' },
+            'codex-bin': { type: 'string' },
+            'codex-home': { type: 'string' },
+            'confirm-protocol-sha256': { type: 'string' },
+            'timeout-ms': { type: 'string' },
+            'skip-oracles': { type: 'boolean', default: false },
+            'allow-network': { type: 'boolean', default: false },
+            help: { type: 'boolean', short: 'h', default: false },
+        },
+    });
+    if (values.help || positionals.length !== 1) {
+        console.log(usage());
+        return values.help ? 0 : 2;
+    }
+    const command = positionals[0];
+    const requireLock = command !== 'lock';
+    const { protocol, protocolPath } = loadProtocol(values.protocol, { requireLock });
+    if (command === 'lock') {
+        if (!values.source) fail('lock requires --source');
+        console.log(JSON.stringify(computeArtifactLock(protocol, protocolPath, values.source), null, 2));
+        return 0;
+    }
+    if (command === 'plan') {
+        console.log(JSON.stringify(buildSchedule(protocol), null, 2));
+        return 0;
+    }
+    if (command === 'fetch-cache') {
+        if (!values.source) fail('fetch-cache requires --source');
+        if (!values['allow-network']) fail('fetch-cache requires explicit --allow-network');
+        console.log(JSON.stringify(prepareOfflineCache({
+            protocol,
+            protocolPath,
+            source: verifySource(values.source, protocol),
+        }), null, 2));
+        return 0;
+    }
+    const timeoutMs = Number(values['timeout-ms'] ?? protocol.execution.timeout_ms);
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1) fail('--timeout-ms must be a positive integer');
+    if (!values.output) fail(`${command} requires --output`);
+    const output = ensureNewOutput(values.output);
+    if (command === 'dry-run') {
+        runExperiment({
+            protocol,
+            protocolPath,
+            output,
+            codexBin: resolve(values['codex-bin'] ?? DEFAULT_FAKE_CODEX),
+            model: 'fake-review-model',
+            effort: protocol.execution.reasoning_effort,
+            timeoutMs,
+            dryRun: true,
+        });
+        return 0;
+    }
+    if (!values.source) fail(`${command} requires --source`);
+    const source = verifySource(values.source, protocol);
+    if (command === 'preflight') {
+        preflight({
+            protocol,
+            protocolPath,
+            source,
+            output,
+            codexBin: values['codex-bin'] ?? 'codex',
+            skipOracles: values['skip-oracles'],
+        });
+        return 0;
+    }
+    if (command === 'run') {
+        const expected = sha256(readFileSync(protocolPath));
+        if (values['confirm-protocol-sha256'] !== expected) {
+            fail(`run requires --confirm-protocol-sha256 ${expected}`);
+        }
+        if (timeoutMs !== protocol.execution.timeout_ms) {
+            fail(`run timeout is frozen at ${protocol.execution.timeout_ms}ms`);
+        }
+        if (values['skip-oracles']) fail('run cannot skip hidden-oracle preflight');
+        preflight({
+            protocol,
+            protocolPath,
+            source,
+            output,
+            codexBin: values['codex-bin'] ?? 'codex',
+            skipOracles: false,
+        });
+        runExperiment({
+            protocol,
+            protocolPath,
+            source,
+            output,
+            codexBin: values['codex-bin'] ?? 'codex',
+            model: protocol.execution.model,
+            effort: protocol.execution.reasoning_effort,
+            timeoutMs,
+            dryRun: false,
+            codexHome: values['codex-home'],
+        });
+        return 0;
+    }
+    fail(`unknown command: ${command}`);
+}
+
+function invokedDirectly() {
+    return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+if (invokedDirectly()) {
+    try {
+        process.exitCode = main();
+    } catch (error) {
+        if (error instanceof ReviewEvalError) {
+            console.error(error.message);
+            process.exitCode = 2;
+        } else {
+            throw error;
+        }
+    }
+}

--- a/eval/review/run.mjs
+++ b/eval/review/run.mjs
@@ -128,8 +128,11 @@ export function validateProtocol(protocol, { requireLock = true } = {}) {
     }
     if (!protocol.schedule || protocol.schedule.repetitions !== 3
         || protocol.schedule.invalid_pair_retry_limit !== 1
+        || protocol.schedule.pairs_per_batch !== 1
+        || protocol.schedule.batch_unit !== 'matched_pair'
+        || !isNonEmptyString(protocol.schedule.resume_rule)
         || !isNonEmptyString(protocol.schedule.seed)) {
-        fail('review protocol must freeze three repetitions and a seed');
+        fail('review protocol must freeze three repetitions, one matched pair per batch, and a seed');
     }
     if (!protocol.execution || !isNonEmptyString(protocol.execution.model)
         || !isNonEmptyString(protocol.execution.reasoning_effort)
@@ -865,6 +868,76 @@ function ensureNewOutput(path) {
     return output;
 }
 
+function validatePrivateBatchTree(root, path = root) {
+    const metadata = lstatSync(path);
+    if (metadata.isSymbolicLink()) fail(`batch output contains a symlink: ${relative(root, path) || '.'}`);
+    if (metadata.isDirectory()) {
+        if ((metadata.mode & 0o077) !== 0) {
+            fail(`batch output directory is not private: ${relative(root, path) || '.'}`);
+        }
+        for (const entry of readdirSync(path)) validatePrivateBatchTree(root, join(path, entry));
+        return;
+    }
+    if (!metadata.isFile()) fail(`batch output contains a special file: ${relative(root, path)}`);
+    if ((metadata.mode & 0o077) !== 0) fail(`batch output file is not private: ${relative(root, path)}`);
+}
+
+function prepareBatchOutput(path) {
+    const output = resolve(path);
+    if (!existsSync(output)) {
+        privateMkdir(output);
+        return { output, resume: false };
+    }
+    const metadata = lstatSync(output);
+    if (metadata.isSymbolicLink() || !metadata.isDirectory()) {
+        fail(`batch output path must be a real directory: ${output}`);
+    }
+    if ((metadata.mode & 0o077) !== 0) {
+        fail(`batch output directory must not be accessible by group or other users: ${output}`);
+    }
+    const entries = readdirSync(output);
+    const occupied = entries.length > 0;
+    if (occupied) validatePrivateBatchTree(output);
+    else privateMkdir(output);
+    const experimentPath = join(output, 'private', 'experiment.json');
+    const resultsPath = join(output, 'private', 'results.jsonl');
+    const resume = existsSync(experimentPath) || existsSync(resultsPath);
+    if (resume !== (existsSync(experimentPath) && existsSync(resultsPath))) {
+        fail('batch output contains a partial checkpoint; inspect private state before resuming');
+    }
+    if (!resume && occupied) {
+        const allowedRoot = new Set(['preflight.json', 'private']);
+        for (const entry of entries) {
+            if (!allowedRoot.has(entry)) {
+                fail(`batch output contains stale non-checkpoint state: ${entry}`);
+            }
+        }
+        const privateRoot = join(output, 'private');
+        if (existsSync(privateRoot) && readdirSync(privateRoot).length > 0) {
+            fail('batch output contains stale private state before the first checkpoint; inspect it before resuming');
+        }
+    }
+    return { output, resume };
+}
+
+function withBatchLock(output, callback) {
+    const lockPath = join(output, 'private', 'batch.lock');
+    privateMkdir(dirname(lockPath));
+    try {
+        writeFileSync(lockPath, `${JSON.stringify({ pid: process.pid, started_at: new Date().toISOString() })}\n`, {
+            flag: 'wx',
+            mode: 0o600,
+        });
+    } catch (error) {
+        fail(`batch output is locked or cannot be locked: ${lockPath} (${error.code ?? error.message})`);
+    }
+    try {
+        return callback();
+    } finally {
+        rmSync(lockPath, { force: true });
+    }
+}
+
 function installOffline(workspace) {
     return run('pnpm', ['install', '--offline', '--frozen-lockfile', '--ignore-scripts'], {
         cwd: workspace,
@@ -1014,10 +1087,20 @@ function executeCell({
         if (!before.equals(after) || !statusBefore.equals(statusAfter)) {
             invalid.push('reviewer mutated the candidate fixture');
         }
+        const artifacts = {
+            events: relative(output, join(runDir, 'events.jsonl')),
+            stderr: relative(output, join(runDir, 'stderr.txt')),
+            candidate_diff: relative(output, join(runDir, 'candidate.diff')),
+            final: finalText ? relative(output, join(runDir, 'final.json')) : null,
+        };
+        const artifactSha256 = Object.fromEntries(Object.entries(artifacts)
+            .filter(([, path]) => path)
+            .map(([key, path]) => [key, sha256(readFileSync(join(output, path)))]));
         const result = {
             study_id: protocol.study_id,
             case_id: cell.case_id,
             repetition: cell.repetition,
+            pair_index: cell.pair_index,
             arm: cell.arm,
             cell_id: cell.cell_id,
             attempt,
@@ -1032,12 +1115,8 @@ function executeCell({
             usage: parsed.usage,
             fixture: fixture.history,
             treatment_guidance_read: guidance.read,
-            artifacts: {
-                events: relative(output, join(runDir, 'events.jsonl')),
-                stderr: relative(output, join(runDir, 'stderr.txt')),
-                candidate_diff: relative(output, join(runDir, 'candidate.diff')),
-                final: finalText ? relative(output, join(runDir, 'final.json')) : null,
-            },
+            artifacts,
+            artifact_sha256: artifactSha256,
         };
         privateWrite(join(runDir, 'result.json'), `${JSON.stringify(result, null, 2)}\n`);
         return result;
@@ -1068,6 +1147,136 @@ export function acceptedResults(protocol, results) {
         }
     }
     return latestValid;
+}
+
+function readResults(path) {
+    if (!existsSync(path)) fail(`missing resumable results: ${path}`);
+    const text = readFileSync(path, 'utf8').trim();
+    if (!text) return [];
+    return text.split('\n').map((line, index) => {
+        try {
+            return JSON.parse(line);
+        } catch (error) {
+            fail(`invalid resumable results JSON at line ${index + 1}: ${error.message}`);
+        }
+    });
+}
+
+function expectedArtifacts(pair, cell, result) {
+    const runName = `${String(pair.pair_index).padStart(2, '0')}-${cell.cell_id}-a${result.attempt}`;
+    const root = join('private', 'runs', runName);
+    return {
+        events: join(root, 'events.jsonl'),
+        stderr: join(root, 'stderr.txt'),
+        candidate_diff: join(root, 'candidate.diff'),
+        final: result.artifacts?.final === null ? null : join(root, 'final.json'),
+    };
+}
+
+function validatePersistedResult({ output, experiment, pair, cell, attempt, result }) {
+    if (!result || typeof result !== 'object' || Array.isArray(result)) {
+        fail(`resumable result for pair ${pair.pair_index} is not an object`);
+    }
+    const expectedIdentity = {
+        study_id: experiment.study_id,
+        case_id: pair.case_id,
+        repetition: pair.repetition,
+        pair_index: pair.pair_index,
+        arm: cell.arm,
+        cell_id: cell.cell_id,
+        attempt,
+        model: experiment.model,
+        reasoning_effort: experiment.reasoning_effort,
+        codex_version: experiment.codex_version,
+    };
+    for (const [key, expected] of Object.entries(expectedIdentity)) {
+        if (result[key] !== expected) {
+            fail(`resumable result mismatch for pair ${pair.pair_index} ${cell.arm}: ${key}`);
+        }
+    }
+    if (typeof result.valid !== 'boolean' || !Array.isArray(result.invalid_reasons)
+        || !Number.isSafeInteger(result.elapsed_ms) || result.elapsed_ms < 0) {
+        fail(`resumable result has invalid status fields for pair ${pair.pair_index} ${cell.arm}`);
+    }
+    const artifacts = expectedArtifacts(pair, cell, result);
+    if (stableJson(result.artifacts) !== stableJson(artifacts)) {
+        fail(`resumable result has unexpected artifact paths for pair ${pair.pair_index} ${cell.arm}`);
+    }
+    const paths = [...Object.values(artifacts).filter(Boolean), join(
+        'private',
+        'runs',
+        `${String(pair.pair_index).padStart(2, '0')}-${cell.cell_id}-a${attempt}`,
+        'result.json',
+    )];
+    for (const artifact of paths) {
+        const path = resolve(output, artifact);
+        ensureInside(output, path);
+        if (!existsSync(path) || lstatSync(path).isSymbolicLink() || !lstatSync(path).isFile()) {
+            fail(`missing or unsafe resumable artifact: ${artifact}`);
+        }
+        ensureInside(realpathSync(output), realpathSync(path));
+        if ((lstatSync(path).mode & 0o077) !== 0) fail(`resumable artifact is not private: ${artifact}`);
+    }
+    const actualHashes = Object.fromEntries(Object.entries(artifacts)
+        .filter(([, path]) => path)
+        .map(([key, path]) => [key, sha256(readFileSync(resolve(output, path)))]));
+    if (stableJson(result.artifact_sha256) !== stableJson(actualHashes)) {
+        fail(`resumable artifact content changed for pair ${pair.pair_index} ${cell.arm}`);
+    }
+    const resultPath = resolve(output, paths.at(-1));
+    let persisted;
+    try { persisted = JSON.parse(readFileSync(resultPath, 'utf8')); }
+    catch (error) { fail(`invalid resumable result artifact ${relative(output, resultPath)}: ${error.message}`); }
+    if (stableJson(persisted) !== stableJson(result)) {
+        fail(`resumable result index disagrees with ${relative(output, resultPath)}`);
+    }
+}
+
+export function validateExperimentProgress({ protocol, output, experiment, results }) {
+    const schedule = buildSchedule(protocol);
+    let cursor = 0;
+    let completedPairs = 0;
+    let terminalInvalidPair = null;
+    for (const pair of schedule) {
+        if (cursor === results.length) break;
+        const first = results.slice(cursor, cursor + 2);
+        if (first.length !== 2) fail(`resumable results split pair ${pair.pair_index}`);
+        first.forEach((result, index) => validatePersistedResult({
+            output,
+            experiment,
+            pair,
+            cell: pair.cells[index],
+            attempt: 1,
+            result,
+        }));
+        cursor += 2;
+        if (first.every((result) => result.valid)) {
+            completedPairs += 1;
+            continue;
+        }
+        const retry = results.slice(cursor, cursor + 2);
+        if (retry.length !== 2) fail(`resumable results split retry for pair ${pair.pair_index}`);
+        retry.forEach((result, index) => validatePersistedResult({
+            output,
+            experiment,
+            pair,
+            cell: pair.cells[index],
+            attempt: 2,
+            result,
+        }));
+        cursor += 2;
+        if (retry.every((result) => result.valid)) completedPairs += 1;
+        else terminalInvalidPair = pair.pair_index;
+        if (terminalInvalidPair !== null) break;
+    }
+    if (cursor !== results.length) {
+        fail('resumable results are not an exact completed prefix of the frozen schedule');
+    }
+    return {
+        completedPairs,
+        terminalInvalidPair,
+        complete: completedPairs === schedule.length,
+    };
 }
 
 function writeScoringArtifacts({ protocol, protocolPath, output, results }) {
@@ -1193,6 +1402,39 @@ function writeScoringArtifacts({ protocol, protocolPath, output, results }) {
     }, null, 2)}\n`);
 }
 
+function writeResults(output, results) {
+    privateWrite(
+        join(output, 'private', 'results.jsonl'),
+        results.length ? `${results.map((result) => JSON.stringify(result)).join('\n')}\n` : '',
+    );
+}
+
+function usageTotals(results) {
+    const totals = {};
+    for (const result of results) {
+        if (!result.usage || typeof result.usage !== 'object' || Array.isArray(result.usage)) continue;
+        for (const [key, value] of Object.entries(result.usage)) {
+            if (typeof value === 'number' && Number.isFinite(value)) totals[key] = (totals[key] ?? 0) + value;
+        }
+    }
+    return totals;
+}
+
+function writeExperimentSummary({ protocol, output, results, progress }) {
+    const latestValid = acceptedResults(protocol, results);
+    const summary = {
+        complete: progress.complete,
+        completed_pairs: progress.completedPairs,
+        total_pairs: buildSchedule(protocol).length,
+        remaining_pairs: buildSchedule(protocol).length - progress.completedPairs,
+        valid_cells: latestValid.size,
+        attempts: results.length,
+        invalid_attempts: results.filter((result) => !result.valid).length,
+    };
+    privateWrite(join(output, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`);
+    return summary;
+}
+
 function runExperiment({
     protocol,
     protocolPath,
@@ -1204,7 +1446,13 @@ function runExperiment({
     timeoutMs,
     dryRun,
     codexHome,
+    resume = false,
+    maxPairs = Number.POSITIVE_INFINITY,
 }) {
+    const activePairPath = join(output, 'private', 'active-pair.json');
+    if (existsSync(activePairPath)) {
+        fail(`previous batch stopped mid-pair; inspect its private artifacts before removing ${activePairPath}`);
+    }
     const reviewerHome = createReviewerHome({ codexHome, includeAuth: false, codexBin });
     const versionEnv = reviewerEnvironment({ reviewerHome, scratch: privateDirectory('cycle-review-version-') });
     let version;
@@ -1223,9 +1471,38 @@ function runExperiment({
         codex_version: version,
         schedule,
     };
-    privateWrite(join(output, 'private', 'experiment.json'), `${JSON.stringify(experiment, null, 2)}\n`);
-    const results = [];
-    for (const pair of schedule) {
+    const experimentPath = join(output, 'private', 'experiment.json');
+    const resultsPath = join(output, 'private', 'results.jsonl');
+    let results;
+    if (resume) {
+        if (!existsSync(experimentPath)) fail(`missing resumable experiment: ${experimentPath}`);
+        let persistedExperiment;
+        try { persistedExperiment = JSON.parse(readFileSync(experimentPath, 'utf8')); }
+        catch (error) { fail(`invalid resumable experiment: ${error.message}`); }
+        if (stableJson(persistedExperiment) !== stableJson(experiment)) {
+            fail('resumable experiment does not match the frozen protocol, model, effort, Codex version, or schedule');
+        }
+        results = readResults(resultsPath);
+    } else {
+        if (existsSync(experimentPath) || existsSync(resultsPath)) fail('new experiment output already contains state');
+        privateWrite(experimentPath, `${JSON.stringify(experiment, null, 2)}\n`);
+        results = [];
+        writeResults(output, results);
+    }
+    let progress = validateExperimentProgress({ protocol, output, experiment, results });
+    if (progress.terminalInvalidPair !== null) {
+        fail(`experiment is terminally incomplete at pair ${progress.terminalInvalidPair}`);
+    }
+    if (progress.complete) fail('experiment is already complete');
+    if (existsSync(join(output, 'scoring'))) fail('incomplete experiment unexpectedly contains scoring artifacts');
+    const beforeCount = results.length;
+    const invocationStarted = Date.now();
+    const selectedPairs = schedule.slice(progress.completedPairs, progress.completedPairs + maxPairs);
+    for (const pair of selectedPairs) {
+        privateWrite(activePairPath, `${JSON.stringify({
+            pair_index: pair.pair_index,
+            started_at: new Date().toISOString(),
+        }, null, 2)}\n`);
         let pairResults = pair.cells.map((cell) => executeCell({
             protocol,
             protocolPath,
@@ -1259,24 +1536,33 @@ function runExperiment({
                 codexHome,
             }));
             results.push(...pairResults);
-            if (pairResults.some((result) => !result.valid)) break;
         }
+        writeResults(output, results);
+        progress = validateExperimentProgress({ protocol, output, experiment, results });
+        rmSync(activePairPath, { force: true });
+        writeExperimentSummary({ protocol, output, results, progress });
+        if (progress.terminalInvalidPair !== null) break;
     }
-    privateWrite(
-        join(output, 'private', 'results.jsonl'),
-        `${results.map((result) => JSON.stringify(result)).join('\n')}\n`,
-    );
-    const latestValid = acceptedResults(protocol, results);
-    const complete = latestValid.size === 36;
-    privateWrite(join(output, 'summary.json'), `${JSON.stringify({
-        complete,
-        valid_cells: latestValid.size,
-        attempts: results.length,
-        invalid_attempts: results.filter((result) => !result.valid).length,
-    }, null, 2)}\n`);
-    if (!complete) fail(`experiment stopped with ${latestValid.size}/36 valid cells`);
-    writeScoringArtifacts({ protocol, protocolPath, output, results });
-    return results;
+    progress = validateExperimentProgress({ protocol, output, experiment, results });
+    const summary = writeExperimentSummary({ protocol, output, results, progress });
+    if (progress.terminalInvalidPair !== null) {
+        fail(`experiment stopped after the retry for pair ${progress.terminalInvalidPair} stayed invalid`);
+    }
+    if (progress.complete) writeScoringArtifacts({ protocol, protocolPath, output, results });
+    const invocationResults = results.slice(beforeCount);
+    return {
+        results,
+        receipt: {
+            pair_index: selectedPairs[0]?.pair_index ?? null,
+            calls: invocationResults.length,
+            invalid_attempts: invocationResults.filter((result) => !result.valid).length,
+            token_usage: usageTotals(invocationResults),
+            elapsed_ms: Date.now() - invocationStarted,
+            completed_pairs: summary.completed_pairs,
+            remaining_pairs: summary.remaining_pairs,
+            complete: summary.complete,
+        },
+    };
 }
 
 function runOracleCommands(workspace, commands) {
@@ -1451,8 +1737,11 @@ function usage() {
   node eval/review/run.mjs plan
   node eval/review/run.mjs fetch-cache --source <checkout> --allow-network
   node eval/review/run.mjs dry-run --output <new-directory>
+  node eval/review/run.mjs dry-run-batch --output <new-or-resumable-directory>
   node eval/review/run.mjs preflight --source <checkout> --output <new-directory> [--skip-oracles]
   node eval/review/run.mjs run --source <checkout> --output <new-directory>
+       --confirm-protocol-sha256 <sha256> [--codex-home <path>]
+  node eval/review/run.mjs run-batch --source <checkout> --output <new-or-resumable-directory>
        --confirm-protocol-sha256 <sha256> [--codex-home <path>]
 
 Options:
@@ -1508,8 +1797,14 @@ export function main(argv = process.argv.slice(2)) {
     }
     const timeoutMs = Number(values['timeout-ms'] ?? protocol.execution.timeout_ms);
     if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1) fail('--timeout-ms must be a positive integer');
+    const experimentCommands = ['dry-run', 'dry-run-batch', 'preflight', 'run', 'run-batch'];
+    if (!experimentCommands.includes(command)) fail(`unknown command: ${command}`);
     if (!values.output) fail(`${command} requires --output`);
-    const output = ensureNewOutput(values.output);
+    const batchCommand = command === 'dry-run-batch' || command === 'run-batch';
+    const prepared = batchCommand
+        ? prepareBatchOutput(values.output)
+        : { output: ensureNewOutput(values.output), resume: false };
+    const { output, resume } = prepared;
     if (command === 'dry-run') {
         runExperiment({
             protocol,
@@ -1522,6 +1817,24 @@ export function main(argv = process.argv.slice(2)) {
             dryRun: true,
         });
         return 0;
+    }
+    if (command === 'dry-run-batch') {
+        return withBatchLock(output, () => {
+            const result = runExperiment({
+                protocol,
+                protocolPath,
+                output,
+                codexBin: resolve(values['codex-bin'] ?? DEFAULT_FAKE_CODEX),
+                model: 'fake-review-model',
+                effort: protocol.execution.reasoning_effort,
+                timeoutMs,
+                dryRun: true,
+                resume,
+                maxPairs: protocol.schedule.pairs_per_batch,
+            });
+            console.log(JSON.stringify(result.receipt, null, 2));
+            return 0;
+        });
     }
     if (!values.source) fail(`${command} requires --source`);
     const source = verifySource(values.source, protocol);
@@ -1536,38 +1849,46 @@ export function main(argv = process.argv.slice(2)) {
         });
         return 0;
     }
-    if (command === 'run') {
+    if (command === 'run' || command === 'run-batch') {
         const expected = sha256(readFileSync(protocolPath));
         if (values['confirm-protocol-sha256'] !== expected) {
-            fail(`run requires --confirm-protocol-sha256 ${expected}`);
+            fail(`${command} requires --confirm-protocol-sha256 ${expected}`);
         }
         if (timeoutMs !== protocol.execution.timeout_ms) {
-            fail(`run timeout is frozen at ${protocol.execution.timeout_ms}ms`);
+            fail(`${command} timeout is frozen at ${protocol.execution.timeout_ms}ms`);
         }
-        if (values['skip-oracles']) fail('run cannot skip hidden-oracle preflight');
-        preflight({
-            protocol,
-            protocolPath,
-            source,
-            output,
-            codexBin: values['codex-bin'] ?? 'codex',
-            skipOracles: false,
-        });
-        runExperiment({
-            protocol,
-            protocolPath,
-            source,
-            output,
-            codexBin: values['codex-bin'] ?? 'codex',
-            model: protocol.execution.model,
-            effort: protocol.execution.reasoning_effort,
-            timeoutMs,
-            dryRun: false,
-            codexHome: values['codex-home'],
-        });
-        return 0;
+        if (values['skip-oracles']) fail(`${command} cannot skip hidden-oracle preflight`);
+        const execute = () => {
+            preflight({
+                protocol,
+                protocolPath,
+                source,
+                output,
+                codexBin: values['codex-bin'] ?? 'codex',
+                skipOracles: false,
+            });
+            const result = runExperiment({
+                protocol,
+                protocolPath,
+                source,
+                output,
+                codexBin: values['codex-bin'] ?? 'codex',
+                model: protocol.execution.model,
+                effort: protocol.execution.reasoning_effort,
+                timeoutMs,
+                dryRun: false,
+                codexHome: values['codex-home'],
+                resume,
+                maxPairs: command === 'run-batch'
+                    ? protocol.schedule.pairs_per_batch
+                    : Number.POSITIVE_INFINITY,
+            });
+            if (command === 'run-batch') console.log(JSON.stringify(result.receipt, null, 2));
+            return 0;
+        };
+        return command === 'run-batch' ? withBatchLock(output, execute) : execute();
     }
-    fail(`unknown command: ${command}`);
+    fail(`unhandled command: ${command}`);
 }
 
 function invokedDirectly() {

--- a/eval/review/score.schema.json
+++ b/eval/review/score.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["scorer_id", "scores"],
+  "properties": {
+    "scorer_id": { "type": "string", "minLength": 1 },
+    "scores": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["packet_id", "output_label", "targets", "independently_disproved"],
+        "properties": {
+          "packet_id": { "type": "string", "pattern": "^[a-f0-9]{16}$" },
+          "output_label": { "enum": ["A", "B"] },
+          "targets": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["target_label", "recall", "repair_direction", "regression_test"],
+              "properties": {
+                "target_label": { "type": "string", "pattern": "^T[1-9][0-9]*$" },
+                "recall": { "enum": ["caught", "partial", "missed", "not-applicable"] },
+                "repair_direction": { "type": "boolean" },
+                "regression_test": { "type": "boolean" }
+              }
+            }
+          },
+          "independently_disproved": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["finding_index", "reason", "evidence"],
+              "properties": {
+                "finding_index": { "type": "integer", "minimum": 0 },
+                "reason": { "type": "string", "minLength": 1 },
+                "evidence": { "type": "string", "minLength": 1 }
+              }
+            }
+          },
+          "notes": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/test/review-eval.test.mjs
+++ b/test/review-eval.test.mjs
@@ -1,0 +1,306 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+    lstatSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    readdirSync,
+    readlinkSync,
+    rmSync,
+    statSync,
+    writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, isAbsolute, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+    assertNoCredentialMaterial,
+    buildSchedule,
+    createReviewerHome,
+    loadProtocol,
+    reviewerConfig,
+    reviewerEnvironment,
+    sha256,
+} from '../eval/review/run.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const RUNNER = join(ROOT, 'eval', 'review', 'run.mjs');
+const PROTOCOL_PATH = join(ROOT, 'eval', 'review', 'protocol.json');
+
+function json(path) {
+    return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function permissionBits(path) {
+    return statSync(path).mode & 0o777;
+}
+
+function assertPrivateTree(path) {
+    assert.equal(permissionBits(path), 0o700, `${path} must be mode 0700`);
+    for (const entry of readdirSync(path, { withFileTypes: true })) {
+        const child = join(path, entry.name);
+        if (entry.isDirectory()) assertPrivateTree(child);
+        else assert.equal(permissionBits(child), 0o600, `${child} must be mode 0600`);
+    }
+}
+
+test('review protocol freezes the balanced study and local artifact hashes', () => {
+    const { protocol } = loadProtocol(PROTOCOL_PATH);
+    const schedule = buildSchedule(protocol);
+    assert.equal(schedule.length, 18);
+    assert.equal(schedule.flatMap((pair) => pair.cells).length, 36);
+    assert.equal(schedule.filter((pair) => pair.arms[0] === 'baseline').length, 9);
+    assert.equal(schedule.filter((pair) => pair.arms[0] === 'treatment').length, 9);
+    assert.equal(new Set(schedule.flatMap((pair) => pair.cells.map((cell) => cell.cell_id))).size, 36);
+    assert.equal(protocol.execution.timeout_ms, 900_000);
+    assert.equal(protocol.execution.fixture_commit_time, '2026-08-29T12:00:00Z');
+    assert.equal(protocol.execution.subagents, false);
+    assert.equal(protocol.execution.command_network, false);
+    assert.equal(protocol.scoring.composite_score, false);
+    assert.equal(protocol.scoring.scorers, 2);
+
+    const reviewRoot = join(ROOT, 'eval', 'review');
+    assert.equal(sha256(readFileSync(RUNNER)), protocol.artifact_lock.runner_sha256);
+    assert.equal(
+        sha256(readFileSync(join(reviewRoot, 'fake-codex.cjs'))),
+        protocol.artifact_lock.fake_reviewer_sha256,
+    );
+    assert.equal(
+        sha256(readFileSync(join(reviewRoot, protocol.census_path))),
+        protocol.artifact_lock.census_sha256,
+    );
+    assert.equal(
+        sha256(readFileSync(join(reviewRoot, protocol.prompt.common_path))),
+        protocol.artifact_lock.common_prompt_sha256,
+    );
+    assert.equal(
+        sha256(readFileSync(join(reviewRoot, protocol.prompt.output_schema_path))),
+        protocol.artifact_lock.output_schema_sha256,
+    );
+    assert.equal(
+        sha256(readFileSync(join(reviewRoot, protocol.scoring.schema_path))),
+        protocol.artifact_lock.score_schema_sha256,
+    );
+    for (const item of protocol.cases.filter((entry) => !entry.variant)) {
+        assert.equal(
+            sha256(readFileSync(join(reviewRoot, item.original_task_path))),
+            protocol.artifact_lock.cases[item.id].original_task_sha256,
+        );
+    }
+});
+
+test('reviewer profile exposes only explicit read roots and drops ambient credentials', () => {
+    const config = reviewerConfig('/usr/bin:/bin', ['/fixture', '/runtime/codex']);
+    assert.match(config, /":root" = "deny"/);
+    assert.match(config, /":minimal" = "read"/);
+    assert.match(config, /"\/fixture" = "read"/);
+    assert.match(config, /"\/runtime\/codex" = "read"/);
+    assert.match(config, /\[permissions\.review-fixture\.network\]\nenabled = false/);
+    assert.match(config, /\[shell_environment_policy\]\ninherit = "none"/);
+    assert.match(config, /multi_agent = false/);
+    assert.doesNotMatch(config, /workspace_roots/);
+
+    const env = reviewerEnvironment({
+        reviewerHome: '/private/reviewer-home',
+        scratch: '/private/reviewer-tmp',
+        cellId: 'cell',
+        arm: 'treatment',
+        caseId: 'case',
+        repetition: 2,
+        pairIndex: 3,
+        attempt: 1,
+    }, {
+        PATH: '/usr/bin:/bin',
+        LANG: 'C',
+        HOME: '/home/private',
+        GH_TOKEN: 'github-secret',
+        OPENAI_API_KEY: 'openai-secret',
+        CODEX_API_KEY: 'codex-secret',
+        NPM_TOKEN: 'npm-secret',
+    });
+    assert.equal(env.HOME, '/private/reviewer-home');
+    assert.equal(env.CODEX_HOME, '/private/reviewer-home');
+    assert.equal(env.TMPDIR, '/private/reviewer-tmp');
+    assert.equal(env.GH_TOKEN, undefined);
+    assert.equal(env.OPENAI_API_KEY, undefined);
+    assert.equal(env.CODEX_API_KEY, undefined);
+    assert.equal(env.NPM_TOKEN, undefined);
+    assert.equal(env.CYCLE_REVIEW_ATTEMPT, '1');
+});
+
+test('outer Codex authentication is symlinked outside the fixture and never copied', () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-review-auth-test-'));
+    let reviewerHome;
+    try {
+        const codexHome = join(scratch, 'codex-home');
+        const workspace = join(scratch, 'workspace');
+        mkdirSync(codexHome);
+        mkdirSync(workspace);
+        const auth = join(codexHome, 'auth.json');
+        const sentinel = 'credential-material-must-stay-outside-the-fixture';
+        writeFileSync(auth, `${sentinel}\n`, { mode: 0o600 });
+        reviewerHome = createReviewerHome({
+            codexHome,
+            includeAuth: true,
+            codexBin: join(ROOT, 'eval', 'review', 'fake-codex.cjs'),
+            workspace,
+        });
+        const authLink = join(reviewerHome, 'auth.json');
+        assert.ok(lstatSync(authLink).isSymbolicLink());
+        assert.equal(readlinkSync(authLink), auth);
+        assert.doesNotMatch(readFileSync(join(reviewerHome, 'config.toml'), 'utf8'), new RegExp(sentinel));
+        assert.doesNotMatch(readFileSync(join(reviewerHome, 'config.toml'), 'utf8'), /auth\.json/);
+        assert.equal(readFileSync(auth, 'utf8'), `${sentinel}\n`);
+    } finally {
+        if (reviewerHome) rmSync(reviewerHome, { recursive: true, force: true });
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
+test('captured output fails closed on authentication material without reporting the secret', () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-review-auth-output-test-'));
+    try {
+        const auth = join(scratch, 'auth.json');
+        const secret = 'credential-material-with-enough-entropy-123456789';
+        writeFileSync(auth, `${JSON.stringify({ tokens: { access_token: secret } })}\n`, { mode: 0o600 });
+        assert.doesNotThrow(() => assertNoCredentialMaterial(['ordinary reviewer output'], auth));
+        assert.throws(
+            () => assertNoCredentialMaterial([`accidental echo: ${secret}`], auth),
+            (error) => {
+                assert.match(error.message, /contained authentication material/);
+                assert.doesNotMatch(error.message, new RegExp(secret));
+                return true;
+            },
+        );
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
+test('fake reviewer exercises paired retry, guidance evidence, normalization, and artifacts', {
+    timeout: 120_000,
+}, () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-review-dry-test-'));
+    try {
+        const output = join(scratch, 'output');
+        execFileSync(process.execPath, [RUNNER, 'dry-run', '--output', output], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            stdio: 'pipe',
+        });
+
+        assert.deepEqual(json(join(output, 'summary.json')), {
+            complete: true,
+            valid_cells: 36,
+            attempts: 38,
+            invalid_attempts: 1,
+        });
+        const results = readFileSync(join(output, 'private', 'results.jsonl'), 'utf8')
+            .trim().split('\n').map(JSON.parse);
+        assert.equal(results.length, 38);
+        const invalid = results.filter((result) => !result.valid);
+        assert.equal(invalid.length, 1);
+        assert.deepEqual(invalid[0].invalid_reasons, ['final response is not JSON']);
+        const retriedPair = results.filter((result) => result.attempt === 2);
+        assert.equal(retriedPair.length, 2);
+        assert.equal(new Set(retriedPair.map((result) => result.case_id)).size, 1);
+        assert.equal(new Set(retriedPair.map((result) => result.repetition)).size, 1);
+        assert.deepEqual(new Set(retriedPair.map((result) => result.arm)), new Set(['baseline', 'treatment']));
+        assert.ok(retriedPair.every((result) => result.valid));
+
+        const valid = results.filter((result) => result.valid);
+        assert.ok(valid.filter((result) => result.arm === 'treatment')
+            .every((result) => result.treatment_guidance_read));
+        assert.ok(valid.filter((result) => result.arm === 'baseline')
+            .every((result) => !result.treatment_guidance_read));
+        const fixtureCommits = new Map();
+        for (const result of results) {
+            const key = `${result.case_id}:${result.arm}`;
+            const commits = fixtureCommits.get(key) ?? new Set();
+            commits.add(result.fixture.commit);
+            fixtureCommits.set(key, commits);
+        }
+        assert.ok([...fixtureCommits.values()].every((commits) => commits.size === 1));
+        for (const result of results) {
+            for (const path of Object.values(result.artifacts).filter(Boolean)) {
+                assert.equal(isAbsolute(path), false);
+                assert.ok(readFileSync(join(output, path)).length >= 0);
+            }
+        }
+
+        const scoringText = readFileSync(join(output, 'scoring', 'scoring-input.json'), 'utf8');
+        assert.doesNotMatch(scoringText, /"(?:arm|case_id|cell_id)"/);
+        assert.doesNotMatch(scoringText, /"(?:baseline|treatment)"/);
+        assert.doesNotMatch(scoringText, /command_execution|tool trace/iu);
+        const scoring = JSON.parse(scoringText);
+        assert.equal(scoring.fixtures.length, 6);
+        assert.equal(scoring.packets.length, 18);
+        assert.equal(scoring.packets.flatMap((packet) => packet.reviews).length, 36);
+        assert.ok(scoring.packets.every((packet) =>
+            packet.reviews.map((review) => review.output_label).sort().join('') === 'AB'));
+
+        const mapping = json(join(output, 'private', 'blinding-map.json'));
+        assert.equal(mapping.length, 36);
+        assert.equal(mapping.filter((entry) => entry.attempt === 2).length, 2);
+        const measures = readFileSync(join(output, 'private', 'measures.jsonl'), 'utf8')
+            .trim().split('\n').map(JSON.parse);
+        assert.equal(measures.length, 36);
+        const manifest = json(join(output, 'scoring', 'manifest.json'));
+        assert.equal(manifest.packet_count, 18);
+        assert.equal(manifest.normalized_review_count, 36);
+        assert.equal(manifest.scoring_input_sha256, sha256(Buffer.from(scoringText)));
+        assert.equal(
+            manifest.score_schema_sha256,
+            sha256(readFileSync(join(output, 'scoring', 'score.schema.json'))),
+        );
+        assertPrivateTree(output);
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
+test('a retry cannot combine valid cells from different attempts', { timeout: 120_000 }, () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-review-split-retry-test-'));
+    try {
+        const output = join(scratch, 'output');
+        assert.throws(() => execFileSync(process.execPath, [RUNNER, 'dry-run', '--output', output], {
+            cwd: ROOT,
+            env: { ...process.env, CYCLE_REVIEW_FAKE_MODE: 'split-retry' },
+            encoding: 'utf8',
+            stdio: 'pipe',
+        }));
+        assert.deepEqual(json(join(output, 'summary.json')), {
+            complete: false,
+            valid_cells: 0,
+            attempts: 4,
+            invalid_attempts: 2,
+        });
+        assert.equal(statSync(join(output, 'scoring'), { throwIfNoEntry: false }), undefined);
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
+test('mentioning guidance paths without returning their contents is invalid', { timeout: 120_000 }, () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-review-guidance-proof-test-'));
+    try {
+        const output = join(scratch, 'output');
+        assert.throws(() => execFileSync(process.execPath, [RUNNER, 'dry-run', '--output', output], {
+            cwd: ROOT,
+            env: { ...process.env, CYCLE_REVIEW_FAKE_MODE: 'guidance-mention-only' },
+            encoding: 'utf8',
+            stdio: 'pipe',
+        }));
+        const results = readFileSync(join(output, 'private', 'results.jsonl'), 'utf8')
+            .trim().split('\n').map(JSON.parse);
+        const invalidTreatment = results.filter((result) => result.arm === 'treatment');
+        assert.equal(invalidTreatment.length, 2);
+        assert.ok(invalidTreatment.every((result) => result.invalid_reasons.includes(
+            'treatment did not read pinned review guidance',
+        )));
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});

--- a/test/review-eval.test.mjs
+++ b/test/review-eval.test.mjs
@@ -10,6 +10,7 @@ import {
     readlinkSync,
     rmSync,
     statSync,
+    symlinkSync,
     writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -58,6 +59,8 @@ test('review protocol freezes the balanced study and local artifact hashes', () 
     assert.equal(protocol.execution.fixture_commit_time, '2026-08-29T12:00:00Z');
     assert.equal(protocol.execution.subagents, false);
     assert.equal(protocol.execution.command_network, false);
+    assert.equal(protocol.schedule.pairs_per_batch, 1);
+    assert.equal(protocol.schedule.batch_unit, 'matched_pair');
     assert.equal(protocol.scoring.composite_score, false);
     assert.equal(protocol.scoring.scorers, 2);
 
@@ -193,6 +196,9 @@ test('fake reviewer exercises paired retry, guidance evidence, normalization, an
 
         assert.deepEqual(json(join(output, 'summary.json')), {
             complete: true,
+            completed_pairs: 18,
+            total_pairs: 18,
+            remaining_pairs: 0,
             valid_cells: 36,
             attempts: 38,
             invalid_attempts: 1,
@@ -273,11 +279,174 @@ test('a retry cannot combine valid cells from different attempts', { timeout: 12
         }));
         assert.deepEqual(json(join(output, 'summary.json')), {
             complete: false,
+            completed_pairs: 0,
+            total_pairs: 18,
+            remaining_pairs: 18,
             valid_cells: 0,
             attempts: 4,
             invalid_attempts: 2,
         });
         assert.equal(statSync(join(output, 'scoring'), { throwIfNoEntry: false }), undefined);
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
+test('fake reviewer resumes one complete matched pair per quota-monitored batch', {
+    timeout: 120_000,
+}, () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-review-batch-test-'));
+    try {
+        const output = join(scratch, 'output');
+        for (let batch = 1; batch <= 18; batch += 1) {
+            const receipt = JSON.parse(execFileSync(process.execPath, [
+                RUNNER,
+                'dry-run-batch',
+                '--output',
+                output,
+            ], {
+                cwd: ROOT,
+                encoding: 'utf8',
+                stdio: 'pipe',
+            }));
+            assert.equal(receipt.pair_index, batch);
+            assert.equal(receipt.calls, batch === 1 ? 4 : 2);
+            assert.equal(receipt.invalid_attempts, batch === 1 ? 1 : 0);
+            assert.equal(receipt.token_usage.input_tokens, receipt.calls * 100);
+            assert.equal(receipt.token_usage.cached_input_tokens, receipt.calls * 25);
+            assert.equal(receipt.token_usage.output_tokens, receipt.calls * 20);
+            assert.equal(receipt.token_usage.reasoning_output_tokens, receipt.calls * 5);
+            assert.equal(receipt.completed_pairs, batch);
+            assert.equal(receipt.remaining_pairs, 18 - batch);
+            assert.equal(receipt.complete, batch === 18);
+            if (batch < 18) assert.equal(statSync(join(output, 'scoring'), { throwIfNoEntry: false }), undefined);
+        }
+        assert.deepEqual(json(join(output, 'summary.json')), {
+            complete: true,
+            completed_pairs: 18,
+            total_pairs: 18,
+            remaining_pairs: 0,
+            valid_cells: 36,
+            attempts: 38,
+            invalid_attempts: 1,
+        });
+        assert.equal(json(join(output, 'scoring', 'manifest.json')).normalized_review_count, 36);
+        assertPrivateTree(output);
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
+test('batched resume rejects changed checkpoint state before another reviewer call', {
+    timeout: 120_000,
+}, () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-review-batch-tamper-test-'));
+    try {
+        const output = join(scratch, 'output');
+        execFileSync(process.execPath, [RUNNER, 'dry-run-batch', '--output', output], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            stdio: 'pipe',
+        });
+        const runsPath = join(output, 'private', 'runs');
+        const runCount = readdirSync(runsPath).length;
+        const activePairPath = join(output, 'private', 'active-pair.json');
+        writeFileSync(activePairPath, '{}\n', { mode: 0o600 });
+        assert.throws(() => execFileSync(process.execPath, [
+            RUNNER,
+            'dry-run-batch',
+            '--output',
+            output,
+        ], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            stdio: 'pipe',
+        }));
+        assert.equal(readdirSync(runsPath).length, runCount);
+        rmSync(activePairPath);
+
+        const resultsPath = join(output, 'private', 'results.jsonl');
+        const results = readFileSync(resultsPath, 'utf8').trim().split('\n').map(JSON.parse);
+        results[0].pair_index = 99;
+        writeFileSync(resultsPath, `${results.map((result) => JSON.stringify(result)).join('\n')}\n`);
+
+        assert.throws(() => execFileSync(process.execPath, [
+            RUNNER,
+            'dry-run-batch',
+            '--output',
+            output,
+        ], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            stdio: 'pipe',
+        }));
+        assert.equal(readdirSync(runsPath).length, runCount);
+
+        results[0].pair_index = 1;
+        writeFileSync(resultsPath, `${results.map((result) => JSON.stringify(result)).join('\n')}\n`);
+        const candidatePath = join(output, results[0].artifacts.candidate_diff);
+        writeFileSync(candidatePath, `${readFileSync(candidatePath, 'utf8')}changed after checkpoint\n`);
+        assert.throws(() => execFileSync(process.execPath, [
+            RUNNER,
+            'dry-run-batch',
+            '--output',
+            output,
+        ], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            stdio: 'pipe',
+        }));
+        assert.equal(readdirSync(runsPath).length, runCount);
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
+test('batched output rejects symlinked state before writing through it', () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-review-batch-symlink-test-'));
+    try {
+        const output = join(scratch, 'output');
+        const target = join(scratch, 'target');
+        mkdirSync(output, { mode: 0o700 });
+        mkdirSync(target, { mode: 0o700 });
+        symlinkSync(target, join(output, 'private'));
+        assert.throws(() => execFileSync(process.execPath, [
+            RUNNER,
+            'dry-run-batch',
+            '--output',
+            output,
+        ], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            stdio: 'pipe',
+        }));
+        assert.deepEqual(readdirSync(target), []);
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
+test('batched execution can restart from preflight-only state before the first checkpoint', {
+    timeout: 120_000,
+}, () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-review-batch-fresh-restart-test-'));
+    try {
+        const output = join(scratch, 'output');
+        mkdirSync(join(output, 'private'), { recursive: true, mode: 0o700 });
+        writeFileSync(join(output, 'preflight.json'), '{}\n', { mode: 0o600 });
+        const receipt = JSON.parse(execFileSync(process.execPath, [
+            RUNNER,
+            'dry-run-batch',
+            '--output',
+            output,
+        ], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            stdio: 'pipe',
+        }));
+        assert.equal(receipt.pair_index, 1);
+        assert.equal(receipt.calls, 4);
+        assert.equal(json(join(output, 'summary.json')).completed_pairs, 1);
     } finally {
         rmSync(scratch, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- Freeze a preregistered, illustrative Release Relay review study with four flawed cases, two target-clean controls, 18 matched pairs, and blinded independent scoring.
- Reconstruct deterministic one-commit fixtures with no future history, run hidden oracles offline, and block scored runs unless filesystem and network isolation pass.
- Add quota-monitored `run-batch` and `dry-run-batch` commands that complete exactly one matched pair per invocation, rerun full preflight before each scored batch, and print a quota receipt.
- Validate resumable checkpoints against the frozen protocol bytes, model, reasoning effort, Codex version, schedule, artifact paths, artifact hashes, and crash markers before another reviewer call.

## Review findings actioned

- Bind accepted baseline and treatment cells to the same retry attempt so split-invalid retries cannot be scored.
- Enforce mode `0700` output trees and mode `0600` artifacts; move schedules and raw results under private storage.
- Require successful, content-backed reads of both treatment guidance files.
- Fail closed before persistence if reviewer output contains authentication material.
- Freeze Git fixture identity independently of host time, hooks, templates, signing, and global config.
- Allow safe restart from preflight-only batch state while still rejecting stale checkpoints, active-pair markers, symlinked state, and tampered private artifacts.

## Verification

- `node --test test/review-eval.test.mjs`
- `node bin/cycle.mjs lint`
- `npm test` — 315/315
- `node bin/cycle.mjs check`
- model-free preflight remains the scored-run gate: artifact lock, six fixtures, auth-home/filesystem/network isolation, four flaw/repair oracle chains, and two controls pass before any metered model call
- inline correctness plus security review of the batching/resume/auth surfaces — no P0/P1/P2 findings

Closes #127

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)
