### PR TITLE
fix(eval): make guidance evidence content-backed

### DIFF
--- a/docs/EVALUATION.md
+++ b/docs/EVALUATION.md
@@ -65,9 +65,11 @@ or prevalence sample.
 
 The frozen protocol contains four flawed Release Relay changes, two named-target-clean controls,
 two arms, and three repetitions. That is 18 matched pairs and 36 valid scored cells. Model, effort,
-timeout, prompt, schema, permissions, ordering seed, fixture commit time, invalid-pair rule, captured
-original tasks, normalized tasks, guidance, source trees, candidate patches, repairs, hidden
-oracles, census, and score schema are all hashed before scoring.
+timeout, prompt, schema, permissions, ordering seed, fixture commit time, captured original tasks,
+normalized tasks, guidance, source trees, candidate patches, repairs, hidden oracles, census, and
+score schema are all hashed before scoring. Revision 3 preserves the study claim, cases, model,
+scoring, seed, repetitions, ordering, and batch size while replacing revision 2's path-mention
+guidance heuristic with content-backed evidence.
 
 ### Model-free validation
 
@@ -95,18 +97,25 @@ node eval/review/run.mjs preflight \
   --output /tmp/review-eval-preflight
 ```
 
-The fake run exercises the complete seeded schedule, a deliberately invalid cell and paired retry,
-successful content-backed reads of both guidance files, normalization, blinded scoring input, and
-private artifact writing. `dry-run-batch` exercises the same path one matched pair at a time and
-resumes from the same output directory:
+The fake run exercises the complete seeded schedule, an absent-file compound guidance check in
+every baseline, a deliberately invalid cell and paired retry, successful content-backed reads of
+both treatment guidance files, normalization, blinded scoring input, and private artifact writing.
+Focused synthetic modes also prove that either guide's returned content invalidates baseline, one
+returned treatment guide is insufficient, and proven baseline exposure stops before retry.
+`dry-run-batch` exercises the same path one matched pair at a time and resumes from the same output
+directory:
 
 ```sh
 node eval/review/run.mjs dry-run-batch --output /tmp/review-eval-dry-batched
 ```
 
-Repeat that command 18 times; each successful invocation prints a receipt with reviewer calls,
-invalid attempts, reported token usage, elapsed time, and completed/remaining pairs. The first fake
-pair deliberately retries both arms, so its receipt shows four calls; ordinary pairs show two.
+Repeat that command 18 times; each successful invocation prints a receipt that separately counts
+reviewer processes, model turns started, model turns completed, invalid cells, reported token
+usage, elapsed time, and completed/remaining pairs. Legacy `calls` and `invalid_attempts` aliases
+remain for existing receipt consumers. The first fake pair deliberately retries both arms, so its
+receipt shows four reviewer processes and model turns; ordinary pairs show two.
+Token usage is summed only from completed turn events. If a turn starts without completing, its
+usage is unavailable and is not inferred to be zero.
 Preflight
 reconstructs all six one-commit repositories, checks the artifact lock and history truncation,
 probes filesystem isolation, and proves every hidden oracle is green before insertion, red on the
@@ -136,8 +145,10 @@ node eval/review/run.mjs run \
 ```
 
 For quota-monitored execution, use `run-batch` with the same output directory and exact hash. Each
