### PR TITLE
fix(eval): preflight strict reviewer config

### DIFF
--- a/eval/review/fake-codex.cjs
+++ b/eval/review/fake-codex.cjs
@@ -10,6 +10,28 @@ if (args[0] === '--version') {
     process.exit(0);
 }
 
+if (args[0] === 'app-server') {
+    if (!args.includes('--strict-config') || !args.includes('--listen') || !args.includes('off')) {
+        console.error('fake reviewer expected strict app-server no-transport config probe');
+        process.exit(2);
+    }
+    const reviewerHome = process.env.CODEX_HOME;
+    if (!reviewerHome || existsSync(join(reviewerHome, 'auth.json'))
+        || process.env.OPENAI_API_KEY || process.env.CODEX_API_KEY) {
+        console.error('fake reviewer config probe received authentication');
+        process.exit(2);
+    }
+    const config = readFileSync(join(reviewerHome, 'config.toml'), 'utf8');
+    const features = config.match(/\[features\]\n([\s\S]*?)(?:\n\[|$)/)?.[1] ?? '';
+    if (/\[tools\]\n[\s\S]*?view_image\s*=/.test(config)
+        || !/^view_image = false$/m.test(features)) {
+        console.error('unknown configuration field `tools.view_image`');
+        process.exit(1);
+    }
+    console.error('Error: no transport configured; use --listen or enable remote control');
+    process.exit(1);
+}
+
 if (args[0] !== 'exec') {
     console.error('fake reviewer expected codex exec');
     process.exit(2);

--- a/eval/review/protocol.json
+++ b/eval/review/protocol.json
@@ -2,6 +2,26 @@
   "version": 1,
   "study_id": "release-relay-review-v1",
   "claim": "Pre-existing repository-specific review guidance helps a single model identify consequential edge cases and produce more actionable review evidence than a strong generic review prompt.",
+  "revision": {
+    "number": 2,
+    "prior_protocol_sha256": "fda4e27bd8186dad607e4c5f78a498f4e4096beed84447b866a3c82827a8b87a",
+    "prior_runner_sha256": "46adf70d6dcce35dbefa51b8487cf55d10ff7525a8f4327e3e728c1f58c0a61d",
+    "reason": "Before any scored model call, Codex CLI 0.150.1 rejected the frozen strict reviewer configuration. Revision 2 preserves the image-tool restriction in the supported feature namespace and adds a credential-free, no-transport strict-config preflight probe.",
+    "preserved_invalid_attempt": {
+      "issue": 128,
+      "results_sha256": "88139d34b4852acad61270bc05391640014bd1e9468366be116a190d9bfd4412",
+      "summary_sha256": "b34ad05184e808e247613fa17683054096706954262cfd076c573d32fd8f9565",
+      "scored_model_calls": 0
+    },
+    "unchanged": [
+      "claim",
+      "cases",
+      "schedule",
+      "model",
+      "scoring",
+      "invalidation"
+    ]
+  },
   "census_path": "CENSUS.md",
   "source": {
     "repository": "https://github.com/brndnsh-labs/release-relay.git",
@@ -212,8 +232,8 @@
     }
   ],
   "artifact_lock": {
-    "runner_sha256": "46adf70d6dcce35dbefa51b8487cf55d10ff7525a8f4327e3e728c1f58c0a61d",
-    "fake_reviewer_sha256": "ab8ae64aa52dec26608af0196711d89fb7cae0134df53e9b86c8f71d6b9ccc06",
+    "runner_sha256": "1084a8a10d75bbeeb70cf2c932c97d6a6bc086aec6f274b33a06d7e4cfdaa084",
+    "fake_reviewer_sha256": "d9ce0ea2fc187ec9d5bb0a72524dfccfa77e54dcb01a1640ad5b83c35b773234",
     "census_sha256": "1eb2272dfdb5110663f277cf70d661dbbc487e73f0b71d6f3e9e8b3b7f20e603",
     "common_prompt_sha256": "98bae734100e4316267052c0f466f8f75658be1ef4702edf1d6b1fc31076353e",
     "output_schema_sha256": "8e3a76201d5a942e80a62245f6bb48bac06b97f6a9a55209eef1a7aaf96fee5d",

--- a/eval/review/run.mjs
+++ b/eval/review/run.mjs
@@ -112,6 +112,22 @@ export function validateProtocol(protocol, { requireLock = true } = {}) {
         || !isNonEmptyString(protocol.census_path)) {
         fail('review protocol requires version 1, study_id, claim, and census_path');
     }
+    const revision = protocol.revision;
+    if (!revision || revision.number !== 2
+        || revision.prior_protocol_sha256 !== 'fda4e27bd8186dad607e4c5f78a498f4e4096beed84447b866a3c82827a8b87a'
+        || revision.prior_runner_sha256 !== '46adf70d6dcce35dbefa51b8487cf55d10ff7525a8f4327e3e728c1f58c0a61d'
+        || !isNonEmptyString(revision.reason)
+        || revision.preserved_invalid_attempt?.issue !== 128
+        || revision.preserved_invalid_attempt?.results_sha256
+            !== '88139d34b4852acad61270bc05391640014bd1e9468366be116a190d9bfd4412'
+        || revision.preserved_invalid_attempt?.summary_sha256
+            !== 'b34ad05184e808e247613fa17683054096706954262cfd076c573d32fd8f9565'
+        || revision.preserved_invalid_attempt?.scored_model_calls !== 0
+        || stableJson(revision.unchanged) !== stableJson([
+            'claim', 'cases', 'schedule', 'model', 'scoring', 'invalidation',
+        ])) {
+        fail('review protocol is missing the frozen revision 2 compatibility record');
+    }
     if (!protocol.source || !isNonEmptyString(protocol.source.repository)
         || !/^[0-9a-f]{40}$/.test(protocol.source.review_guidance_commit)
         || !Array.isArray(protocol.source.review_guidance_paths)
@@ -564,8 +580,6 @@ multi_agent = false
 network_proxy = false
 shell_snapshot = false
 skill_mcp_dependency_install = false
-
-[tools]
 view_image = false
 
 [permissions.review-fixture.filesystem]
@@ -857,6 +871,50 @@ function codexVersion(codexBin, env) {
     const result = run(codexBin, ['--version'], { env, allowFailure: true });
     if (result.status !== 0) fail(`cannot run ${codexBin} --version`);
     return result.stdout.trim();
+}
+
+export function runStrictConfigProbe({ codexBin, reviewerHome, workspace, scratch }) {
+    if (existsSync(join(reviewerHome, 'auth.json'))) {
+        fail('strict reviewer-config probe must not receive authentication');
+    }
+    const env = reviewerEnvironment({ reviewerHome, scratch });
+    const result = run(codexBin, [
+        'app-server', '--strict-config', '--listen', 'off',
+    ], {
+        cwd: workspace,
+        env,
+        timeout: 30_000,
+        allowFailure: true,
+    });
+    const expectedDiagnostic = 'Error: no transport configured; use --listen or enable remote control';
+    const expectedNoTransport = result.status === 1
+        && (result.stderr ?? '').trim() === expectedDiagnostic
+        && !(result.stdout ?? '').trim();
+    if (!expectedNoTransport) {
+        const diagnostic = result.error?.message || result.stderr || result.stdout || '';
+        fail(`Codex strict reviewer-config probe failed (${result.status})\n${diagnostic}`.trimEnd());
+    }
+    return {
+        strict_config: 'pass',
+        credentials: 'absent',
+        model_calls: 0,
+    };
+}
+
+export function probeReviewerConfig(codexBin = 'codex') {
+    const root = privateDirectory('cycle-review-config-probe-');
+    const workspace = join(root, 'workspace');
+    const scratch = join(root, 'tmp');
+    let reviewerHome;
+    try {
+        privateMkdir(workspace);
+        privateMkdir(scratch);
+        reviewerHome = createReviewerHome({ includeAuth: false, codexBin, workspace });
+        return runStrictConfigProbe({ codexBin, reviewerHome, workspace, scratch });
+    } finally {
+        if (reviewerHome) rmSync(reviewerHome, { recursive: true, force: true });
+        rmSync(root, { recursive: true, force: true });
+    }
 }
 
 function ensureNewOutput(path) {
@@ -1694,6 +1752,7 @@ export function probeIsolation(codexBin = 'codex') {
 
 function preflight({ protocol, protocolPath, source, output, codexBin, skipOracles }) {
     assertArtifactLock(protocol, protocolPath, source);
+    const reviewerConfigProbe = probeReviewerConfig(codexBin);
     const fixtures = [];
     for (const item of protocol.cases) {
         const root = privateDirectory(`cycle-review-preflight-${item.id}-`);
@@ -1724,6 +1783,7 @@ function preflight({ protocol, protocolPath, source, output, codexBin, skipOracl
         study_id: protocol.study_id,
         protocol_sha256: sha256(readFileSync(protocolPath)),
         artifact_lock: 'pass',
+        reviewer_config: reviewerConfigProbe,
         fixtures,
         isolation,
         oracles,

--- a/test/review-eval.test.mjs
+++ b/test/review-eval.test.mjs
@@ -21,8 +21,10 @@ import {
     buildSchedule,
     createReviewerHome,
     loadProtocol,
+    probeReviewerConfig,
     reviewerConfig,
     reviewerEnvironment,
+    runStrictConfigProbe,
     sha256,
 } from '../eval/review/run.mjs';
 
@@ -36,6 +38,13 @@ function json(path) {
 
 function permissionBits(path) {
     return statSync(path).mode & 0o777;
+}
+
+function reviewerProbeTempEntries() {
+    return readdirSync(tmpdir()).filter((entry) => [
+        'cycle-review-config-probe-',
+        'cycle-review-codex-home-',
+    ].some((prefix) => entry.startsWith(prefix))).sort();
 }
 
 function assertPrivateTree(path) {
@@ -63,6 +72,11 @@ test('review protocol freezes the balanced study and local artifact hashes', () 
     assert.equal(protocol.schedule.batch_unit, 'matched_pair');
     assert.equal(protocol.scoring.composite_score, false);
     assert.equal(protocol.scoring.scorers, 2);
+    assert.equal(protocol.revision.number, 2);
+    assert.equal(protocol.revision.preserved_invalid_attempt.scored_model_calls, 0);
+    assert.deepEqual(protocol.revision.unchanged, [
+        'claim', 'cases', 'schedule', 'model', 'scoring', 'invalidation',
+    ]);
 
     const reviewRoot = join(ROOT, 'eval', 'review');
     assert.equal(sha256(readFileSync(RUNNER)), protocol.artifact_lock.runner_sha256);
@@ -103,6 +117,9 @@ test('reviewer profile exposes only explicit read roots and drops ambient creden
     assert.match(config, /\[permissions\.review-fixture\.network\]\nenabled = false/);
     assert.match(config, /\[shell_environment_policy\]\ninherit = "none"/);
     assert.match(config, /multi_agent = false/);
+    const featureSection = config.match(/\[features\]\n([\s\S]*?)(?:\n\[|$)/)?.[1] ?? '';
+    assert.match(featureSection, /^view_image = false$/m);
+    assert.doesNotMatch(config, /\[tools\]/);
     assert.doesNotMatch(config, /workspace_roots/);
 
     const env = reviewerEnvironment({
@@ -131,6 +148,48 @@ test('reviewer profile exposes only explicit read roots and drops ambient creden
     assert.equal(env.CODEX_API_KEY, undefined);
     assert.equal(env.NPM_TOKEN, undefined);
     assert.equal(env.CYCLE_REVIEW_ATTEMPT, '1');
+});
+
+test('strict reviewer-config preflight is credential-free and rejects the obsolete field', () => {
+    const fakeCodex = join(ROOT, 'eval', 'review', 'fake-codex.cjs');
+    const tempEntriesBefore = reviewerProbeTempEntries();
+    assert.deepEqual(probeReviewerConfig(fakeCodex), {
+        strict_config: 'pass',
+        credentials: 'absent',
+        model_calls: 0,
+    });
+    assert.deepEqual(reviewerProbeTempEntries(), tempEntriesBefore);
+
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-review-config-probe-test-'));
+    try {
+        const reviewerHome = join(scratch, 'home');
+        const workspace = join(scratch, 'workspace');
+        const reviewerScratch = join(scratch, 'tmp');
+        mkdirSync(reviewerHome);
+        mkdirSync(workspace);
+        mkdirSync(reviewerScratch);
+        writeFileSync(join(reviewerHome, 'config.toml'), '[tools]\nview_image = false\n');
+        assert.throws(
+            () => runStrictConfigProbe({
+                codexBin: fakeCodex,
+                reviewerHome,
+                workspace,
+                scratch: reviewerScratch,
+            }),
+            /strict reviewer-config probe failed/,
+        );
+        assert.throws(
+            () => runStrictConfigProbe({
+                codexBin: '/bin/true',
+                reviewerHome,
+                workspace,
+                scratch: reviewerScratch,
+            }),
+            /strict reviewer-config probe failed \(0\)/,
+        );
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
 });
 
 test('outer Codex authentication is symlinked outside the fixture and never copied', () => {


### PR DESCRIPTION
## Summary

- move view_image disabling into the CLI-supported features namespace
- validate the exact credential-free reviewer profile through a strict no-transport preflight before any scored cell
- record protocol revision 2 while preserving the original design and zero-call invalid attempt
- add regression coverage for obsolete config, false-positive zero exits, credential absence, and temporary-state cleanup

## Review

The inline correctness and security review found two bounded issues and both were fixed: the sentinel check now fails closed, and cleanup has direct coverage. Authentication, filesystem, network, and tool isolation remain restricted.

## Verification

- node bin/cycle.mjs lint
- npm test: 318 passing
- node bin/cycle.mjs check
- real release-relay preflight: 6 fixtures, 6 oracles, artifact lock pass, strict config pass, credentials absent, scored_model_calls 0
- protocol SHA-256: 0bb13d82827552e592018692c14edb661c9d0ab0752fda0c0458c76c1208e9f4
- runner SHA-256: 1084a8a10d75bbeeb70cf2c932c97d6a6bc086aec6f274b33a06d7e4cfdaa084

No scored model calls were made.

Closes #131
Part of #128

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)
