### PR TITLE
fix(eval): preserve batch failure receipts

### DIFF
--- a/eval/review/protocol.json
+++ b/eval/review/protocol.json
@@ -212,7 +212,7 @@
     }
   ],
   "artifact_lock": {
-    "runner_sha256": "75a1174e31bae8ecfe0d76dcb98a8bbae31451b2d5b4ceb4654e801c203e93c5",
+    "runner_sha256": "46adf70d6dcce35dbefa51b8487cf55d10ff7525a8f4327e3e728c1f58c0a61d",
     "fake_reviewer_sha256": "ab8ae64aa52dec26608af0196711d89fb7cae0134df53e9b86c8f71d6b9ccc06",
     "census_sha256": "1eb2272dfdb5110663f277cf70d661dbbc487e73f0b71d6f3e9e8b3b7f20e603",
     "common_prompt_sha256": "98bae734100e4316267052c0f466f8f75658be1ef4702edf1d6b1fc31076353e",

--- a/eval/review/run.mjs
+++ b/eval/review/run.mjs
@@ -1545,23 +1545,25 @@ function runExperiment({
     }
     progress = validateExperimentProgress({ protocol, output, experiment, results });
     const summary = writeExperimentSummary({ protocol, output, results, progress });
-    if (progress.terminalInvalidPair !== null) {
+    const invocationResults = results.slice(beforeCount);
+    const receipt = {
+        pair_index: selectedPairs[0]?.pair_index ?? null,
+        calls: invocationResults.length,
+        invalid_attempts: invocationResults.filter((result) => !result.valid).length,
+        token_usage: usageTotals(invocationResults),
+        elapsed_ms: Date.now() - invocationStarted,
+        completed_pairs: summary.completed_pairs,
+        remaining_pairs: summary.remaining_pairs,
+        complete: summary.complete,
+    };
+    if (progress.terminalInvalidPair !== null && !Number.isFinite(maxPairs)) {
         fail(`experiment stopped after the retry for pair ${progress.terminalInvalidPair} stayed invalid`);
     }
     if (progress.complete) writeScoringArtifacts({ protocol, protocolPath, output, results });
-    const invocationResults = results.slice(beforeCount);
     return {
         results,
-        receipt: {
-            pair_index: selectedPairs[0]?.pair_index ?? null,
-            calls: invocationResults.length,
-            invalid_attempts: invocationResults.filter((result) => !result.valid).length,
-            token_usage: usageTotals(invocationResults),
-            elapsed_ms: Date.now() - invocationStarted,
-            completed_pairs: summary.completed_pairs,
-            remaining_pairs: summary.remaining_pairs,
-            complete: summary.complete,
-        },
+        receipt,
+        terminalInvalidPair: progress.terminalInvalidPair,
     };
 }
 
@@ -1833,6 +1835,9 @@ export function main(argv = process.argv.slice(2)) {
                 maxPairs: protocol.schedule.pairs_per_batch,
             });
             console.log(JSON.stringify(result.receipt, null, 2));
+            if (result.terminalInvalidPair !== null) {
+                fail(`experiment stopped after the retry for pair ${result.terminalInvalidPair} stayed invalid`);
+            }
             return 0;
         });
     }
@@ -1883,7 +1888,12 @@ export function main(argv = process.argv.slice(2)) {
                     ? protocol.schedule.pairs_per_batch
                     : Number.POSITIVE_INFINITY,
             });
-            if (command === 'run-batch') console.log(JSON.stringify(result.receipt, null, 2));
+            if (command === 'run-batch') {
+                console.log(JSON.stringify(result.receipt, null, 2));
+                if (result.terminalInvalidPair !== null) {
+                    fail(`experiment stopped after the retry for pair ${result.terminalInvalidPair} stayed invalid`);
+                }
+            }
             return 0;
         };
         return command === 'run-batch' ? withBatchLock(output, execute) : execute();

--- a/test/review-eval.test.mjs
+++ b/test/review-eval.test.mjs
@@ -426,6 +426,71 @@ test('batched output rejects symlinked state before writing through it', () => {
     }
 });
 
+test('an early zero-call batch failure can retry from the same output', { timeout: 120_000 }, () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-review-batch-early-failure-test-'));
+    try {
+        const output = join(scratch, 'output');
+        assert.throws(() => execFileSync(process.execPath, [
+            RUNNER,
+            'dry-run-batch',
+            '--output',
+            output,
+            '--codex-bin',
+            join(scratch, 'missing-codex'),
+        ], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            stdio: 'pipe',
+        }));
+        assert.deepEqual(readdirSync(join(output, 'private')), []);
+        const receipt = JSON.parse(execFileSync(process.execPath, [
+            RUNNER,
+            'dry-run-batch',
+            '--output',
+            output,
+        ], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            stdio: 'pipe',
+        }));
+        assert.equal(receipt.pair_index, 1);
+        assert.equal(receipt.calls, 4);
+        assert.equal(receipt.completed_pairs, 1);
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
+test('a terminally invalid batch still reports consumed calls and tokens', { timeout: 120_000 }, () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-review-batch-invalid-receipt-test-'));
+    try {
+        const output = join(scratch, 'output');
+        let failure;
+        try {
+            execFileSync(process.execPath, [RUNNER, 'dry-run-batch', '--output', output], {
+                cwd: ROOT,
+                env: { ...process.env, CYCLE_REVIEW_FAKE_MODE: 'split-retry' },
+                encoding: 'utf8',
+                stdio: 'pipe',
+            });
+        } catch (error) {
+            failure = error;
+        }
+        assert.ok(failure);
+        const receipt = JSON.parse(failure.stdout);
+        assert.equal(receipt.pair_index, 1);
+        assert.equal(receipt.calls, 4);
+        assert.equal(receipt.invalid_attempts, 2);
+        assert.equal(receipt.token_usage.input_tokens, 400);
+        assert.equal(receipt.completed_pairs, 0);
+        assert.equal(receipt.remaining_pairs, 18);
+        assert.equal(receipt.complete, false);
+        assert.equal(statSync(join(output, 'scoring'), { throwIfNoEntry: false }), undefined);
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
 test('batched execution can restart from preflight-only state before the first checkpoint', {
     timeout: 120_000,
 }, () => {


### PR DESCRIPTION
## Summary

- Treat an output as resumable only when both frozen checkpoint files exist, so a zero-call startup or preflight failure can safely retry in place.
- Keep partial/stale checkpoint state fail-closed.
- Emit calls, invalid attempts, token usage, elapsed time, and remaining pairs before a terminally invalid matched pair exits nonzero.

## Review findings actioned

- P1: fixed pre-checkpoint directory state being misclassified as a resume.
- P2: fixed consumed quota being hidden when the single allowed paired retry remained invalid.
- Security review remains clean: no auth material enters checkpoint state or receipts, and terminal-invalid output remains unscored.

## Verification

- `node --test test/review-eval.test.mjs` — 13/13
- `npm test` — 317/317
- `node bin/cycle.mjs lint`
- `node bin/cycle.mjs check`

Closes #127

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)