-invocation completes exactly one matched pair, including both arms of its single allowed retry, and
-then stops with a receipt:
+invocation completes exactly one matched pair and then stops with a receipt. Ordinary cell
+invalidity gets one paired retry. Successful command output containing the frozen content of either
+guide proves baseline contamination and instead stops the experiment immediately, preserving the
+first pair without spending a retry:
 
 ```sh
 node eval/review/run.mjs run-batch \

--- a/eval/review/common-prompt.md
+++ b/eval/review/common-prompt.md
@@ -5,8 +5,9 @@ outside this repository, or attempt to recover later history. Inspect the implem
 and relevant repository documentation closely enough to identify consequential correctness,
 contract, safety, and edge-case defects.
 
-Before reviewing, read `.agents/skills/review/SKILL.md` if that repository-local guide exists.
-Otherwise perform a strong general code review using the same output contract.
+Before reviewing, if the repository-local guides exist, read both
+`.agents/skills/review/SKILL.md` and `.agents/skills/DOCTRINE.md` in full. If neither exists,
+perform a strong general code review using the same output contract.
 
 Return only findings that are actionable and caused by the uncommitted change. For each finding,
 provide:

--- a/eval/review/fake-codex.cjs
+++ b/eval/review/fake-codex.cjs
@@ -65,8 +65,23 @@ for (const path of guidancePaths) {
             type: 'command_execution',
             command: `cat ${path}`,
             aggregated_output: fakeMode === 'guidance-mention-only'
+                || (fakeMode === 'guidance-one-file' && path.endsWith('DOCTRINE.md'))
                 ? 'mentioned a path without returning its contents\n'
                 : content,
+            exit_code: 0,
+            status: 'completed',
+        },
+    }));
+}
+
+if (process.env.CYCLE_REVIEW_ARM === 'baseline') {
+    console.log(JSON.stringify({
+        type: 'item.completed',
+        item: {
+            id: `item-${++item}`,
+            type: 'command_execution',
+            command: 'pwd && if [ -f .agents/skills/review/SKILL.md ]; then sed -n \'1,240p\' .agents/skills/review/SKILL.md; fi && if [ -f .agents/skills/DOCTRINE.md ]; then sed -n \'1,260p\' .agents/skills/DOCTRINE.md; fi',
+            aggregated_output: `${workspace}\n`,
             exit_code: 0,
             status: 'completed',
         },
@@ -91,12 +106,14 @@ console.log(JSON.stringify({
             : JSON.stringify({ findings: [], summary: 'No actionable findings in deterministic fake review.' }),
     },
 }));
-console.log(JSON.stringify({
-    type: 'turn.completed',
-    usage: {
-        input_tokens: 100,
-        cached_input_tokens: 25,
-        output_tokens: 20,
-        reasoning_output_tokens: 5,
-    },
-}));
+if (fakeMode !== 'turn-start-only') {
+    console.log(JSON.stringify({
+        type: 'turn.completed',
+        usage: {
+            input_tokens: 100,
+            cached_input_tokens: 25,
+            output_tokens: 20,
+            reasoning_output_tokens: 5,
+        },
+    }));
+}

--- a/eval/review/protocol.json
+++ b/eval/review/protocol.json
@@ -3,23 +3,38 @@
   "study_id": "release-relay-review-v1",
   "claim": "Pre-existing repository-specific review guidance helps a single model identify consequential edge cases and produce more actionable review evidence than a strong generic review prompt.",
   "revision": {
-    "number": 2,
-    "prior_protocol_sha256": "fda4e27bd8186dad607e4c5f78a498f4e4096beed84447b866a3c82827a8b87a",
-    "prior_runner_sha256": "46adf70d6dcce35dbefa51b8487cf55d10ff7525a8f4327e3e728c1f58c0a61d",
-    "reason": "Before any scored model call, Codex CLI 0.150.1 rejected the frozen strict reviewer configuration. Revision 2 preserves the image-tool restriction in the supported feature namespace and adds a credential-free, no-transport strict-config preflight probe.",
-    "preserved_invalid_attempt": {
-      "issue": 128,
-      "results_sha256": "88139d34b4852acad61270bc05391640014bd1e9468366be116a190d9bfd4412",
-      "summary_sha256": "b34ad05184e808e247613fa17683054096706954262cfd076c573d32fd8f9565",
-      "scored_model_calls": 0
-    },
+    "number": 3,
+    "prior_protocol_sha256": "0bb13d82827552e592018692c14edb661c9d0ab0752fda0c0458c76c1208e9f4",
+    "prior_runner_sha256": "1084a8a10d75bbeeb70cf2c932c97d6a6bc086aec6f274b33a06d7e4cfdaa084",
+    "reason": "Revision 2 consumed four scored model turns before a path-mention heuristic falsely classified absent-file checks as baseline guidance exposure. Revision 3 requires content-backed guidance evidence, explicitly requests both frozen guides, stops without retry only for proven baseline contamination, and separates reviewer-process, model-turn, and invalid-cell counts.",
+    "preserved_invalid_attempts": [
+      {
+        "revision": 1,
+        "issue": 128,
+        "protocol_sha256": "fda4e27bd8186dad607e4c5f78a498f4e4096beed84447b866a3c82827a8b87a",
+        "runner_sha256": "46adf70d6dcce35dbefa51b8487cf55d10ff7525a8f4327e3e728c1f58c0a61d",
+        "results_sha256": "88139d34b4852acad61270bc05391640014bd1e9468366be116a190d9bfd4412",
+        "summary_sha256": "b34ad05184e808e247613fa17683054096706954262cfd076c573d32fd8f9565",
+        "scored_model_calls": 0
+      },
+      {
+        "revision": 2,
+        "issue": 128,
+        "protocol_sha256": "0bb13d82827552e592018692c14edb661c9d0ab0752fda0c0458c76c1208e9f4",
+        "runner_sha256": "1084a8a10d75bbeeb70cf2c932c97d6a6bc086aec6f274b33a06d7e4cfdaa084",
+        "preflight_sha256": "a4c427eebf2faba029c4a696a38a47e4f9519223fa900cb0659007ea5b8e8e62",
+        "experiment_sha256": "cc614c2f26d7642f926b90176a4c6b9870310d6c3298321147e41e979acde11a",
+        "results_sha256": "bea51a8734ba05e9791019f2b44cdaddfefba70c5ebe41c4c2779c88b58567a7",
+        "summary_sha256": "9cec93f92c7672b63387daff64ffd8b2aa1164edc7b00a4b8b408e7dc34cdee2",
+        "scored_model_calls": 4
+      }
+    ],
     "unchanged": [
       "claim",
       "cases",
-      "schedule",
       "model",
       "scoring",
-      "invalidation"
+      "schedule seed, repetitions, ordering, and batch size"
     ]
   },
   "census_path": "CENSUS.md",
@@ -60,7 +75,7 @@
     "pairs_per_batch": 1,
     "batch_unit": "matched_pair",
     "resume_rule": "Each batch invocation completes exactly one matched pair, including its paired retry if needed. Resume only from an exact validated prefix of the frozen schedule; a mid-pair marker or state drift stops before another reviewer call.",
-    "invalid_run_rule": "Invalidate and rerun both arms for the same case and repetition; preserve the invalid attempt."
+    "invalid_run_rule": "Preserve every invalid attempt. Retry both arms once for ordinary cell invalidity. If successful command output proves that baseline received either frozen guide's content, stop the experiment before a paired retry."
   },
   "execution": {
     "model": "gpt-5.6-sol",
@@ -97,7 +112,7 @@
       "missing or schema-invalid final findings",
       "candidate mutation",
       "treatment did not read pinned guidance",
-      "baseline discovered treatment guidance"
+      "baseline received treatment guidance content"
     ],
     "experiment": [
       "artifact-lock mismatch",
@@ -107,7 +122,7 @@
       "resume state, artifact content, model, effort, Codex version, protocol, or schedule mismatch",
       "authentication path or material in a fixture, reviewer command environment, or captured public artifact"
     ],
-    "pair_rule": "If either cell is invalid, retain both attempts and rerun the pair once. If either retry is invalid, stop incomplete and score neither attempt from that pair."
+    "pair_rule": "If either cell is ordinarily invalid, retain both attempts and rerun the pair once. If either retry is invalid, stop incomplete and score neither attempt from that pair. Proven baseline guidance-content exposure is an integrity stop: retain the first pair and stop incomplete without retrying it."
   },
   "privacy": {
     "public_allowlist": [
@@ -232,10 +247,10 @@
     }
   ],
   "artifact_lock": {
-    "runner_sha256": "1084a8a10d75bbeeb70cf2c932c97d6a6bc086aec6f274b33a06d7e4cfdaa084",
-    "fake_reviewer_sha256": "d9ce0ea2fc187ec9d5bb0a72524dfccfa77e54dcb01a1640ad5b83c35b773234",
+    "runner_sha256": "6e679ceba66a5a94ed6acc31cc7095b4d28c616b39a14bf0a345e1df5baca372",
+    "fake_reviewer_sha256": "437914f53b2357d7ce2804846ec1d4380b9cd77d289a8d79da59fd4b53bc9ad2",
     "census_sha256": "1eb2272dfdb5110663f277cf70d661dbbc487e73f0b71d6f3e9e8b3b7f20e603",
-    "common_prompt_sha256": "98bae734100e4316267052c0f466f8f75658be1ef4702edf1d6b1fc31076353e",
+    "common_prompt_sha256": "6dbba2b706777f1fad06a471c38a98f3a000880b0ed9718dd4786f8a9bdcf2e6",
     "output_schema_sha256": "8e3a76201d5a942e80a62245f6bb48bac06b97f6a9a55209eef1a7aaf96fee5d",
     "score_schema_sha256": "917bf21114333358b025ef55e9b2eeb9e2b26be29e4ba4c4c431950fd581b198",
     "review_guidance_sha256": "21dda26d26949cea99effd704c8c6b7fa7bfc8c1632d214f02a4146505a83178",

--- a/eval/review/run.mjs
+++ b/eval/review/run.mjs
@@ -113,20 +113,43 @@ export function validateProtocol(protocol, { requireLock = true } = {}) {
         fail('review protocol requires version 1, study_id, claim, and census_path');
     }
     const revision = protocol.revision;
-    if (!revision || revision.number !== 2
-        || revision.prior_protocol_sha256 !== 'fda4e27bd8186dad607e4c5f78a498f4e4096beed84447b866a3c82827a8b87a'
-        || revision.prior_runner_sha256 !== '46adf70d6dcce35dbefa51b8487cf55d10ff7525a8f4327e3e728c1f58c0a61d'
+    if (!revision || revision.number !== 3
+        || revision.prior_protocol_sha256 !== '0bb13d82827552e592018692c14edb661c9d0ab0752fda0c0458c76c1208e9f4'
+        || revision.prior_runner_sha256 !== '1084a8a10d75bbeeb70cf2c932c97d6a6bc086aec6f274b33a06d7e4cfdaa084'
         || !isNonEmptyString(revision.reason)
-        || revision.preserved_invalid_attempt?.issue !== 128
-        || revision.preserved_invalid_attempt?.results_sha256
+        || !Array.isArray(revision.preserved_invalid_attempts)
+        || revision.preserved_invalid_attempts.length !== 2
+        || revision.preserved_invalid_attempts[0]?.revision !== 1
+        || revision.preserved_invalid_attempts[0]?.issue !== 128
+        || revision.preserved_invalid_attempts[0]?.protocol_sha256
+            !== 'fda4e27bd8186dad607e4c5f78a498f4e4096beed84447b866a3c82827a8b87a'
+        || revision.preserved_invalid_attempts[0]?.runner_sha256
+            !== '46adf70d6dcce35dbefa51b8487cf55d10ff7525a8f4327e3e728c1f58c0a61d'
+        || revision.preserved_invalid_attempts[0]?.results_sha256
             !== '88139d34b4852acad61270bc05391640014bd1e9468366be116a190d9bfd4412'
-        || revision.preserved_invalid_attempt?.summary_sha256
+        || revision.preserved_invalid_attempts[0]?.summary_sha256
             !== 'b34ad05184e808e247613fa17683054096706954262cfd076c573d32fd8f9565'
-        || revision.preserved_invalid_attempt?.scored_model_calls !== 0
+        || revision.preserved_invalid_attempts[0]?.scored_model_calls !== 0
+        || revision.preserved_invalid_attempts[1]?.revision !== 2
+        || revision.preserved_invalid_attempts[1]?.issue !== 128
+        || revision.preserved_invalid_attempts[1]?.protocol_sha256
+            !== '0bb13d82827552e592018692c14edb661c9d0ab0752fda0c0458c76c1208e9f4'
+        || revision.preserved_invalid_attempts[1]?.runner_sha256
+            !== '1084a8a10d75bbeeb70cf2c932c97d6a6bc086aec6f274b33a06d7e4cfdaa084'
+        || revision.preserved_invalid_attempts[1]?.preflight_sha256
+            !== 'a4c427eebf2faba029c4a696a38a47e4f9519223fa900cb0659007ea5b8e8e62'
+        || revision.preserved_invalid_attempts[1]?.experiment_sha256
+            !== 'cc614c2f26d7642f926b90176a4c6b9870310d6c3298321147e41e979acde11a'
+        || revision.preserved_invalid_attempts[1]?.results_sha256
+            !== 'bea51a8734ba05e9791019f2b44cdaddfefba70c5ebe41c4c2779c88b58567a7'
+        || revision.preserved_invalid_attempts[1]?.summary_sha256
+            !== '9cec93f92c7672b63387daff64ffd8b2aa1164edc7b00a4b8b408e7dc34cdee2'
+        || revision.preserved_invalid_attempts[1]?.scored_model_calls !== 4
         || stableJson(revision.unchanged) !== stableJson([
-            'claim', 'cases', 'schedule', 'model', 'scoring', 'invalidation',
+            'claim', 'cases', 'model', 'scoring',
+            'schedule seed, repetitions, ordering, and batch size',
         ])) {
-        fail('review protocol is missing the frozen revision 2 compatibility record');
+        fail('review protocol is missing the frozen revision 3 compatibility record');
     }
     if (!protocol.source || !isNonEmptyString(protocol.source.repository)
         || !/^[0-9a-f]{40}$/.test(protocol.source.review_guidance_commit)
@@ -393,7 +416,8 @@ This repository is an isolated historical review fixture.
 - Review the current uncommitted diff against the task under \`.review-eval/task.md\`.
 - Do not modify files or use the network.
 - Do not inspect paths outside this repository or attempt to recover later history.
-- If \`.agents/skills/review/SKILL.md\` exists, read it before reviewing.
+- If they exist, read both \`.agents/skills/review/SKILL.md\` and
+  \`.agents/skills/DOCTRINE.md\` in full before reviewing.
 - Return findings using the requested structured output contract.
 `;
 
@@ -410,14 +434,21 @@ function writeFixtureMetadata(destination, protocol, protocolPath, item) {
     );
 }
 
-function writeTreatmentGuidance(destination, protocol, source) {
-    for (const rel of protocol.source.review_guidance_paths) {
+function frozenGuidance(protocol, source) {
+    return protocol.source.review_guidance_paths.map((path) => ({
+        path,
+        content: git(source, [
+            'show', `${protocol.source.review_guidance_commit}:${path}`,
+        ], { encoding: null }).stdout.toString('utf8'),
+    }));
+}
+
+function writeTreatmentGuidance(destination, guidance) {
+    for (const { path: rel, content } of guidance) {
         const path = resolve(destination, rel);
         ensureInside(destination, path);
         mkdirSync(dirname(path), { recursive: true });
-        writeFileSync(path, git(source, [
-            'show', `${protocol.source.review_guidance_commit}:${rel}`,
-        ], { encoding: null }).stdout);
+        writeFileSync(path, content);
     }
 }
 
@@ -504,7 +535,8 @@ export function materializeFixture({
     mkdirSync(workspace, { recursive: true });
     writeTree(workspace, treeEntries(root, item.base, protocol.source.excluded_fixture_paths));
     writeFixtureMetadata(workspace, protocol, protocolPath, item);
-    if (arm === 'treatment') writeTreatmentGuidance(workspace, protocol, root);
+    const guidance = frozenGuidance(protocol, root);
+    if (arm === 'treatment') writeTreatmentGuidance(workspace, guidance);
     initializeFixtureRepository(workspace, protocol.execution.fixture_commit_time);
     const candidatePatch = patchBetween(
         root,
@@ -520,7 +552,7 @@ export function materializeFixture({
     }
     run('git', ['add', '--intent-to-add', '--', '.'], { cwd: workspace });
     const history = assertHistoryTruncated(workspace);
-    return { workspace, item, history };
+    return { workspace, item, history, guidance };
 }
 
 function seededRank(seed, value) {
@@ -767,16 +799,16 @@ function guidanceMarkers(content) {
     return [...new Set([lines[0], lines[Math.floor(lines.length / 2)], lines.at(-1)])];
 }
 
-function guidanceEvidence(events, paths, workspace) {
+export function guidanceEvidence(events, guidance, workspace) {
     const completed = events
         .filter((event) => event.type === 'item.completed'
             && event.item?.type === 'command_execution'
             && event.item?.status === 'completed'
             && event.item?.exit_code === 0);
-    const touched = events.some((event) => event.type === 'item.completed'
-        && event.item?.type === 'command_execution'
-        && paths.some((path) => String(event.item.command ?? '').includes(path)));
-    const read = paths.every((path) => {
+    const allOutput = completed
+        .map((event) => String(event.item.aggregated_output ?? ''))
+        .join('\n');
+    const readPaths = guidance.filter(({ path, content }) => {
         const guidancePath = join(workspace, path);
         if (!existsSync(guidancePath)) return false;
         const output = completed
@@ -784,10 +816,18 @@ function guidanceEvidence(events, paths, workspace) {
             .map((event) => String(event.item.aggregated_output ?? ''))
             .join('\n');
         if (!output) return false;
-        return guidanceMarkers(readFileSync(guidancePath, 'utf8'))
+        return guidanceMarkers(content)
             .every((marker) => output.includes(marker));
-    });
-    return { read, touched };
+    }).map(({ path }) => path);
+    const exposedPaths = guidance
+        .filter(({ content }) => guidanceMarkers(content).every((marker) => allOutput.includes(marker)))
+        .map(({ path }) => path);
+    return {
+        read: readPaths.length === guidance.length,
+        exposed: exposedPaths.length > 0,
+        readPaths,
+        exposedPaths,
+    };
 }
 
 function finalAgentText(events) {
@@ -848,23 +888,30 @@ function commonPrompt(protocol, protocolPath, item) {
     }`;
 }
 
-function setupDryFixture(protocol, protocolPath, publicCase, arm, destination) {
+function setupDryFixture(protocol, protocolPath, publicCase, arm, destination, fakeMode) {
     mkdirSync(destination, { recursive: true });
     const item = sourceCase(protocol, publicCase);
+    const guidance = [
+        {
+            path: '.agents/skills/review/SKILL.md',
+            content: '# Frozen review guidance\nInspect concrete edge cases and report actionable evidence.\n',
+        },
+        {
+            path: '.agents/skills/DOCTRINE.md',
+            content: '# Frozen review doctrine\nPreserve trust boundaries and verify consequential claims.\n',
+        },
+    ];
     writeFileSync(join(destination, 'AGENTS.md'), NEUTRAL_AGENTS);
     mkdirSync(join(destination, '.review-eval'), { recursive: true });
     writeFileSync(join(destination, '.review-eval', 'task.md'), readFileSync(resolveProtocolAsset(protocolPath, item.task_path)));
     writeFileSync(join(destination, '.review-eval', 'findings.schema.json'), readFileSync(resolveProtocolAsset(protocolPath, protocol.prompt.output_schema_path)));
-    if (arm === 'treatment') {
-        mkdirSync(join(destination, '.agents', 'skills', 'review'), { recursive: true });
-        writeFileSync(join(destination, '.agents', 'skills', 'review', 'SKILL.md'), '# Frozen review guidance\n');
-        mkdirSync(join(destination, '.agents', 'skills'), { recursive: true });
-        writeFileSync(join(destination, '.agents', 'skills', 'DOCTRINE.md'), '# Frozen doctrine\n');
+    if (arm === 'treatment' || fakeMode === 'baseline-guidance-exposure') {
+        writeTreatmentGuidance(destination, guidance);
     }
     writeFileSync(join(destination, 'candidate.txt'), 'historical base\n');
     initializeFixtureRepository(destination, protocol.execution.fixture_commit_time);
     writeFileSync(join(destination, 'candidate.txt'), `uncommitted candidate for ${item.id}\n`);
-    return { workspace: destination, item, history: assertHistoryTruncated(destination) };
+    return { workspace: destination, item, history: assertHistoryTruncated(destination), guidance };
 }
 
 function codexVersion(codexBin, env) {
@@ -1071,8 +1118,9 @@ function executeCell({
     privateMkdir(runDir);
     let reviewerHome;
     try {
+        const fakeMode = dryRun ? process.env.CYCLE_REVIEW_FAKE_MODE ?? '' : '';
         const fixture = dryRun
-            ? setupDryFixture(protocol, protocolPath, publicCase, cell.arm, workspace)
+            ? setupDryFixture(protocol, protocolPath, publicCase, cell.arm, workspace, fakeMode)
             : materializeFixture({ protocol, protocolPath, source, caseId: cell.case_id, arm: cell.arm, destination: workspace });
         if (!dryRun) installOffline(workspace);
         const before = run('git', [
@@ -1094,7 +1142,7 @@ function executeCell({
             repetition: cell.repetition,
             pairIndex: cell.pair_index,
             attempt,
-            fakeMode: dryRun ? process.env.CYCLE_REVIEW_FAKE_MODE ?? '' : '',
+            fakeMode,
         });
         const args = [
             'exec', '--json', '--ephemeral', '--strict-config', '--ignore-rules',
@@ -1137,11 +1185,13 @@ function executeCell({
         if (schemaInvalid) invalid.push(schemaInvalid);
         const guidance = guidanceEvidence(
             parsed.events,
-            protocol.source.review_guidance_paths,
+            fixture.guidance,
             workspace,
         );
         if (cell.arm === 'treatment' && !guidance.read) invalid.push('treatment did not read pinned review guidance');
-        if (cell.arm === 'baseline' && guidance.touched) invalid.push('baseline discovered treatment review guidance');
+        if (cell.arm === 'baseline' && guidance.exposed) {
+            invalid.push('baseline received treatment review guidance content');
+        }
         if (!before.equals(after) || !statusBefore.equals(statusAfter)) {
             invalid.push('reviewer mutated the candidate fixture');
         }
@@ -1172,7 +1222,12 @@ function executeCell({
             elapsed_ms: processResult.elapsedMs,
             usage: parsed.usage,
             fixture: fixture.history,
+            model_turn_started: parsed.events.some((event) => event.type === 'turn.started'),
+            model_turn_completed: parsed.events.some((event) => event.type === 'turn.completed'),
             treatment_guidance_read: guidance.read,
+            guidance_files_read: guidance.readPaths.length,
+            guidance_files_exposed: guidance.exposedPaths.length,
+            baseline_guidance_exposed: cell.arm === 'baseline' && guidance.exposed,
             artifacts,
             artifact_sha256: artifactSha256,
         };
@@ -1253,7 +1308,13 @@ function validatePersistedResult({ output, experiment, pair, cell, attempt, resu
         }
     }
     if (typeof result.valid !== 'boolean' || !Array.isArray(result.invalid_reasons)
-        || !Number.isSafeInteger(result.elapsed_ms) || result.elapsed_ms < 0) {
+        || !Number.isSafeInteger(result.elapsed_ms) || result.elapsed_ms < 0
+        || typeof result.model_turn_started !== 'boolean'
+        || typeof result.model_turn_completed !== 'boolean'
+        || typeof result.treatment_guidance_read !== 'boolean'
+        || !Number.isSafeInteger(result.guidance_files_read) || result.guidance_files_read < 0
+        || !Number.isSafeInteger(result.guidance_files_exposed) || result.guidance_files_exposed < 0
+        || typeof result.baseline_guidance_exposed !== 'boolean') {
         fail(`resumable result has invalid status fields for pair ${pair.pair_index} ${cell.arm}`);
     }
     const artifacts = expectedArtifacts(pair, cell, result);
@@ -1311,6 +1372,10 @@ export function validateExperimentProgress({ protocol, output, experiment, resul
         if (first.every((result) => result.valid)) {
             completedPairs += 1;
             continue;
+        }
+        if (first.some((result) => result.arm === 'baseline' && result.baseline_guidance_exposed)) {
+            terminalInvalidPair = pair.pair_index;
+            break;
         }
         const retry = results.slice(cursor, cursor + 2);
         if (retry.length !== 2) fail(`resumable results split retry for pair ${pair.pair_index}`);
@@ -1577,7 +1642,9 @@ function runExperiment({
             codexHome,
         }));
         results.push(...pairResults);
-        if (pairResults.some((result) => !result.valid)) {
+        const baselineGuidanceExposed = pairResults.some((result) =>
+            result.arm === 'baseline' && result.baseline_guidance_exposed);
+        if (pairResults.some((result) => !result.valid) && !baselineGuidanceExposed) {
             pairResults = pair.cells.map((cell) => executeCell({
                 protocol,
                 protocolPath,
@@ -1606,6 +1673,10 @@ function runExperiment({
     const invocationResults = results.slice(beforeCount);
     const receipt = {
         pair_index: selectedPairs[0]?.pair_index ?? null,
+        reviewer_processes: invocationResults.length,
+        model_turns_started: invocationResults.filter((result) => result.model_turn_started).length,
+        model_turns_completed: invocationResults.filter((result) => result.model_turn_completed).length,
+        invalid_cells: invocationResults.filter((result) => !result.valid).length,
         calls: invocationResults.length,
         invalid_attempts: invocationResults.filter((result) => !result.valid).length,
         token_usage: usageTotals(invocationResults),
@@ -1615,7 +1686,7 @@ function runExperiment({
         complete: summary.complete,
     };
     if (progress.terminalInvalidPair !== null && !Number.isFinite(maxPairs)) {
-        fail(`experiment stopped after the retry for pair ${progress.terminalInvalidPair} stayed invalid`);
+        fail(`experiment stopped at terminally invalid pair ${progress.terminalInvalidPair}`);
     }
     if (progress.complete) writeScoringArtifacts({ protocol, protocolPath, output, results });
     return {
@@ -1896,7 +1967,7 @@ export function main(argv = process.argv.slice(2)) {
             });
             console.log(JSON.stringify(result.receipt, null, 2));
             if (result.terminalInvalidPair !== null) {
-                fail(`experiment stopped after the retry for pair ${result.terminalInvalidPair} stayed invalid`);
+                fail(`experiment stopped at terminally invalid pair ${result.terminalInvalidPair}`);
             }
             return 0;
         });
@@ -1951,7 +2022,7 @@ export function main(argv = process.argv.slice(2)) {
             if (command === 'run-batch') {
                 console.log(JSON.stringify(result.receipt, null, 2));
                 if (result.terminalInvalidPair !== null) {
-                    fail(`experiment stopped after the retry for pair ${result.terminalInvalidPair} stayed invalid`);
+                    fail(`experiment stopped at terminally invalid pair ${result.terminalInvalidPair}`);
                 }
             }
             return 0;

--- a/test/review-eval.test.mjs
+++ b/test/review-eval.test.mjs
@@ -20,6 +20,7 @@ import {
     assertNoCredentialMaterial,
     buildSchedule,
     createReviewerHome,
+    guidanceEvidence,
     loadProtocol,
     probeReviewerConfig,
     reviewerConfig,
@@ -72,10 +73,12 @@ test('review protocol freezes the balanced study and local artifact hashes', () 
     assert.equal(protocol.schedule.batch_unit, 'matched_pair');
     assert.equal(protocol.scoring.composite_score, false);
     assert.equal(protocol.scoring.scorers, 2);
-    assert.equal(protocol.revision.number, 2);
-    assert.equal(protocol.revision.preserved_invalid_attempt.scored_model_calls, 0);
+    assert.equal(protocol.revision.number, 3);
+    assert.deepEqual(protocol.revision.preserved_invalid_attempts.map((attempt) =>
+        attempt.scored_model_calls), [0, 4]);
     assert.deepEqual(protocol.revision.unchanged, [
-        'claim', 'cases', 'schedule', 'model', 'scoring', 'invalidation',
+        'claim', 'cases', 'model', 'scoring',
+        'schedule seed, repetitions, ordering, and batch size',
     ]);
 
     const reviewRoot = join(ROOT, 'eval', 'review');
@@ -277,9 +280,15 @@ test('fake reviewer exercises paired retry, guidance evidence, normalization, an
 
         const valid = results.filter((result) => result.valid);
         assert.ok(valid.filter((result) => result.arm === 'treatment')
-            .every((result) => result.treatment_guidance_read));
+            .every((result) => result.treatment_guidance_read
+                && result.guidance_files_read === 2
+                && result.guidance_files_exposed === 2));
         assert.ok(valid.filter((result) => result.arm === 'baseline')
-            .every((result) => !result.treatment_guidance_read));
+            .every((result) => !result.treatment_guidance_read
+                && result.guidance_files_read === 0
+                && result.guidance_files_exposed === 0
+                && !result.baseline_guidance_exposed));
+        assert.ok(results.every((result) => result.model_turn_started && result.model_turn_completed));
         const fixtureCommits = new Map();
         for (const result of results) {
             const key = `${result.case_id}:${result.arm}`;
@@ -371,6 +380,10 @@ test('fake reviewer resumes one complete matched pair per quota-monitored batch'
             assert.equal(receipt.pair_index, batch);
             assert.equal(receipt.calls, batch === 1 ? 4 : 2);
             assert.equal(receipt.invalid_attempts, batch === 1 ? 1 : 0);
+            assert.equal(receipt.reviewer_processes, receipt.calls);
+            assert.equal(receipt.model_turns_started, receipt.calls);
+            assert.equal(receipt.model_turns_completed, receipt.calls);
+            assert.equal(receipt.invalid_cells, receipt.invalid_attempts);
             assert.equal(receipt.token_usage.input_tokens, receipt.calls * 100);
             assert.equal(receipt.token_usage.cached_input_tokens, receipt.calls * 25);
             assert.equal(receipt.token_usage.output_tokens, receipt.calls * 20);
@@ -514,6 +527,9 @@ test('an early zero-call batch failure can retry from the same output', { timeou
         }));
         assert.equal(receipt.pair_index, 1);
         assert.equal(receipt.calls, 4);
+        assert.equal(receipt.reviewer_processes, 4);
+        assert.equal(receipt.model_turns_started, 4);
+        assert.equal(receipt.model_turns_completed, 4);
         assert.equal(receipt.completed_pairs, 1);
     } finally {
         rmSync(scratch, { recursive: true, force: true });
@@ -540,6 +556,10 @@ test('a terminally invalid batch still reports consumed calls and tokens', { tim
         assert.equal(receipt.pair_index, 1);
         assert.equal(receipt.calls, 4);
         assert.equal(receipt.invalid_attempts, 2);
+        assert.equal(receipt.reviewer_processes, 4);
+        assert.equal(receipt.model_turns_started, 4);
+        assert.equal(receipt.model_turns_completed, 4);
+        assert.equal(receipt.invalid_cells, 2);
         assert.equal(receipt.token_usage.input_tokens, 400);
         assert.equal(receipt.completed_pairs, 0);
         assert.equal(receipt.remaining_pairs, 18);
@@ -593,6 +613,146 @@ test('mentioning guidance paths without returning their contents is invalid', { 
         assert.ok(invalidTreatment.every((result) => result.invalid_reasons.includes(
             'treatment did not read pinned review guidance',
         )));
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
+test('guidance exposure requires frozen content, not an absent-file compound command', () => {
+    const guidance = [
+        { path: '.agents/skills/review/SKILL.md', content: 'first distinctive frozen guidance marker for review evidence\n' },
+        { path: '.agents/skills/DOCTRINE.md', content: 'second distinctive frozen doctrine marker for review evidence\n' },
+    ];
+    const absentCheck = [{
+        type: 'item.completed',
+        item: {
+            type: 'command_execution',
+            status: 'completed',
+            exit_code: 0,
+            command: "pwd && if [ -f .agents/skills/review/SKILL.md ]; then sed -n '1,240p' .agents/skills/review/SKILL.md; fi && if [ -f .agents/skills/DOCTRINE.md ]; then sed -n '1,260p' .agents/skills/DOCTRINE.md; fi",
+            aggregated_output: '/isolated/workspace\n',
+        },
+    }];
+    assert.deepEqual(guidanceEvidence(absentCheck, guidance, '/isolated/workspace'), {
+        read: false,
+        exposed: false,
+        readPaths: [],
+        exposedPaths: [],
+    });
+
+    for (const exposed of guidance) {
+        const evidence = guidanceEvidence([{
+            type: 'item.completed',
+            item: {
+                type: 'command_execution',
+                status: 'completed',
+                exit_code: 0,
+                command: 'unexpected output',
+                aggregated_output: exposed.content,
+            },
+        }], guidance, '/isolated/workspace');
+        assert.equal(evidence.exposed, true);
+        assert.deepEqual(evidence.exposedPaths, [exposed.path]);
+    }
+});
+
+test('treatment must return content from both frozen guidance files', { timeout: 120_000 }, () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-review-one-guide-test-'));
+    try {
+        const output = join(scratch, 'output');
+        assert.throws(() => execFileSync(process.execPath, [RUNNER, 'dry-run-batch', '--output', output], {
+            cwd: ROOT,
+            env: { ...process.env, CYCLE_REVIEW_FAKE_MODE: 'guidance-one-file' },
+            encoding: 'utf8',
+            stdio: 'pipe',
+        }));
+        const results = readFileSync(join(output, 'private', 'results.jsonl'), 'utf8')
+            .trim().split('\n').map(JSON.parse);
+        const treatment = results.filter((result) => result.arm === 'treatment');
+        assert.equal(treatment.length, 2);
+        assert.ok(treatment.every((result) => !result.valid
+            && !result.treatment_guidance_read
+            && result.guidance_files_read === 1));
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
+test('proven baseline guidance exposure stops before the paired retry', { timeout: 120_000 }, () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-review-baseline-exposure-test-'));
+    try {
+        const output = join(scratch, 'output');
+        let failure;
+        try {
+            execFileSync(process.execPath, [RUNNER, 'dry-run-batch', '--output', output], {
+                cwd: ROOT,
+                env: { ...process.env, CYCLE_REVIEW_FAKE_MODE: 'baseline-guidance-exposure' },
+                encoding: 'utf8',
+                stdio: 'pipe',
+            });
+        } catch (error) {
+            failure = error;
+        }
+        assert.ok(failure);
+        const receipt = JSON.parse(failure.stdout);
+        assert.deepEqual({
+            reviewer_processes: receipt.reviewer_processes,
+            model_turns_started: receipt.model_turns_started,
+            model_turns_completed: receipt.model_turns_completed,
+            invalid_cells: receipt.invalid_cells,
+        }, {
+            reviewer_processes: 2,
+            model_turns_started: 2,
+            model_turns_completed: 2,
+            invalid_cells: 1,
+        });
+        const results = readFileSync(join(output, 'private', 'results.jsonl'), 'utf8')
+            .trim().split('\n').map(JSON.parse);
+        assert.equal(results.length, 2);
+        assert.ok(results.every((result) => result.attempt === 1));
+        const baseline = results.find((result) => result.arm === 'baseline');
+        assert.equal(baseline.baseline_guidance_exposed, true);
+        assert.deepEqual(baseline.invalid_reasons, [
+            'baseline received treatment review guidance content',
+        ]);
+        assert.equal(json(join(output, 'summary.json')).completed_pairs, 0);
+        assert.equal(statSync(join(output, 'scoring'), { throwIfNoEntry: false }), undefined);
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
+test('receipts distinguish reviewer processes from started and completed model turns', {
+    timeout: 120_000,
+}, () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-review-turn-count-test-'));
+    try {
+        const output = join(scratch, 'output');
+        let failure;
+        try {
+            execFileSync(process.execPath, [RUNNER, 'dry-run-batch', '--output', output], {
+                cwd: ROOT,
+                env: { ...process.env, CYCLE_REVIEW_FAKE_MODE: 'turn-start-only' },
+                encoding: 'utf8',
+                stdio: 'pipe',
+            });
+        } catch (error) {
+            failure = error;
+        }
+        assert.ok(failure);
+        const receipt = JSON.parse(failure.stdout);
+        assert.deepEqual({
+            reviewer_processes: receipt.reviewer_processes,
+            model_turns_started: receipt.model_turns_started,
+            model_turns_completed: receipt.model_turns_completed,
+            invalid_cells: receipt.invalid_cells,
+        }, {
+            reviewer_processes: 4,
+            model_turns_started: 4,
+            model_turns_completed: 0,
+            invalid_cells: 4,
+        });
+        assert.deepEqual(receipt.token_usage, {});
     } finally {
         rmSync(scratch, { recursive: true, force: true });
     }


### PR DESCRIPTION
## What shipped

- replaces guidance-path mentions with content-backed evidence from the two files pinned at the frozen Release Relay commit;
- explicitly asks reviewers to read both repository guides when present;
- stops without a retry only when baseline output proves real guidance-content exposure, while preserving the paired retry for ordinary invalid cells;
- adds separate reviewer-process, model-turn-started, model-turn-completed, and invalid-cell receipt counters;
- freezes protocol revision 3 while preserving both prior invalid-run records and the study's claim, cases, model, scoring, and schedule mechanics.

## Review and verification

- added exact synthetic coverage for the absent-file compound command, either-guide baseline exposure, one-guide treatment failure, both-guide treatment success, no-retry contamination, and incomplete-turn accounting;
- the inline correctness and security/integrity review found one P2 test gap: the original counter checks did not force the three lifecycle counts to differ. The patch adds a 4-process / 4-started / 0-completed regression and preserves unavailable usage as unknown rather than zero;
- full fake study: 18/18 pairs, 36 valid normalized reviews, one deliberate ordinary retry;
- real pinned-fixture preflight: artifact lock, strict credential-free config, isolation, four red-to-green hidden oracles, and two clean controls all pass with 0 scored model calls;
- node bin/cycle.mjs lint, npm test (322 tests), and node bin/cycle.mjs check pass.

Frozen revision-3 protocol SHA-256: b897826f7888ed5996dc583c1632940870c2808ef157be294d24f7098cd87212

Closes #133

Part of #128. That parent remains status:needs-decision; another scored pair still requires fresh approval.

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)
