### PR TITLE
feat(eval): add full-pipeline pilot

### DIFF
--- a/docs/EVALUATION.md
+++ b/docs/EVALUATION.md
@@ -197,3 +197,108 @@ mappings, tool traces, and possibly host-local metadata. Public artifacts are li
 protocol/census, path-scrubbed preflight summary, normalized scoring packets and locked score files,
 and a reviewed aggregate report. The requested output root is also mode 0700 by default; copy only
 the allowlisted artifacts when sharing them.
+
+## Full intake-to-cycle pilot
+
+`eval/pipeline/` tests a different, broader claim: whether the complete intake, implementation,
+review, patch, and delivery structure improves work that begins as a short request. It is a
+four-case descriptive Songs I Know pilot, not a general benchmark. The census applies one fixed
+two-day eligibility rule and a deterministic hash rank before selecting #133, #131, #139, and #123.
+
+Each case begins with one resumable `$intake` session. A frozen answer sheet responds only when the
+model asks a question, and the GitHub double captures the one issue it files. The exact resulting
+title and body bytes then feed both shaped arms:
+
+```text
+raw request ──┬── intake + scripted answers ── exact issue bytes ─┬── shaped direct
+              │                                                   └── implement
+              └── raw direct                                           │
+                                                                        review
+                                                                          │
+                                                                        patch
+                                                                          │
+                                                                        done
+```
+
+The full-cycle stages are separate resumed turns in one Codex thread, so the patch stage retains the
+review context and the evaluator can capture deltas after all four stages. The raw-direct arm gets
+the same scripted responder if it asks a material question. All arms use the same frozen model and
+effort; implementation-arm ordering is fixed in the protocol.
+
+The candidate workspaces are physical one-commit repositories without remotes, tags, alternates, or
+later source objects. Current pipeline guidance is injected only into intake and full-cycle
+fixtures. Direct arms receive a neutral repository instruction. Dependency trees are full physical
+copies of the selected local Songs I Know checkout, never symlinks or hardlinks back to it. Completed
+arm workspaces are discarded before the next arm so the pilot does not retain several copies at
+once. Model commands get write access only to the exact candidate root, no network, no ambient
+credentials, and a stateless local `gh`/push double. Hidden regression tests are inserted later into
+a separate verifier copy; candidate-authored tests and test-runner configuration cannot replace or
+disable them. Before evaluator-side Git inspection, the runner verifies the original physical
+`.git` control directory, rejects links and special files, and restores a known-safe local Git
+configuration. Batch resume likewise rejects links or special files anywhere in the output tree
+before writing another artifact.
+
+### Model-free validation
+
+The local Songs I Know checkout supplies the frozen public Git objects and an installed physical
+`node_modules` tree. First exercise all resumable lifecycle and artifact paths with the fake client:
+
+```sh
+node eval/pipeline/run.mjs dry-run --output /tmp/pipeline-eval-dry
+```
+
+The fake run deliberately invalidates the first shaped-direct attempt, retries the whole case, and
+then completes all four cases. It covers intake follow-ups, raw-direct follow-ups, all three arms,
+the four resumed full-cycle stages, tracker and push doubles, stage snapshots, private artifacts,
+normalization, and scoring blinding without a scored model call.
+
+Quota-style batching completes one full case per invocation. Reuse the exact output path four times:
+
+```sh
+node eval/pipeline/run.mjs dry-run-batch --output /tmp/pipeline-eval-dry-batched
+```
+
+Every receipt separates process turns started/completed from token usage actually reported. Resume
+validates an exact result prefix and every artifact hash. A lock prevents concurrent batches, and
+an `active-case.json` marker fails closed after interruption so a partially spent case is never
+silently repeated.
+
+Then prove the real historical fixtures and hidden verifier:
+
+```sh
+node eval/pipeline/run.mjs preflight \
+  --source ../songsiknow \
+  --output /tmp/pipeline-eval-preflight
+```
+
+Preflight checks the artifact lock, exact Codex version, strict permission profile, physical
+history isolation, evaluator-asset write denial, command-network denial, and all four hidden
+oracles. Each oracle must fail on the historical base, pass after the accepted repair, and fail
+again when the accepted production repair is removed. It records `scored_model_calls: 0`.
+
+### Scored batch brake
+
+A scored batch authenticates the outer Codex client and can spend several resumed turns, but it
+completes only one case before returning control for quota inspection. Review the model-free output,
+calculate the exact frozen protocol bytes, and explicitly confirm them:
+
+```sh
+sha256sum eval/pipeline/protocol.json
+
+node eval/pipeline/run.mjs run-batch \
+  --source ../songsiknow \
+  --output /tmp/pipeline-eval-scored \
+  --confirm-protocol-sha256 EXACT_HASH_FROM_ABOVE
+```
+
+Repeat the same command and output directory for the remaining cases. Every invocation reruns the
+model-free preflight before authentication-backed turns. Authentication exists only as a symlink in
+a disposable mode-0700 client home; raw output is fingerprint-scanned before persistence and the
+candidate command environment cannot read that home.
+
+Do not commit scored output. Raw events, stderr, host paths, tracker transcripts, stage measures,
+arm order, and the blinding map remain under `private/`. Only the protocol/census, path-scrubbed
+preflight, normalized `scoring/` packet, locked score files, and reviewed aggregate report are
+shareable. Two independent scorers should lock their files before the private arm map is revealed.
+Report the four matched outcomes and qualitative mechanisms separately from turns, tokens, elapsed
+time, and stage evidence; do not claim significance, prevalence, or a composite score.

--- a/eval/pipeline/CENSUS.md
+++ b/eval/pipeline/CENSUS.md
@@ -1,0 +1,56 @@
+# Full-pipeline pilot census
+
+Frozen 2026-08-30. This is a descriptive pilot over four real historical changes, not a
+representative sample of coding tasks and not a basis for statistical-significance or defect-rate
+claims.
+
+## Eligibility rule
+
+Start with every first-parent change merged to `brndnsh-labs/songsiknow` during the two complete
+America/New_York calendar days 2026-08-28 and 2026-08-29. Keep a change only when it:
+
+1. closes exactly one work story;
+2. changes no more than six files;
+3. includes automated regression coverage for the named behavior; and
+4. is not documentation, dependency, workflow, deployment, migration, by-ear, physical-device,
+   bundle-inspection, or other externally verified work.
+
+The fourth rule keeps the hidden outcome verifier executable and identical across arms. Passing it
+does not prove visual quality or production readiness.
+
+## Census
+
+| Merge | Story | Files | Result | Frozen reason |
+|---|---:|---:|---|---|
+| `31513e8` | #16 | 9 | excluded | More than six files |
+| `142078c` | #139 | 6 | eligible | One story and executable regression coverage |
+| `6de1d1c` | #134 | 10 | excluded | More than six files |
+| `ef80880` | #133 | 3 | eligible | One story and executable regression coverage |
+| `eb1b11c` | #117 | 1 | excluded | No automated regression file for the named contrast behavior |
+| `d895468` | #33, #34, #35, #36 | 4 | excluded | Closes four stories |
+| `546198d` | none | 2 | excluded | Dependency maintenance |
+| `3b4ad21` | #132 | 2 | excluded | Acceptance includes physical keyboard/touch verification |
+| `2ca6aa2` | #131 | 2 | eligible | One story and executable regression coverage |
+| `a724994` | #130 | 2 | eligible | One story and executable regression coverage |
+| `e4c84fe` | #129 | 2 | excluded | Acceptance includes production bundle-manifest inspection |
+| `ef418ac` | #128 | 5 | excluded | Documentation |
+| `07a650e` | #127 | 1 | excluded | Documentation and live deployment-state verification |
+| `6f8bf57` | #123 | 2 | eligible | One story and executable regression coverage |
+| `655d383` | none | 21 | excluded | Generated workflow maintenance |
+| `7bcc3c0` | none | 1 | excluded | Documentation |
+
+## Deterministic selection
+
+The eligible issue set is `123, 130, 131, 133, 139`. Rank each issue by ascending hexadecimal
+SHA-256 of `full-pipeline-pilot-v1-2026-08-30:<issue>`:
+
+| Rank | Issue | Digest | Selected |
+|---:|---:|---|---|
+| 1 | #133 | `0f40a2b147a08a3b80d5284cc7e96c9ec8fbf9b890db2507ca6008410533da93` | yes |
+| 2 | #131 | `6c10edd2b50ee48c6be3a2728cef2dfa2ccb679f8eeee5b8b11e5a3a440ad569` | yes |
+| 3 | #139 | `c52550befe91414bb9445a62902747ef06ae427273a0d764c38264c971372d73` | yes |
+| 4 | #123 | `f264e5438b3883fc40bd1db29b387afd00aeaf7a439ae530e1853be92a77f6ae` | yes |
+| 5 | #130 | `f4a651897375166bed6ddf6f53f524ffe4111c701a6d0798c224018587ab225e` | no |
+
+The #130 result is excluded solely by its frozen rank. Its historical review outcome was not used
+to select the four cases.

--- a/eval/pipeline/answers/sik-123.json
+++ b/eval/pipeline/answers/sik-123.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "sik-123",
+  "max_followups_per_stage": 3,
+  "rules": [
+    {
+      "id": "approve-filing",
+      "question_regex": "((approve|file).*(draft|issue)|(draft|issue).*(approve|file)|ready to create)",
+      "answer": "Approved. File the drafted issue and proceed."
+    }
+  ],
+  "default_answer": "Use the repository's 44 by 44 pixel touch floor in the shared Drawer component. Preserve header proportions, prevent long titles from shrinking the target, keep close behavior unchanged, and add a focused regression test. Spot-check representative Drawer consumers at 390 pixels."
+}

--- a/eval/pipeline/answers/sik-131.json
+++ b/eval/pipeline/answers/sik-131.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "sik-131",
+  "max_followups_per_stage": 3,
+  "rules": [
+    {
+      "id": "approve-filing",
+      "question_regex": "((approve|file).*(draft|issue)|(draft|issue).*(approve|file)|ready to create)",
+      "answer": "Approved. File the drafted issue and proceed."
+    }
+  ],
+  "default_answer": "The open-filter trigger and Clear action should be sibling native buttons with distinct accessible names and independent keyboard behavior. Clearing must not open the menu, and opening must not clear. Keep the visible pill height stable while providing at least a 44 by 44 pixel clear hit target; add focused regression coverage."
+}

--- a/eval/pipeline/answers/sik-133.json
+++ b/eval/pipeline/answers/sik-133.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "sik-133",
+  "max_followups_per_stage": 3,
+  "rules": [
+    {
+      "id": "approve-filing",
+      "question_regex": "((approve|file).*(draft|issue)|(draft|issue).*(approve|file)|ready to create)",
+      "answer": "Approved. File the drafted issue and proceed."
+    }
+  ],
+  "default_answer": "Use a hard ceiling of exactly 1,000,000 bytes. Check the Stripe signature header before reading the body; reject declared or streamed overflow with 413; preserve the exact raw bytes for signature verification; keep paid-session and idempotency behavior; add boundary and deceptive Content-Length regression coverage. Treat this as payment/security-sensitive and retain security review plus a human merge brake."
+}

--- a/eval/pipeline/answers/sik-139.json
+++ b/eval/pipeline/answers/sik-139.json
@@ -1,0 +1,12 @@
+{
+  "case_id": "sik-139",
+  "max_followups_per_stage": 3,
+  "rules": [
+    {
+      "id": "approve-filing",
+      "question_regex": "((approve|file).*(draft|issue)|(draft|issue).*(approve|file)|ready to create)",
+      "answer": "Approved. File the drafted issue and proceed."
+    }
+  ],
+  "default_answer": "Use a five-second grace period after onblocked. Then reject with an actionable close-other-tabs-and-reload error, clear only the still-current cached open generation, allow a later retry, and close an uncancellable late-success connection. Surface one deduplicated app-wide toast. Test the timeout boundary, temporary recovery, retry, late cleanup, and notification."
+}

--- a/eval/pipeline/bin/fake-gh.cjs
+++ b/eval/pipeline/bin/fake-gh.cjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('node:child_process');
+const { existsSync, readFileSync } = require('node:fs');
+
+const args = process.argv.slice(2);
+
+function fail(message) {
+    console.error(message);
+    process.exit(2);
+}
+
+function option(name, fallback = null) {
+    const index = args.indexOf(name);
+    return index >= 0 && args[index + 1] !== undefined ? args[index + 1] : fallback;
+}
+
+function labels(value) {
+    return String(value ?? '').split(',').map((name) => name.trim()).filter(Boolean)
+        .map((name) => ({ id: `fake-${name}`, name, description: '', color: 'ededed' }));
+}
+
+function issueBody() {
+    const encoded = process.env.CYCLE_PIPELINE_ISSUE_BODY_BASE64 ?? '';
+    return encoded ? Buffer.from(encoded, 'base64').toString('utf8') : '';
+}
+
+function issueRecord() {
+    return {
+        number: 1,
+        title: process.env.CYCLE_PIPELINE_ISSUE_TITLE ?? 'Frozen pipeline evaluation issue',
+        state: 'OPEN',
+        url: 'https://example.invalid/pipeline-eval/issues/1',
+        labels: labels(process.env.CYCLE_PIPELINE_ISSUE_LABEL ?? 'status:ready'),
+        milestone: null,
+        body: issueBody(),
+    };
+}
+
+function selectedJson(record) {
+    const requested = option('--json');
+    if (!requested) return record;
+    const fields = requested.split(',').map((field) => field.trim()).filter(Boolean);
+    return Object.fromEntries(fields.map((field) => [field, record[field] ?? null]));
+}
+
+if (args[0] === '--version' || args[0] === 'version') {
+    console.log('gh version 2.0.0-pipeline-double');
+    process.exit(0);
+}
+
+if (args[0] === 'issue' && args[1] === 'list') {
+    console.log('[]');
+    process.exit(0);
+}
+
+if (args[0] === 'issue' && args[1] === 'view') {
+    console.log(JSON.stringify(selectedJson(issueRecord())));
+    process.exit(0);
+}
+
+if (args[0] === 'issue' && args[1] === 'create') {
+    const bodyFile = option('--body-file');
+    let body = option('--body', '');
+    if (bodyFile) {
+        if (!existsSync(bodyFile)) fail(`fake gh body file does not exist: ${bodyFile}`);
+        body = readFileSync(bodyFile, 'utf8');
+    }
+    const title = option('--title', 'Untitled evaluation issue');
+    const encoded = Buffer.from(body).toString('base64');
+    console.log(`CYCLE_PIPELINE_TRACKER_CREATE:${encoded}`);
+    console.log(`CYCLE_PIPELINE_TRACKER_TITLE:${Buffer.from(title).toString('base64')}`);
+    console.log('https://example.invalid/pipeline-eval/issues/1');
+    process.exit(0);
+}
+
+if (args[0] === 'issue' && ['edit', 'comment', 'close'].includes(args[1])) {
+    console.log('https://example.invalid/pipeline-eval/issues/1');
+    process.exit(0);
+}
+
+if (args[0] === 'pr' && args[1] === 'create') {
+    console.log('https://example.invalid/pipeline-eval/pull/1');
+    process.exit(0);
+}
+
+if (args[0] === 'pr' && args[1] === 'list') {
+    console.log('[]');
+    process.exit(0);
+}
+
+if (args[0] === 'pr' && args[1] === 'view') {
+    const record = {
+        number: 1,
+        state: 'OPEN',
+        url: 'https://example.invalid/pipeline-eval/pull/1',
+        headRefName: option('--head', 'eval/fixture'),
+        baseRefName: 'main',
+        mergeStateStatus: 'CLEAN',
+    };
+    console.log(JSON.stringify(selectedJson(record)));
+    process.exit(0);
+}
+
+if (args[0] === 'pr' && args[1] === 'checks') {
+    console.log('local-gates\tpass\t1s\thttps://example.invalid/checks/1');
+    process.exit(0);
+}
+
+if (args[0] === 'pr' && args[1] === 'merge') {
+    const advanced = spawnSync('/usr/bin/git', ['branch', '-f', 'main', 'HEAD'], {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+    });
+    if (advanced.status !== 0) fail(`fake gh could not advance local main: ${advanced.stderr}`);
+    console.log('https://example.invalid/pipeline-eval/pull/1');
+    process.exit(0);
+}
+
+if (args[0] === 'pr' && ['edit', 'comment'].includes(args[1])) {
+    console.log('https://example.invalid/pipeline-eval/pull/1');
+    process.exit(0);
+}
+
+fail(`unsupported fake gh command: ${args.join(' ')}`);

--- a/eval/pipeline/bin/gh
+++ b/eval/pipeline/bin/gh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec node "$(dirname "$0")/fake-gh.cjs" "$@"

--- a/eval/pipeline/bin/git
+++ b/eval/pipeline/bin/git
@@ -1,0 +1,13 @@
+#!/bin/sh
+if [ "$1" = "push" ]; then
+    printf '%s\n' 'CYCLE_PIPELINE_GIT_PUSH:accepted-local-double'
+    exit 0
+fi
+if [ "$1" = "fetch" ]; then
+    printf '%s\n' 'CYCLE_PIPELINE_GIT_FETCH:accepted-local-double'
+    exit 0
+fi
+if [ "$1" = "reset" ] && [ "$2" = "--hard" ] && [ "$3" = "origin/main" ]; then
+    exec /usr/bin/git reset --hard main
+fi
+exec /usr/bin/git "$@"

--- a/eval/pipeline/canonical-issues/sik-123.md
+++ b/eval/pipeline/canonical-issues/sik-123.md
@@ -1,0 +1,35 @@
+**Why:** `src/components/ui/drawer.tsx:122-131` renders the sheet's Close button at a hardcoded
+`width: 32, height: 32` with no per-consumer override path (`Drawer`'s own `className` prop only
+reaches the panel div, not this button). `Drawer` backs 7 call sites: `FeedbackSection.tsx`,
+`BottomTabs.tsx` (the More menu), `FeedbackDrawer.tsx`, `SessionQueue.tsx` (Up Next), the
+player's `AdjustDrawer.tsx`, `Recap.tsx`, `ShareSetlistDialog.tsx` — every one inherits the same
+32×32 target.
+
+Found while verifying #114's practice-session touch-target sweep (`a[href], button, select,
+[role=button]` ≥44×44 at 390px) — the Up Next sheet's Close button failed the sweep. Deliberately
+**not** fixed there: it's shared infrastructure with a much wider blast radius than #114's four
+named files, matching that issue's own precedent for "elsewhere, out of scope."
+
+**Touches:** `src/components/ui/drawer.tsx`.
+
+**Fix (drafted):**
+```tsx
+// drawer.tsx:126 — 32×32 → 44×44
+style={{
+  width: 44, height: 44, borderRadius: 'var(--r-sm)', border: 'none',
+  background: 'none', color: 'var(--ink-3)', cursor: 'pointer',
+  fontSize: 20, lineHeight: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
+}}
+```
+The header row (`drawer.tsx:115-118`) doesn't set `alignItems`, so it defaults to `stretch` —
+growing the button will grow the header's rendered height slightly across all 7 consumers. Check
+each surface's header still reads fine after the bump (a `padding` trim on the header row, e.g.
+`'8px 16px 10px'`, may be enough to keep the overall proportions close to today's).
+
+**Acceptance:**
+- Every `Drawer` consumer's Close button measures ≥44×44 at 390px.
+- No layout breakage in any of the 7 call sites (spot-check at least Up Next, the player's Adjust
+  panel, and one Settings dialog).
+
+---
+_Found verifying #114's touch-target sweep, 2026-08-28._

--- a/eval/pipeline/canonical-issues/sik-131.md
+++ b/eval/pipeline/canonical-issues/sik-131.md
@@ -1,0 +1,9 @@
+**Why:** `src/components/library/FilterPopover.tsx:45-80` renders the active filter's clear `<button>` inside its trigger `<button>`. The exact inner control is `<button type="button" aria-label={\`Clear ${label}\`} onClick={e => { e.stopPropagation(); onClear!(); close() }}>×</button>`. An active filter therefore contains invalid nested interactive content. The clear control is also only 20×20px.
+
+Failure scenario: browsers and assistive technology can expose the open-filter and clear-filter actions unpredictably, while a hands-occupied user gets a target far below the repository's established 44px touch floor.
+
+**Touches:** `src/components/library/FilterPopover.tsx`; focused component tests.
+
+**Fix (drafted):** Move the pill background, border, and layout to a non-interactive `inline-flex` wrapper. Render the trigger and `Clear ${label}` action as sibling native buttons. Keep `aria-expanded` and `aria-haspopup="menu"` only on the trigger. Have the clear sibling call `onClear()` and `close()` directly. Give both controls independent focus-visible rings and the clear action a minimum 44×44px target.
+
+**Acceptance:** An active filter renders two sibling buttons with distinct accessible names; neither contains the other. Keyboard users can focus and activate each independently. Clearing does not open the menu; opening does not clear. A regression test covers DOM nesting, names, and both actions; standard gates pass; the pill is checked on a touch device.

--- a/eval/pipeline/canonical-issues/sik-133.md
+++ b/eval/pipeline/canonical-issues/sik-133.md
@@ -1,0 +1,11 @@
+**Why:** `src/app/api/payments/webhook/route.ts:7-15` buffers the entire public request body before checking for the required signature: `const rawBody = await req.text()` runs before `const sig = req.headers.get('stripe-signature')` and the missing-signature return. The deployed Caddy route has no application-specific request-body cap. Stripe verification requires the unchanged raw body, so parsing and re-serializing is unsafe.
+
+Failure scenario: an unauthenticated caller sends concurrent oversized POST bodies to `/api/payments/webhook`. The single PM2 process buffers each complete body before it checks whether a signature exists; forged signatures also reach the unbounded read. This can consume memory and CPU before authentication.
+
+**Touches:** `src/app/api/payments/webhook/route.ts`; bounded raw-body helper and tests.
+
+**Fix (drafted):** Move the `stripe-signature` check before any body read. Propose `MAX_STRIPE_WEBHOOK_BYTES = 1_000_000` for approval. Add a bounded raw-byte reader that rejects a declared `Content-Length` above the cap, streams chunks, stops when cumulative bytes exceed the cap, and returns the unchanged `Buffer`/`Uint8Array` to `constructEvent`. Never call `request.json()` or re-serialize the payload.
+
+**Acceptance:** Missing signature returns 400 without pulling the request stream. A forged-signature body of `MAX + 1` bytes returns 413 without invoking `constructEvent`. A valid SDK-generated signature over an at-or-under-limit raw fixture verifies and preserves existing paid-session/idempotency behavior. Standard gates pass.
+
+**Decision:** Stripe does not publish a webhook payload maximum. Approve the proposed 1MB ceiling, or choose a different operational ceiling. This is a payment-surface §5 brake and requires security review plus a human merge.

--- a/eval/pipeline/canonical-issues/sik-139.md
+++ b/eval/pipeline/canonical-issues/sik-139.md
@@ -1,0 +1,11 @@
+**Why:** Found by `audio-stems-reviewer` while reviewing #130 (retry a failed IndexedDB open instead of caching the rejection). `openDb()` (`src/lib/stems/store.ts`) has no `req.onblocked` handler. A blocked open never fires `error` — it stays pending indefinitely — and `if (dbPromise) return dbPromise` hands that pending promise to every caller. `wipeLocalDevice()` already knows about this exact hazard and handles it (`store.ts` — `req.onblocked = () => resolve()`, "a best-effort wipe must not hang"); `openDb()` doesn't.
+
+Concrete scenario the file's own comments already anticipate (`store.ts:168-172` — "a backgrounded phone tab holds a pending source — S8a"): a frozen/backgrounded tab holds a v6 connection open. A new tab on a newer build (v7) opens → `blocked` → the frozen tab's `onversionchange` never runs to release the lock (it's frozen, not closed) → the new tab's player, library, and sync all hang forever on `openDb()` with no error surfaced to the user.
+
+This is a distinct failure mode from what #130 fixed — #130 was about a *rejected* open being cached forever; this is about an open that *never settles*.
+
+**Touches:** `src/lib/stems/store.ts` (`openDb()`).
+
+**Fix (sketch):** add `req.onblocked` with a bounded timeout that rejects (and, per #130's generation-guard pattern, nulls `dbPromise` only if it's still the current generation) so the UI can surface "close other tabs to continue" instead of spinning silently. Needs a decision on the timeout window and what the calling UI does with the rejection — flagging as needs-decision rather than drafting a fix inline.
+
+**Acceptance:** A blocked `indexedDB.open()` surfaces as a rejected `openDb()` within a bounded time, not an indefinite hang; existing non-blocked paths are unaffected.

--- a/eval/pipeline/direct-prompt.md
+++ b/eval/pipeline/direct-prompt.md
@@ -1,0 +1,7 @@
+Work in this isolated historical repository. Implement the user request completely, including
+appropriate tests and verification. Do not use the network or inspect paths outside the repository.
+Do not use or invent a project workflow beyond the instructions present in this fixture.
+
+When a material product or safety choice is genuinely required, stop and return `needs-input` with
+one concise question. Otherwise implement the change and return `complete`. Always obey the
+requested structured-output schema; set `question` to an empty string when complete.

--- a/eval/pipeline/fake-codex.cjs
+++ b/eval/pipeline/fake-codex.cjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('node:child_process');
+const { appendFileSync, existsSync, readFileSync, writeFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+const args = process.argv.slice(2);
+
+if (args[0] === '--version') {
+    console.log('fake-pipeline-codex 1.0');
+    process.exit(0);
+}
+
+if (args[0] === 'app-server') {
+    if (!args.includes('--strict-config') || !args.includes('--listen') || !args.includes('off')) {
+        console.error('fake pipeline Codex expected strict no-transport config probe');
+        process.exit(2);
+    }
+    const home = process.env.CODEX_HOME;
+    if (!home || existsSync(join(home, 'auth.json')) || process.env.OPENAI_API_KEY) {
+        console.error('fake pipeline config probe received authentication');
+        process.exit(2);
+    }
+    const config = readFileSync(join(home, 'config.toml'), 'utf8');
+    if (!/\[permissions\.pipeline-fixture\.filesystem\]/.test(config)
+        || !/":root" = "deny"/.test(config)
+        || !/\[permissions\.pipeline-fixture\.network\]\nenabled = false/.test(config)) {
+        console.error('fake pipeline config probe found an invalid permission profile');
+        process.exit(1);
+    }
+    console.error('Error: no transport configured; use --listen or enable remote control');
+    process.exit(1);
+}
+
+if (args[0] !== 'exec') {
+    console.error('fake pipeline Codex expected codex exec');
+    process.exit(2);
+}
+
+const resume = args[1] === 'resume';
+const workspace = process.cwd();
+const stage = process.env.CYCLE_PIPELINE_STAGE;
+const arm = process.env.CYCLE_PIPELINE_ARM;
+const caseId = process.env.CYCLE_PIPELINE_CASE;
+const attempt = Number(process.env.CYCLE_PIPELINE_ATTEMPT ?? '1');
+const turn = Number(process.env.CYCLE_PIPELINE_TURN ?? '1');
+const threadId = process.env.CYCLE_PIPELINE_SESSION_ID ?? `fake-${caseId}-${arm}`;
+let item = 0;
+
+function event(value) {
+    console.log(JSON.stringify(value));
+}
+
+function command(command, commandArgs) {
+    const result = spawnSync(command, commandArgs, {
+        cwd: workspace,
+        env: process.env,
+        encoding: 'utf8',
+    });
+    event({
+        type: 'item.completed',
+        item: {
+            id: `item-${++item}`,
+            type: 'command_execution',
+            command: [command, ...commandArgs].join(' '),
+            aggregated_output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+            exit_code: result.status,
+            status: result.status === 0 ? 'completed' : 'failed',
+        },
+    });
+    if (result.status !== 0) process.exit(result.status ?? 2);
+    return result;
+}
+
+function finish(payload) {
+    event({
+        type: 'item.completed',
+        item: { id: `item-${++item}`, type: 'agent_message', text: JSON.stringify(payload) },
+    });
+    event({
+        type: 'turn.completed',
+        usage: {
+            input_tokens: 100,
+            cached_input_tokens: resume ? 50 : 0,
+            output_tokens: 25,
+            reasoning_output_tokens: 5,
+        },
+    });
+}
+
+event({ type: 'thread.started', thread_id: threadId });
+event({ type: 'turn.started' });
+
+if (caseId === 'sik-133' && arm === 'shaped-direct' && attempt === 1 && turn === 1) {
+    event({ type: 'item.completed', item: { id: `item-${++item}`, type: 'agent_message', text: 'invalid fake response' } });
+    event({ type: 'turn.completed', usage: { input_tokens: 10, output_tokens: 3 } });
+    process.exit(0);
+}
+
+if (stage === 'intake') {
+    if (turn === 1) {
+        finish({
+            status: 'needs-input',
+            question: 'What exact boundary and acceptance behavior should this change use?',
+            summary: 'The raw request needs one bounded acceptance decision.',
+        });
+    } else {
+        const body = Buffer.from(process.env.CYCLE_PIPELINE_CANONICAL_ISSUE_BASE64 ?? '', 'base64').toString('utf8');
+        command('gh', [
+            'issue', 'create', '--title', `Frozen ${caseId} issue`, '--body', body, '--label', 'enhancement',
+        ]);
+        finish({ status: 'complete', question: '', summary: 'Filed one actionable issue.' });
+    }
+    process.exit(0);
+}
+
+if (arm === 'raw-direct' && turn === 1) {
+    finish({
+        status: 'needs-input',
+        question: 'What behavior and edge cases should the implementation preserve?',
+        summary: 'The short request needs one product clarification.',
+    });
+    process.exit(0);
+}
+
+if (stage === 'direct') {
+    writeFileSync(join(workspace, 'feature.txt'), `${caseId} implemented\n`);
+    command('npm', ['test']);
+    finish({ status: 'complete', question: '', summary: 'Implemented and verified the direct arm.' });
+    process.exit(0);
+}
+
+if (stage === 'implement') {
+    command('gh', ['issue', 'view', '1', '--json', 'number,title,state,url,labels,milestone,body']);
+    command('gh', ['issue', 'edit', '1', '--remove-label', 'status:ready,status:in-progress,status:in-review,status:needs-decision,status:blocked']);
+    command('gh', ['issue', 'edit', '1', '--add-label', 'status:in-progress']);
+    command('git', ['checkout', '-b', `eval/${caseId}`]);
+    writeFileSync(join(workspace, 'feature.txt'), `${caseId} implemented\n`);
+    command('npm', ['test']);
+    finish({ status: 'complete', question: '', summary: 'Implemented the shaped issue and ran the gate.' });
+    process.exit(0);
+}
+
+if (stage === 'review') {
+    command('git', ['status', '--short']);
+    command('git', ['diff', '--stat']);
+    finish({ status: 'complete', question: '', summary: 'Review found one bounded edge-case hardening item.' });
+    process.exit(0);
+}
+
+if (stage === 'patch') {
+    appendFileSync(join(workspace, 'feature.txt'), 'review finding patched\n');
+    command('npm', ['test']);
+    finish({ status: 'complete', question: '', summary: 'Patched the review finding and reran the gate.' });
+    process.exit(0);
+}
+
+if (stage === 'done') {
+    command('gh', ['issue', 'view', '1', '--json', 'number,title,state,url,labels,milestone,body']);
+    command('git', ['add', 'feature.txt']);
+    command('git', ['commit', '-m', `fix: complete ${caseId} pipeline fixture`]);
+    command('git', ['push', '-u', 'origin', `eval/${caseId}`]);
+    command('gh', ['pr', 'create', '--head', `eval/${caseId}`, '--base', 'main', '--title', `Fix ${caseId}`, '--body', 'Closes #1']);
+    command('gh', ['issue', 'edit', '1', '--remove-label', 'status:ready,status:in-progress,status:in-review,status:needs-decision,status:blocked']);
+    command('gh', ['issue', 'edit', '1', '--add-label', 'status:in-review']);
+    command('gh', ['issue', 'comment', '1', '--body', 'PR: https://example.invalid/pipeline-eval/pull/1']);
+    if (caseId !== 'sik-133') {
+        command('gh', ['pr', 'checks', '1', '--watch', '--interval', '30', '--fail-fast']);
+        command('gh', ['pr', 'merge', '1', '--squash', '--delete-branch']);
+        command('git', ['checkout', 'main']);
+        command('git', ['fetch', 'origin']);
+        command('git', ['reset', '--hard', 'origin/main']);
+    }
+    finish({ status: 'complete', question: '', summary: 'Committed, recorded the local push, and opened the fake PR.' });
+    process.exit(0);
+}
+
+console.error(`unknown fake pipeline stage: ${stage}`);
+process.exit(2);

--- a/eval/pipeline/protocol.json
+++ b/eval/pipeline/protocol.json
@@ -1,0 +1,272 @@
+{
+  "version": 1,
+  "study_id": "songsiknow-full-pipeline-pilot-v1",
+  "claim": "For short, underspecified coding requests, a frozen intake-to-cycle workflow can improve verified task completion, decision handling, regression coverage, scope control, and evidence quality relative to direct implementation prompts.",
+  "census_path": "CENSUS.md",
+  "source": {
+    "repository": "https://github.com/brndnsh-labs/songsiknow.git",
+    "pipeline_guidance_commit": "31513e80e7d425bb04aeb71792776c8950cdca6e",
+    "pipeline_guidance_paths": [
+      "AGENTS.md",
+      "CLAUDE.md",
+      ".cycle/config.jsonc",
+      ".agents/skills/DOCTRINE.md",
+      ".agents/skills/FILING.md",
+      ".agents/skills/DELIVERY.md",
+      ".agents/skills/intake/SKILL.md",
+      ".agents/skills/implement/SKILL.md",
+      ".agents/skills/review/SKILL.md",
+      ".agents/skills/patch/SKILL.md",
+      ".agents/skills/done/SKILL.md",
+      ".agents/skills/cycle/SKILL.md"
+    ],
+    "excluded_fixture_paths": [
+      ".agents",
+      ".claude",
+      ".codex",
+      ".cycle",
+      ".git",
+      "AGENTS.md",
+      "CLAUDE.md",
+      "node_modules"
+    ]
+  },
+  "prompts": {
+    "direct_path": "direct-prompt.md",
+    "stage_path": "stage-prompt.md",
+    "turn_schema_path": "turn.schema.json"
+  },
+  "arms": [
+    {
+      "id": "raw-direct",
+      "input": "reconstructed raw request",
+      "workflow": "generic direct implementation"
+    },
+    {
+      "id": "shaped-direct",
+      "input": "exact issue title and body bytes created by the frozen intake session",
+      "workflow": "generic direct implementation"
+    },
+    {
+      "id": "full-cycle",
+      "input": "the same exact issue title and body bytes as shaped-direct",
+      "workflow": "four resumed stages: implement, review, patch, done"
+    }
+  ],
+  "schedule": {
+    "seed": "songsiknow-full-pipeline-pilot-v1-2026-08-30",
+    "case_order": ["sik-133", "sik-131", "sik-139", "sik-123"],
+    "arms_per_case": 3,
+    "cases_per_batch": 1,
+    "invalid_case_retry_limit": 1,
+    "resume_rule": "Each invocation completes exactly one case across intake and all three arms. Resume only from an exact validated prefix. An active-case marker stops before any repeated model turn.",
+    "retry_rule": "Preserve every invalid attempt and retry the entire case once. If the retry is invalid, stop incomplete and do not score either attempt."
+  },
+  "execution": {
+    "model": "gpt-5.6-sol",
+    "reasoning_effort": "high",
+    "codex_version": "codex-cli 0.150.1",
+    "timeout_ms_per_turn": 900000,
+    "fixture_commit_time": "2026-08-30T12:00:00Z",
+    "subagents": false,
+    "command_network": false,
+    "workspace_access": "read-write exact candidate root only",
+    "dependency_install": "full physical copy of the selected local node_modules tree into each workspace; no symlink, hardlink, or shared root",
+    "intake": {
+      "fresh_session": true,
+      "resumable": true,
+      "max_followups_per_stage": 3,
+      "output_contract": "turn.schema.json"
+    },
+    "raw_direct": {
+      "fresh_session": true,
+      "resumable": true,
+      "answer_responder": true
+    },
+    "shaped_direct": {
+      "fresh_session": true,
+      "resumable": true,
+      "answer_responder": true
+    },
+    "full_cycle": {
+      "fresh_session": true,
+      "resumed_stages": ["implement", "review", "patch", "done"],
+      "snapshots_after": ["implement", "review", "patch", "done"],
+      "answer_responder": true
+    }
+  },
+  "scoring": {
+    "schema_path": "score.schema.json",
+    "primary": "Whether the evaluator-owned hidden regression oracle passes against the arm's final source tree.",
+    "process_quality": {
+      "scope_control": "Avoid unrelated production changes and preserve stated non-goals.",
+      "decision_handling": "Identify and resolve material ambiguity without silently inventing policy.",
+      "test_quality": "Add regression coverage that targets the failure mechanism rather than only the happy path.",
+      "evidence_quality": "Report commands and outcomes that are supported by captured execution evidence."
+    },
+    "separate_measures": [
+      "model turns started and completed",
+      "token usage when reported",
+      "elapsed time",
+      "changed paths",
+      "test and gate command evidence",
+      "full-cycle stage deltas"
+    ],
+    "blinding": "After all four cases are valid, deterministically assign opaque case and arm labels. Expose only allowlisted issue text, normalized final diffs, hidden-oracle outcomes, and command evidence to two independent scorers.",
+    "analysis": "Report four matched case tables and qualitative mechanisms. Do not combine measures into one score, claim statistical significance, or infer population prevalence."
+  },
+  "privacy": {
+    "public_allowlist": [
+      "protocol and census",
+      "path-scrubbed preflight summary",
+      "normalized scoring packet and score schema",
+      "reviewed aggregate report"
+    ],
+    "private_only": [
+      "raw events and stderr",
+      "per-turn measures and host paths",
+      "arm ordering and blinding map",
+      "tracker transcript and created issue bytes",
+      "Codex home and authentication symlink"
+    ],
+    "credential_rule": "Codex authentication remains an outer-client symlink in a mode-0700 disposable home. It is never copied into a candidate, inherited by model-generated commands, or persisted before credential-fingerprint scanning."
+  },
+  "invalidation": {
+    "turn": [
+      "nonzero exit or timeout",
+      "malformed JSONL or missing turn.started or turn.completed",
+      "missing or schema-invalid final response",
+      "unmatched question or follow-up limit exceeded"
+    ],
+    "case": [
+      "intake did not create exactly one issue",
+      "shaped-direct and full-cycle did not receive byte-identical issue title and body text",
+      "required full-cycle stage or snapshot is missing",
+      "candidate repository gained a remote, later object, credential, symlinked dependency tree, or writable evaluator asset"
+    ],
+    "experiment": [
+      "artifact-lock mismatch",
+      "hidden-oracle base-fail repair-pass or mutation proof failure",
+      "filesystem or command-network isolation probe failure",
+      "resume state, artifact hash, protocol, model, effort, CLI version, or schedule mismatch"
+    ]
+  },
+  "cases": [
+    {
+      "id": "sik-133",
+      "issue": 133,
+      "title": "Bound raw Stripe webhook bodies",
+      "raw_prompt_path": "raw-prompts/sik-133.md",
+      "canonical_issue_path": "canonical-issues/sik-133.md",
+      "answer_sheet_path": "answers/sik-133.json",
+      "base": "eb1b11c2dd53c542452e1212925ad53dc454821c",
+      "repair": "ef808807a0662f25fa3810101d0eace958bf155d",
+      "repair_paths": [
+        "src/app/api/payments/webhook/route.ts",
+        "src/lib/payments/webhook-body.ts"
+      ],
+      "oracle_paths": ["src/app/api/payments/webhook/route.test.ts"],
+      "oracle_commands": ["npx vitest run src/app/api/payments/webhook/route.test.ts"]
+    },
+    {
+      "id": "sik-131",
+      "issue": 131,
+      "title": "Make FilterPopover clear actions independent",
+      "raw_prompt_path": "raw-prompts/sik-131.md",
+      "canonical_issue_path": "canonical-issues/sik-131.md",
+      "answer_sheet_path": "answers/sik-131.json",
+      "base": "a724994a53b197f3b5467cd634e4925f6c904e8a",
+      "repair": "2ca6aa20eda638bee51bdaec886137eff0b1e2ff",
+      "repair_paths": ["src/components/library/FilterPopover.tsx"],
+      "oracle_paths": ["src/components/library/FilterPopover.test.tsx"],
+      "oracle_commands": ["npx vitest run src/components/library/FilterPopover.test.tsx"]
+    },
+    {
+      "id": "sik-139",
+      "issue": 139,
+      "title": "Bound blocked IndexedDB opens",
+      "raw_prompt_path": "raw-prompts/sik-139.md",
+      "canonical_issue_path": "canonical-issues/sik-139.md",
+      "answer_sheet_path": "answers/sik-139.json",
+      "base": "6de1d1c79b999677896e3366c1d2c707dc233edf",
+      "repair": "142078c3f3b6f5df3d272814162b1c3d6620304b",
+      "repair_paths": [
+        "src/app/layout.tsx",
+        "src/components/layout/StorageBlockedToastMount.tsx",
+        "src/lib/stems/storage-events.ts",
+        "src/lib/stems/store.ts"
+      ],
+      "oracle_paths": [
+        "src/components/layout/StorageBlockedToastMount.test.tsx",
+        "src/lib/stems/store.test.ts"
+      ],
+      "oracle_commands": [
+        "npx vitest run src/lib/stems/store.test.ts src/components/layout/StorageBlockedToastMount.test.tsx"
+      ]
+    },
+    {
+      "id": "sik-123",
+      "issue": 123,
+      "title": "Grow the shared Drawer close target",
+      "raw_prompt_path": "raw-prompts/sik-123.md",
+      "canonical_issue_path": "canonical-issues/sik-123.md",
+      "answer_sheet_path": "answers/sik-123.json",
+      "base": "655d38300d94b724fa3148e0dac5f10165464606",
+      "repair": "6f8bf57d4368b1507feb14228733b6f25d37e215",
+      "repair_paths": ["src/components/ui/drawer.tsx"],
+      "oracle_paths": ["src/components/ui/drawer.test.tsx"],
+      "oracle_commands": ["npx vitest run src/components/ui/drawer.test.tsx"]
+    }
+  ],
+  "artifact_lock": {
+    "runner_sha256": "2fc240e5d0589c630d3c117dcc5006ada5295a56704d5cd272d9355da1453b70",
+    "fake_codex_sha256": "e65f1997e33c6f4a7736a7f2181d87c7279712027d85276ddf1c0f3964723204",
+    "fake_tracker_sha256": "348839290d85bff664edef0474cb148d5b1c46410cb7c3830c45c16c3bb97f97",
+    "fake_git_sha256": "47ec70403d0bf70dd6624d28d2ec9809eac2353a3fbac91b126cd3f0f7929c4f",
+    "census_sha256": "e42323abc27318d48769bdaef231d897645111721454e0b4bacd6265cd164fcc",
+    "direct_prompt_sha256": "a7b38e269d6e8d95ce7c83fa75d2f2d80aa37c1a2a0cf94f3c536d0eccab79cf",
+    "stage_prompt_sha256": "ae218d4ed179519db48150060e7a1bdf46a5958d584498895156a8e0988b5e87",
+    "turn_schema_sha256": "81192f93ffcde962204d333c87270c197553108638b226faa199f52539f6d3d4",
+    "score_schema_sha256": "5b837720daf02407e0a956d2224a1a245478557846dc1ace40ac4a074667d960",
+    "pipeline_guidance_sha256": "5a71931cf22a3afe2f174d4cd4828e7de7f43aa85a7697a01a6fc171f54c7212",
+    "dependency_manifest_sha256": "0933e5e95f2e8a40cadf822593837dfd06821c0ba44e647f4f0d97257aadfd54",
+    "cases": {
+      "sik-133": {
+        "raw_prompt_sha256": "2621d4fd6c8a1edbd9bfa79470abb022fe0c31b5bcc4295b6db99bdd5f1f6029",
+        "canonical_issue_sha256": "904bed1a59740efe017ebca9d58ce4acddceec411b038af615ec7139c8399a75",
+        "answer_sheet_sha256": "120b65add9eac2d3e94215ebd6c1971def847e9acd8b7b40b181d352259f8cd8",
+        "base_tree_sha256": "d727a3b7fccb127ee1b190f4e4c92b0407b59100a8fe25b38ee4a7721dba784a",
+        "repair_patch_sha256": "fce7d8a6bfe1aed81e7669506b38a626efb8ac6c28abea03fd26b6a96f805381",
+        "oracle_patch_sha256": "a1de573a500e04bdfcfed7c05c55e36ac408d831910a2478cded0c7db6b82b2f",
+        "aggregate_sha256": "963d49247afb820d65de04b12b60884108735cd1eaa92878d9630d64a966f29b"
+      },
+      "sik-131": {
+        "raw_prompt_sha256": "3b7c057fe3ddeba5e26242c9d6cbcc57f457c54e632c5fc3db8bf3844ff86966",
+        "canonical_issue_sha256": "de5d69e907ffaf32f4de7c994b332712cb7e461d2c60f8c757a71857afb60da5",
+        "answer_sheet_sha256": "c51df6ae1a207d3a61cf1b41ffbd127b5fc4d179f6498cc54f68797021288a62",
+        "base_tree_sha256": "e3a6786ffc292b1ef3f4a3d190815d51854929024f10f7a8a4617e8d906d7a83",
+        "repair_patch_sha256": "516de23d2f60ce365ee08db07e7d0a46088a9cb19ce606156e84c49f663580bf",
+        "oracle_patch_sha256": "5c5b2ae39845e383f235a8a754237b57c01b35bd95cd9ef0a8a93bb4d4e9376d",
+        "aggregate_sha256": "b864efa134fa9bb51ab5a65e9bc596e02a7e23338134205fe3408e557159e8fe"
+      },
+      "sik-139": {
+        "raw_prompt_sha256": "e4d88af817f2be9042956d389798f50f4e85af9dcc6ae10ae623ada6f09bdd10",
+        "canonical_issue_sha256": "48487cad0f67183e2c6ec551ec983431db265cab78e8227a7bb06a3125425daf",
+        "answer_sheet_sha256": "fe3b336a418bebf9733d220a3c112e67de1c1e1bd2c36e3046c1c10ae4bb446f",
+        "base_tree_sha256": "bf93a178035b3656b6b56d369c46d73dfa6de1462f9f999696199ed39f9c9fd7",
+        "repair_patch_sha256": "b8fe7262699c9332b78af3a85923ad42d4460391d3bbb64617d0c2a1beed8c53",
+        "oracle_patch_sha256": "8224503a867cd90297f14de8b2d2a6fac341604073cf1021d853d06f0944d043",
+        "aggregate_sha256": "6d3ab94877720727e34cae5f206f842fd1baf815c94ca8a3ab3af4b38e7b9117"
+      },
+      "sik-123": {
+        "raw_prompt_sha256": "db21aab495bb398a5b65eb59cfa1d40befb8ca74af9b05ecd28f5e031446afc9",
+        "canonical_issue_sha256": "320ef6e50a877a2bd475e621f5c0f8f4ec4afddaa1986e3c5e78c7061c18e320",
+        "answer_sheet_sha256": "31d473e6b8cf0ff2304e92e099d6bc2cbb28dc2a57075367eda594648b725c4c",
+        "base_tree_sha256": "d4075334bf7bd746e05cf178a27edf040850a1d5f0f3e642b523a3941cb438b2",
+        "repair_patch_sha256": "fefb95eb5813d42dec8a43d98b728fd2844c39aab1986f87808cafbee17e4c9b",
+        "oracle_patch_sha256": "c0b7af5597f4149c03d2f9d175d55fd5f7587429c3379669e139d9c8f17f595e",
+        "aggregate_sha256": "f97fdab35d4832b834ab5072e8f821868b2513623854707b9acd31cd6ed9ba30"
+      }
+    }
+  }
+}

--- a/eval/pipeline/raw-prompts/sik-123.md
+++ b/eval/pipeline/raw-prompts/sik-123.md
@@ -1,0 +1,1 @@
+Make the Drawer Close button easier to tap.

--- a/eval/pipeline/raw-prompts/sik-131.md
+++ b/eval/pipeline/raw-prompts/sik-131.md
@@ -1,0 +1,1 @@
+Fix the filter clear button.

--- a/eval/pipeline/raw-prompts/sik-133.md
+++ b/eval/pipeline/raw-prompts/sik-133.md
@@ -1,0 +1,1 @@
+Protect the Stripe webhook from oversized bodies.

--- a/eval/pipeline/raw-prompts/sik-139.md
+++ b/eval/pipeline/raw-prompts/sik-139.md
@@ -1,0 +1,1 @@
+Stop IndexedDB upgrades from hanging forever.

--- a/eval/pipeline/run.mjs
+++ b/eval/pipeline/run.mjs
@@ -1,0 +1,2795 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { spawn, spawnSync } from 'node:child_process';
+import {
+    chmodSync,
+    closeSync,
+    existsSync,
+    lstatSync,
+    mkdirSync,
+    mkdtempSync,
+    openSync,
+    readFileSync,
+    readdirSync,
+    readlinkSync,
+    realpathSync,
+    renameSync,
+    rmSync,
+    statSync,
+    symlinkSync,
+    unlinkSync,
+    writeFileSync,
+} from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { parseArgs } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '..', '..');
+const DEFAULT_PROTOCOL = join(HERE, 'protocol.json');
+const DEFAULT_FAKE_CODEX = join(HERE, 'fake-codex.cjs');
+const FAKE_BIN = join(HERE, 'bin');
+const MAX_BUFFER = 128 * 1024 * 1024;
+const MAX_CAPTURE_FILE = 16 * 1024 * 1024;
+const MAX_GIT_CONTROL_ENTRIES = 100_000;
+const TREE_CACHE = new Map();
+const PATCH_CACHE = new Map();
+
+export class PipelineEvalError extends Error {}
+
+function fail(message) {
+    throw new PipelineEvalError(message);
+}
+
+function run(command, args, {
+    cwd = ROOT,
+    env = process.env,
+    input,
+    encoding = 'utf8',
+    timeout,
+    allowFailure = false,
+} = {}) {
+    const started = Date.now();
+    const result = spawnSync(command, args, {
+        cwd,
+        env,
+        input,
+        encoding,
+        timeout,
+        maxBuffer: MAX_BUFFER,
+    });
+    const elapsedMs = Date.now() - started;
+    if (result.error && !allowFailure) fail(`${command} failed to start: ${result.error.message}`);
+    if (result.status !== 0 && !allowFailure) {
+        const stderr = encoding === null ? result.stderr?.toString('utf8') : result.stderr;
+        const stdout = encoding === null ? result.stdout?.toString('utf8') : result.stdout;
+        fail(`${command} ${args.join(' ')} failed (${result.status})\n${stderr || stdout || ''}`.trimEnd());
+    }
+    return { ...result, elapsedMs };
+}
+
+function evaluatorGitEnvironment() {
+    return {
+        PATH: sanitizedPath(),
+        LANG: 'C.UTF-8',
+        LC_ALL: 'C.UTF-8',
+        HOME: '/nonexistent',
+        GIT_CONFIG_NOSYSTEM: '1',
+        GIT_CONFIG_GLOBAL: '/dev/null',
+        GIT_ATTR_NOSYSTEM: '1',
+        GIT_NO_REPLACE_OBJECTS: '1',
+        GIT_PAGER: 'cat',
+        PAGER: 'cat',
+        GIT_TERMINAL_PROMPT: '0',
+    };
+}
+
+function git(source, args, options = {}) {
+    const root = resolve(source);
+    const safeConfig = [
+        '-c', `core.worktree=${root}`,
+        '-c', 'core.bare=false',
+        '-c', 'core.fsmonitor=false',
+        '-c', 'core.hooksPath=/dev/null',
+        '-c', 'core.attributesFile=/dev/null',
+        '-c', 'core.excludesFile=/dev/null',
+        '-c', 'commit.gpgSign=false',
+        '-c', 'tag.gpgSign=false',
+        '-c', 'protocol.file.allow=never',
+    ];
+    return run('/usr/bin/git', ['-C', root, ...safeConfig, ...args], {
+        ...options,
+        env: options.env ?? evaluatorGitEnvironment(),
+    });
+}
+
+export function sha256(value) {
+    return createHash('sha256').update(value).digest('hex');
+}
+
+function stable(value) {
+    if (Array.isArray(value)) return value.map(stable);
+    if (value && typeof value === 'object') {
+        return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stable(value[key])]));
+    }
+    return value;
+}
+
+function stableJson(value) {
+    return JSON.stringify(stable(value));
+}
+
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+
+function ensureInside(root, path) {
+    const rel = relative(root, path);
+    if (!rel || rel === '..' || rel.startsWith(`..${sep}`)) fail(`unsafe path outside ${root}: ${path}`);
+}
+
+function protocolAsset(protocolPath, rel) {
+    if (!isNonEmptyString(rel) || rel.includes('\0')) fail(`invalid protocol asset path: ${rel}`);
+    const root = dirname(protocolPath);
+    const path = resolve(root, rel);
+    ensureInside(root, path);
+    if (!existsSync(path) || !lstatSync(path).isFile() || lstatSync(path).isSymbolicLink()) {
+        fail(`missing or unsafe protocol asset: ${rel}`);
+    }
+    return path;
+}
+
+export function validateProtocol(protocol, { requireLock = true } = {}) {
+    if (!protocol || typeof protocol !== 'object' || Array.isArray(protocol)) {
+        fail('pipeline protocol must be an object');
+    }
+    if (protocol.version !== 1 || protocol.study_id !== 'songsiknow-full-pipeline-pilot-v1'
+        || !isNonEmptyString(protocol.claim) || protocol.census_path !== 'CENSUS.md') {
+        fail('pipeline protocol has an invalid identity');
+    }
+    const expectedArms = ['raw-direct', 'shaped-direct', 'full-cycle'];
+    if (stableJson(protocol.arms?.map((arm) => arm.id)) !== stableJson(expectedArms)) {
+        fail('pipeline protocol must freeze the three arms in order');
+    }
+    const schedule = protocol.schedule;
+    if (!schedule || schedule.seed !== 'songsiknow-full-pipeline-pilot-v1-2026-08-30'
+        || stableJson(schedule.case_order) !== stableJson(['sik-133', 'sik-131', 'sik-139', 'sik-123'])
+        || schedule.arms_per_case !== 3 || schedule.cases_per_batch !== 1
+        || schedule.invalid_case_retry_limit !== 1) {
+        fail('pipeline protocol has an invalid frozen schedule');
+    }
+    const execution = protocol.execution;
+    if (!execution || execution.model !== 'gpt-5.6-sol'
+        || execution.reasoning_effort !== 'high'
+        || execution.codex_version !== 'codex-cli 0.150.1'
+        || !Number.isSafeInteger(execution.timeout_ms_per_turn)
+        || execution.timeout_ms_per_turn < 1
+        || execution.subagents !== false || execution.command_network !== false
+        || stableJson(execution.full_cycle?.resumed_stages)
+            !== stableJson(['implement', 'review', 'patch', 'done'])) {
+        fail('pipeline protocol has an invalid execution contract');
+    }
+    if (!protocol.source || !/^[0-9a-f]{40}$/.test(protocol.source.pipeline_guidance_commit ?? '')
+        || !Array.isArray(protocol.source.pipeline_guidance_paths)
+        || !Array.isArray(protocol.source.excluded_fixture_paths)) {
+        fail('pipeline protocol has an invalid source contract');
+    }
+    if (!protocol.prompts || !protocol.scoring || !protocol.privacy || !protocol.invalidation) {
+        fail('pipeline protocol is missing prompt, scoring, privacy, or invalidation rules');
+    }
+    if (!Array.isArray(protocol.cases) || protocol.cases.length !== 4) {
+        fail('pipeline protocol must freeze four cases');
+    }
+    const ids = new Set();
+    for (const item of protocol.cases) {
+        if (!isNonEmptyString(item.id) || ids.has(item.id)) fail(`invalid or duplicate case id: ${item.id}`);
+        ids.add(item.id);
+        if (!Number.isSafeInteger(item.issue)) fail(`case ${item.id} has an invalid issue number`);
+        for (const key of ['base', 'repair']) {
+            if (!/^[0-9a-f]{40}$/.test(item[key] ?? '')) fail(`case ${item.id} has invalid ${key}`);
+        }
+        for (const key of ['raw_prompt_path', 'canonical_issue_path', 'answer_sheet_path']) {
+            if (!isNonEmptyString(item[key])) fail(`case ${item.id} is missing ${key}`);
+        }
+        if (!Array.isArray(item.repair_paths) || !item.repair_paths.length
+            || !Array.isArray(item.oracle_paths) || !item.oracle_paths.length
+            || !Array.isArray(item.oracle_commands) || !item.oracle_commands.length) {
+            fail(`case ${item.id} is missing repair or oracle data`);
+        }
+    }
+    if (stableJson([...ids]) !== stableJson(schedule.case_order)) {
+        fail('pipeline case definitions must match the frozen case order');
+    }
+    if (!protocol.artifact_lock || typeof protocol.artifact_lock !== 'object') {
+        fail('pipeline protocol is missing artifact_lock');
+    }
+    if (requireLock && stableJson(protocol.artifact_lock).includes('PENDING')) {
+        fail('pipeline protocol artifact lock is not frozen');
+    }
+    return protocol;
+}
+
+export function loadProtocol(path = DEFAULT_PROTOCOL, options) {
+    const protocolPath = resolve(path);
+    let protocol;
+    try {
+        protocol = JSON.parse(readFileSync(protocolPath, 'utf8'));
+    } catch (error) {
+        fail(`cannot read protocol ${protocolPath}: ${error.message}`);
+    }
+    validateProtocol(protocol, options);
+    return { protocol, protocolPath };
+}
+
+function isExcluded(path, excluded) {
+    return excluded.some((entry) => path === entry || path.startsWith(`${entry}/`));
+}
+
+function treeEntries(source, revision, excluded) {
+    const key = stableJson([resolve(source), revision, excluded]);
+    if (TREE_CACHE.has(key)) return TREE_CACHE.get(key);
+    const listing = git(source, ['ls-tree', '-r', '-z', '--full-tree', revision]).stdout;
+    const entries = [];
+    for (const record of listing.split('\0').filter(Boolean)) {
+        const match = /^(\d{6}) (\w+) ([0-9a-f]{40})\t(.+)$/.exec(record);
+        if (!match) fail(`cannot parse source tree record at ${revision}`);
+        const [, mode, type, object, path] = match;
+        if (isExcluded(path, excluded)) continue;
+        if (type !== 'blob' || mode === '120000') fail(`unsupported ${type} or symlink in source: ${path}`);
+        const content = git(source, ['show', `${revision}:${path}`], { encoding: null }).stdout;
+        entries.push({ mode, object, path, content });
+    }
+    TREE_CACHE.set(key, entries);
+    return entries;
+}
+
+function treeDigest(entries) {
+    const hash = createHash('sha256');
+    for (const entry of entries) {
+        hash.update(entry.mode);
+        hash.update('\0');
+        hash.update(entry.path);
+        hash.update('\0');
+        hash.update(entry.content);
+        hash.update('\0');
+    }
+    return hash.digest('hex');
+}
+
+function patchBetween(source, from, to, paths) {
+    const key = stableJson([resolve(source), from, to, paths]);
+    if (PATCH_CACHE.has(key)) return PATCH_CACHE.get(key);
+    const patch = git(source, [
+        'diff', '--binary', '--full-index', '--no-ext-diff', '--no-textconv', '--no-renames',
+        from, to, '--', ...paths,
+    ], { encoding: null }).stdout;
+    if (!patch.length) fail(`empty patch from ${from} to ${to} for ${paths.join(', ')}`);
+    PATCH_CACHE.set(key, patch);
+    return patch;
+}
+
+function hashNamedFiles(source, revision, paths) {
+    const hash = createHash('sha256');
+    for (const path of [...paths].sort()) {
+        const content = git(source, ['show', `${revision}:${path}`], { encoding: null }).stdout;
+        hash.update(path);
+        hash.update('\0');
+        hash.update(content);
+        hash.update('\0');
+    }
+    return hash.digest('hex');
+}
+
+function repairParent(source, revision) {
+    const parents = git(source, ['show', '-s', '--format=%P', revision]).stdout.trim().split(/\s+/).filter(Boolean);
+    if (parents.length !== 1) fail(`repair ${revision} must have exactly one parent`);
+    return parents[0];
+}
+
+export function verifySource(source, protocol) {
+    const root = resolve(source);
+    if (!existsSync(root) || !statSync(root).isDirectory()) fail(`source is not a directory: ${source}`);
+    if (git(root, ['rev-parse', '--is-inside-work-tree'], { allowFailure: true }).status !== 0) {
+        fail(`source is not a Git repository: ${source}`);
+    }
+    const refs = new Set([
+        protocol.source.pipeline_guidance_commit,
+        ...protocol.cases.flatMap((item) => [item.base, item.repair]),
+    ]);
+    for (const revision of refs) {
+        if (git(root, ['cat-file', '-e', `${revision}^{commit}`], { allowFailure: true }).status !== 0) {
+            fail(`source is missing required commit ${revision}`);
+        }
+    }
+    for (const item of protocol.cases) {
+        if (repairParent(root, item.repair) !== item.base) {
+            fail(`case ${item.id} repair is not a direct child of its frozen base`);
+        }
+    }
+    const dependencies = join(root, 'node_modules');
+    if (!existsSync(dependencies) || !lstatSync(dependencies).isDirectory()
+        || lstatSync(dependencies).isSymbolicLink()) {
+        fail(`source needs a physical node_modules tree: ${dependencies}`);
+    }
+    return root;
+}
+
+export function computeArtifactLock(protocol, protocolPath, source) {
+    const root = verifySource(source, protocol);
+    const lock = {
+        runner_sha256: sha256(readFileSync(fileURLToPath(import.meta.url))),
+        fake_codex_sha256: sha256(readFileSync(DEFAULT_FAKE_CODEX)),
+        fake_tracker_sha256: hashLocalFiles([join(FAKE_BIN, 'gh'), join(FAKE_BIN, 'fake-gh.cjs')]),
+        fake_git_sha256: sha256(readFileSync(join(FAKE_BIN, 'git'))),
+        census_sha256: sha256(readFileSync(protocolAsset(protocolPath, protocol.census_path))),
+        direct_prompt_sha256: sha256(readFileSync(protocolAsset(protocolPath, protocol.prompts.direct_path))),
+        stage_prompt_sha256: sha256(readFileSync(protocolAsset(protocolPath, protocol.prompts.stage_path))),
+        turn_schema_sha256: sha256(readFileSync(protocolAsset(protocolPath, protocol.prompts.turn_schema_path))),
+        score_schema_sha256: sha256(readFileSync(protocolAsset(protocolPath, protocol.scoring.schema_path))),
+        pipeline_guidance_sha256: hashNamedFiles(
+            root,
+            protocol.source.pipeline_guidance_commit,
+            protocol.source.pipeline_guidance_paths,
+        ),
+        dependency_manifest_sha256: sha256(readFileSync(join(root, 'node_modules', '.package-lock.json'))),
+        cases: {},
+    };
+    for (const item of protocol.cases) {
+        const caseHash = createHash('sha256');
+        const fields = {
+            raw_prompt_sha256: sha256(readFileSync(protocolAsset(protocolPath, item.raw_prompt_path))),
+            canonical_issue_sha256: sha256(readFileSync(protocolAsset(protocolPath, item.canonical_issue_path))),
+            answer_sheet_sha256: sha256(readFileSync(protocolAsset(protocolPath, item.answer_sheet_path))),
+            base_tree_sha256: treeDigest(treeEntries(root, item.base, protocol.source.excluded_fixture_paths)),
+            repair_patch_sha256: sha256(patchBetween(root, item.base, item.repair, item.repair_paths)),
+            oracle_patch_sha256: sha256(patchBetween(root, item.base, item.repair, item.oracle_paths)),
+        };
+        for (const [name, digest] of Object.entries(fields)) {
+            caseHash.update(name);
+            caseHash.update('\0');
+            caseHash.update(digest);
+            caseHash.update('\0');
+        }
+        lock.cases[item.id] = { ...fields, aggregate_sha256: caseHash.digest('hex') };
+    }
+    return lock;
+}
+
+function hashLocalFiles(paths) {
+    const hash = createHash('sha256');
+    for (const path of paths) {
+        hash.update(relative(HERE, path));
+        hash.update('\0');
+        hash.update(readFileSync(path));
+        hash.update('\0');
+    }
+    return hash.digest('hex');
+}
+
+export function assertLocalArtifactLock(protocol, protocolPath) {
+    const actual = {
+        runner_sha256: sha256(readFileSync(fileURLToPath(import.meta.url))),
+        fake_codex_sha256: sha256(readFileSync(DEFAULT_FAKE_CODEX)),
+        fake_tracker_sha256: hashLocalFiles([join(FAKE_BIN, 'gh'), join(FAKE_BIN, 'fake-gh.cjs')]),
+        fake_git_sha256: sha256(readFileSync(join(FAKE_BIN, 'git'))),
+        census_sha256: sha256(readFileSync(protocolAsset(protocolPath, protocol.census_path))),
+        direct_prompt_sha256: sha256(readFileSync(protocolAsset(protocolPath, protocol.prompts.direct_path))),
+        stage_prompt_sha256: sha256(readFileSync(protocolAsset(protocolPath, protocol.prompts.stage_path))),
+        turn_schema_sha256: sha256(readFileSync(protocolAsset(protocolPath, protocol.prompts.turn_schema_path))),
+        score_schema_sha256: sha256(readFileSync(protocolAsset(protocolPath, protocol.scoring.schema_path))),
+    };
+    for (const [key, digest] of Object.entries(actual)) {
+        if (protocol.artifact_lock[key] !== digest) fail(`local artifact lock mismatch: ${key}`);
+    }
+    for (const item of protocol.cases) {
+        const expected = protocol.artifact_lock.cases?.[item.id];
+        const assets = {
+            raw_prompt_sha256: sha256(readFileSync(protocolAsset(protocolPath, item.raw_prompt_path))),
+            canonical_issue_sha256: sha256(readFileSync(protocolAsset(protocolPath, item.canonical_issue_path))),
+            answer_sheet_sha256: sha256(readFileSync(protocolAsset(protocolPath, item.answer_sheet_path))),
+        };
+        for (const [key, digest] of Object.entries(assets)) {
+            if (expected?.[key] !== digest) fail(`local artifact lock mismatch: ${item.id}.${key}`);
+        }
+    }
+    return actual;
+}
+
+export function assertArtifactLock(protocol, protocolPath, source) {
+    const actual = computeArtifactLock(protocol, protocolPath, source);
+    if (stableJson(actual) !== stableJson(protocol.artifact_lock)) {
+        fail(`artifact lock mismatch\nexpected ${stableJson(protocol.artifact_lock)}\nactual   ${stableJson(actual)}`);
+    }
+    return actual;
+}
+
+function writeTree(destination, entries) {
+    for (const entry of entries) {
+        const path = resolve(destination, entry.path);
+        ensureInside(destination, path);
+        mkdirSync(dirname(path), { recursive: true });
+        writeFileSync(path, entry.content);
+        chmodSync(path, entry.mode === '100755' ? 0o755 : 0o644);
+    }
+}
+
+function writePipelineGuidance(destination, source, protocol) {
+    for (const rel of protocol.source.pipeline_guidance_paths) {
+        const path = resolve(destination, rel);
+        ensureInside(destination, path);
+        mkdirSync(dirname(path), { recursive: true });
+        writeFileSync(
+            path,
+            git(source, ['show', `${protocol.source.pipeline_guidance_commit}:${rel}`], { encoding: null }).stdout,
+        );
+    }
+}
+
+const NEUTRAL_AGENTS = `# Full-pipeline evaluation fixture
+
+This is an isolated historical repository. Implement only the request supplied by the evaluator.
+Do not use the network, inspect paths outside this repository, or invent a project workflow.
+Run focused regression coverage and relevant local gates. Do not commit or push unless asked.
+`;
+
+function gitEnvironment(commitTime) {
+    return {
+        ...evaluatorGitEnvironment(),
+        GIT_AUTHOR_NAME: 'Pipeline Fixture',
+        GIT_AUTHOR_EMAIL: 'pipeline@example.invalid',
+        GIT_COMMITTER_NAME: 'Pipeline Fixture',
+        GIT_COMMITTER_EMAIL: 'pipeline@example.invalid',
+        GIT_AUTHOR_DATE: commitTime,
+        GIT_COMMITTER_DATE: commitTime,
+    };
+}
+
+function initializeRepository(destination, commitTime) {
+    const env = gitEnvironment(commitTime);
+    const template = privateDirectory('cycle-pipeline-git-template-');
+    try {
+        run('/usr/bin/git', ['init', '-q', '--template', template, '-b', 'main'], { cwd: destination, env });
+        run('/usr/bin/git', ['config', 'user.name', 'Pipeline Fixture'], { cwd: destination, env });
+        run('/usr/bin/git', ['config', 'user.email', 'pipeline@example.invalid'], { cwd: destination, env });
+        run('/usr/bin/git', ['config', 'core.logAllRefUpdates', 'false'], { cwd: destination, env });
+        run('/usr/bin/git', ['config', 'core.hooksPath', '/dev/null'], { cwd: destination, env });
+        run('/usr/bin/git', ['config', 'core.autocrlf', 'false'], { cwd: destination, env });
+        run('/usr/bin/git', ['config', 'commit.gpgSign', 'false'], { cwd: destination, env });
+        run('/usr/bin/git', ['add', '--', '.'], { cwd: destination, env });
+        run('/usr/bin/git', ['commit', '-q', '--no-verify', '-m', 'fixture: frozen historical base'], {
+            cwd: destination,
+            env,
+        });
+        return git(destination, ['rev-parse', 'HEAD']).stdout.trim();
+    } finally {
+        rmSync(template, { recursive: true, force: true });
+    }
+}
+
+function gitDirectoryIdentity(workspace) {
+    const path = join(workspace, '.git');
+    if (!existsSync(path)) fail('candidate repository lost its .git directory');
+    const stat = lstatSync(path);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+        fail('candidate repository replaced its .git control directory');
+    }
+    return { dev: stat.dev, ino: stat.ino };
+}
+
+const SAFE_CANDIDATE_GIT_CONFIG = `[core]
+\trepositoryformatversion = 0
+\tfilemode = true
+\tbare = false
+\tlogallrefupdates = false
+\thooksPath = /dev/null
+\tautocrlf = false
+[user]
+\tname = Pipeline Candidate
+\temail = candidate@example.invalid
+[commit]
+\tgpgSign = false
+[tag]
+\tgpgSign = false
+`;
+
+export function sanitizeCandidateRepository(workspace, expectedIdentity) {
+    const gitDir = join(workspace, '.git');
+    const actual = gitDirectoryIdentity(workspace);
+    if (!expectedIdentity || actual.dev !== expectedIdentity.dev || actual.ino !== expectedIdentity.ino) {
+        fail('candidate repository changed its .git control directory identity');
+    }
+    for (const rel of ['objects/info/alternates', 'info/grafts', 'shallow', 'logs']) {
+        if (existsSync(join(gitDir, rel))) fail(`candidate repository created forbidden .git/${rel}`);
+    }
+    const queue = [gitDir];
+    let entries = 0;
+    while (queue.length) {
+        const directory = queue.pop();
+        for (const entry of readdirSync(directory, { withFileTypes: true })) {
+            entries += 1;
+            if (entries > MAX_GIT_CONTROL_ENTRIES) fail('candidate .git control tree is unexpectedly large');
+            const path = join(directory, entry.name);
+            if (entry.isDirectory()) queue.push(path);
+            else if (entry.isFile()) {
+                if (lstatSync(path).nlink !== 1) fail('candidate .git control tree contains a hard-linked file');
+            } else {
+                fail('candidate .git control tree contains a link or special file');
+            }
+        }
+    }
+    const config = join(gitDir, 'config');
+    if (existsSync(config)) unlinkSync(config);
+    writeFileSync(config, SAFE_CANDIDATE_GIT_CONFIG, { flag: 'wx', mode: 0o600 });
+    return actual;
+}
+
+export function assertHistoryTruncated(workspace, forbiddenCommits = [], {
+    expectedCommitCount = null,
+    expectedRoot = null,
+} = {}) {
+    const commits = git(workspace, ['rev-list', '--all']).stdout.trim().split('\n').filter(Boolean);
+    if (!commits.length) fail('fixture repository has no commit');
+    if (expectedCommitCount !== null && commits.length !== expectedCommitCount) {
+        fail(`fixture repository has ${commits.length} commits instead of ${expectedCommitCount}`);
+    }
+    const roots = git(workspace, ['rev-list', '--max-parents=0', '--all']).stdout.trim().split('\n').filter(Boolean);
+    if (expectedRoot && stableJson(roots) !== stableJson([expectedRoot])) {
+        fail('candidate history no longer has exactly the frozen base root');
+    }
+    if (git(workspace, ['remote']).stdout.trim()) fail('fixture repository has a remote');
+    if (git(workspace, ['tag', '--list']).stdout.trim()) fail('fixture repository has tags');
+    const refs = git(workspace, ['for-each-ref', '--format=%(refname)']).stdout.trim().split('\n').filter(Boolean);
+    if (refs.some((ref) => !ref.startsWith('refs/heads/'))) fail('fixture repository has a non-local-branch ref');
+    const alternates = join(workspace, '.git', 'objects', 'info', 'alternates');
+    if (existsSync(alternates)) fail('fixture repository has object alternates');
+    for (const rel of ['.git/shallow', '.git/logs']) {
+        if (existsSync(join(workspace, rel))) fail(`fixture repository unexpectedly contains ${rel}`);
+    }
+    for (const revision of forbiddenCommits) {
+        if (git(workspace, ['cat-file', '-e', `${revision}^{commit}`], { allowFailure: true }).status === 0) {
+            fail(`fixture contains forbidden historical object ${revision}`);
+        }
+    }
+    return { commits: commits.length, remotes: 0, tags: 0, alternates: false };
+}
+
+function writeFixtureMetadata(destination, protocol, protocolPath, mode) {
+    mkdirSync(join(destination, '.pipeline-eval'), { recursive: true });
+    writeFileSync(
+        join(destination, '.pipeline-eval', 'turn.schema.json'),
+        readFileSync(protocolAsset(protocolPath, protocol.prompts.turn_schema_path)),
+    );
+    if (mode === 'neutral') writeFileSync(join(destination, 'AGENTS.md'), NEUTRAL_AGENTS);
+}
+
+export function materializeFixture({
+    protocol,
+    protocolPath,
+    source,
+    caseId,
+    mode,
+    destination,
+    dependencies = false,
+}) {
+    const item = protocol.cases.find((entry) => entry.id === caseId);
+    if (!item) fail(`unknown case: ${caseId}`);
+    mkdirSync(destination, { recursive: true });
+    const entries = treeEntries(source, item.base, protocol.source.excluded_fixture_paths);
+    writeTree(destination, entries);
+    if (mode === 'pipeline') writePipelineGuidance(destination, source, protocol);
+    writeFixtureMetadata(destination, protocol, protocolPath, mode);
+    const initialCommit = initializeRepository(destination, protocol.execution.fixture_commit_time);
+    const history = assertHistoryTruncated(
+        destination,
+        [item.repair, protocol.source.pipeline_guidance_commit],
+        { expectedCommitCount: 1, expectedRoot: initialCommit },
+    );
+    const dependency = dependencies ? cloneDependencies(source, destination) : null;
+    if (git(destination, ['status', '--porcelain=v1']).stdout.trim()) {
+        fail(`fixture ${caseId} is dirty immediately after materialization`);
+    }
+    return {
+        item,
+        initial_commit: initialCommit,
+        git_directory: gitDirectoryIdentity(destination),
+        base_tree_sha256: treeDigest(entries),
+        history,
+        dependency,
+    };
+}
+
+function cloneDependencies(source, destination) {
+    const from = join(source, 'node_modules');
+    const to = join(destination, 'node_modules');
+    run('/bin/cp', ['-a', '--reflink=never', from, to]);
+    const sourceStat = lstatSync(from);
+    const targetStat = lstatSync(to);
+    if (!targetStat.isDirectory() || targetStat.isSymbolicLink()
+        || (sourceStat.dev === targetStat.dev && sourceStat.ino === targetStat.ino)) {
+        fail('dependency root is not physically isolated');
+    }
+    const sourceManifest = join(from, '.package-lock.json');
+    const targetManifest = join(to, '.package-lock.json');
+    if (!existsSync(sourceManifest) || !existsSync(targetManifest)) {
+        fail('dependency tree is missing its npm lock manifest');
+    }
+    if (readlinkEscapes(to)) fail('dependency tree contains a symlink that escapes its physical root');
+    return {
+        method: 'full physical copy',
+        source_manifest_sha256: sha256(readFileSync(sourceManifest)),
+        target_manifest_sha256: sha256(readFileSync(targetManifest)),
+        root_inode_distinct: true,
+    };
+}
+
+function readlinkEscapes(root) {
+    const queue = [root];
+    const realRoot = realpathSync(root);
+    while (queue.length) {
+        const directory = queue.pop();
+        for (const entry of readdirSync(directory, { withFileTypes: true })) {
+            const path = join(directory, entry.name);
+            if (entry.isDirectory()) queue.push(path);
+            else if (entry.isSymbolicLink()) {
+                const target = resolve(dirname(path), readlinkSync(path));
+                const rel = relative(realRoot, target);
+                if (rel === '..' || rel.startsWith(`..${sep}`)) return true;
+            }
+        }
+    }
+    return false;
+}
+
+function materializeDryFixture({ protocol, protocolPath, caseId, mode, destination }) {
+    mkdirSync(destination, { recursive: true });
+    writeFileSync(join(destination, 'package.json'), `${JSON.stringify({
+        name: `pipeline-dry-${caseId}`,
+        private: true,
+        scripts: { test: 'node --test test.mjs' },
+    }, null, 2)}\n`);
+    writeFileSync(join(destination, 'test.mjs'), [
+        "import { test } from 'node:test';",
+        "import assert from 'node:assert/strict';",
+        "test('dry fixture', () => assert.equal(1, 1));",
+        '',
+    ].join('\n'));
+    if (mode === 'pipeline') {
+        writeFileSync(join(destination, 'AGENTS.md'), '# Dry full-pipeline fixture\nUse the frozen skills.\n');
+        for (const stage of ['intake', 'implement', 'review', 'patch', 'done']) {
+            const path = join(destination, '.agents', 'skills', stage, 'SKILL.md');
+            mkdirSync(dirname(path), { recursive: true });
+            writeFileSync(path, `# ${stage}\nDry lifecycle skill.\n`);
+        }
+    }
+    writeFixtureMetadata(destination, protocol, protocolPath, mode);
+    const initialCommit = initializeRepository(destination, protocol.execution.fixture_commit_time);
+    return {
+        item: protocol.cases.find((entry) => entry.id === caseId),
+        initial_commit: initialCommit,
+        git_directory: gitDirectoryIdentity(destination),
+        base_tree_sha256: 'dry-fixture',
+        history: assertHistoryTruncated(destination, [], {
+            expectedCommitCount: 1,
+            expectedRoot: initialCommit,
+        }),
+        dependency: null,
+    };
+}
+
+function sanitizedPath(pathValue = process.env.PATH ?? '/usr/bin:/bin') {
+    return pathValue.split(':').filter((entry) => entry && !entry.includes('\n') && !entry.includes('\0')).join(':');
+}
+
+function resolveExecutable(command, pathValue = process.env.PATH ?? '') {
+    const candidates = command.includes(sep)
+        ? [resolve(command)]
+        : pathValue.split(':').filter(Boolean).map((entry) => resolve(entry, command));
+    const path = candidates.find((candidate) => existsSync(candidate));
+    if (!path) fail(`cannot resolve executable: ${command}`);
+    const realPath = realpathSync(path);
+    if (!statSync(realPath).isFile()) fail(`resolved executable is not a file: ${realPath}`);
+    return realPath;
+}
+
+function privateDirectory(prefix) {
+    const path = mkdtempSync(join(tmpdir(), prefix));
+    chmodSync(path, 0o700);
+    return path;
+}
+
+function privateMkdir(path) {
+    if (existsSync(path)) {
+        const stat = lstatSync(path);
+        if (!stat.isDirectory() || stat.isSymbolicLink()) fail(`private path is not a physical directory: ${path}`);
+    } else {
+        mkdirSync(path, { recursive: true, mode: 0o700 });
+        const stat = lstatSync(path);
+        if (!stat.isDirectory() || stat.isSymbolicLink()) fail(`private path is not a physical directory: ${path}`);
+    }
+    chmodSync(path, 0o700);
+    return path;
+}
+
+function privateWrite(path, data) {
+    privateMkdir(dirname(path));
+    writeFileSync(path, data, { mode: 0o600 });
+    chmodSync(path, 0o600);
+}
+
+function resolveAuthPath(codexHome) {
+    return resolve(codexHome ?? process.env.CODEX_HOME ?? join(homedir(), '.codex'), 'auth.json');
+}
+
+export function assertNoCredentialMaterial(values, authPath) {
+    if (!authPath) return;
+    const raw = readFileSync(authPath, 'utf8');
+    const fingerprints = new Set();
+    const add = (value) => {
+        if (typeof value === 'string' && value.length >= 24) fingerprints.add(value);
+    };
+    add(raw.trim());
+    try {
+        const visit = (value) => {
+            if (typeof value === 'string') add(value);
+            else if (Array.isArray(value)) value.forEach(visit);
+            else if (value && typeof value === 'object') Object.values(value).forEach(visit);
+        };
+        visit(JSON.parse(raw));
+    } catch {
+        // The full non-JSON auth file fingerprint remains protected.
+    }
+    for (const value of values) {
+        const text = Buffer.isBuffer(value) ? value.toString('utf8') : String(value ?? '');
+        if ([...fingerprints].some((fingerprint) => text.includes(fingerprint))) {
+            fail('model output contained authentication material; raw output was not written');
+        }
+    }
+}
+
+export function pipelineConfig({
+    workspace,
+    codexBin,
+    issueBody = '',
+    issueTitle = '',
+    pathValue = process.env.PATH,
+}) {
+    const workspacePath = existsSync(workspace) ? realpathSync(workspace) : resolve(workspace);
+    const nodeExecutable = resolveExecutable('node', pathValue);
+    const cellarMarker = `${sep}Cellar${sep}`;
+    const nodeRuntimeRoot = nodeExecutable.includes(cellarMarker)
+        ? nodeExecutable.slice(0, nodeExecutable.indexOf(cellarMarker))
+        : nodeExecutable;
+    const readable = [...new Set([
+        resolveExecutable(codexBin),
+        nodeRuntimeRoot,
+        realpathSync(FAKE_BIN),
+    ])].sort().map((path) => `${JSON.stringify(path)} = "read"`).join('\n');
+    const commandPath = `${FAKE_BIN}:${sanitizedPath(pathValue)}`;
+    const trackerEnvironment = issueBody || issueTitle ? [
+        `CYCLE_PIPELINE_ISSUE_BODY_BASE64 = ${JSON.stringify(Buffer.from(issueBody).toString('base64'))}`,
+        `CYCLE_PIPELINE_ISSUE_TITLE = ${JSON.stringify(issueTitle)}`,
+        'CYCLE_PIPELINE_ISSUE_LABEL = "status:ready"',
+        '',
+    ].join('\n') : '';
+    return `approval_policy = "never"
+default_permissions = "pipeline-fixture"
+allow_login_shell = false
+web_search = "disabled"
+check_for_update_on_startup = false
+file_opener = "none"
+
+[feedback]
+enabled = false
+
+[features]
+goals = false
+hooks = false
+memories = false
+multi_agent = false
+network_proxy = false
+shell_snapshot = false
+skill_mcp_dependency_install = false
+view_image = false
+
+[permissions.pipeline-fixture.filesystem]
+":root" = "deny"
+":minimal" = "read"
+${JSON.stringify(workspacePath)} = "write"
+${readable}
+
+[permissions.pipeline-fixture.network]
+enabled = false
+
+[shell_environment_policy]
+inherit = "none"
+ignore_default_excludes = false
+
+[shell_environment_policy.set]
+HOME = "/nonexistent"
+PATH = ${JSON.stringify(commandPath)}
+LANG = "C.UTF-8"
+LC_ALL = "C.UTF-8"
+NO_COLOR = "1"
+CI = "1"
+GIT_CONFIG_NOSYSTEM = "1"
+GIT_CONFIG_GLOBAL = "/dev/null"
+GIT_AUTHOR_NAME = "Pipeline Candidate"
+GIT_AUTHOR_EMAIL = "candidate@example.invalid"
+GIT_COMMITTER_NAME = "Pipeline Candidate"
+GIT_COMMITTER_EMAIL = "candidate@example.invalid"
+${trackerEnvironment}
+`;
+}
+
+export function createClientHome({
+    codexHome,
+    includeAuth,
+    codexBin,
+    workspace,
+    issueBody,
+    issueTitle,
+}) {
+    const home = privateDirectory('cycle-pipeline-codex-home-');
+    writeFileSync(join(home, 'config.toml'), pipelineConfig({
+        workspace,
+        codexBin,
+        issueBody,
+        issueTitle,
+    }), { mode: 0o600 });
+    if (includeAuth) {
+        const source = resolveAuthPath(codexHome);
+        if (!existsSync(source) || !lstatSync(source).isFile() || lstatSync(source).isSymbolicLink()) {
+            rmSync(home, { recursive: true, force: true });
+            fail(`Codex authentication is unavailable at ${source}`);
+        }
+        symlinkSync(source, join(home, 'auth.json'));
+    }
+    return home;
+}
+
+export function clientEnvironment({
+    clientHome,
+    scratch,
+    caseId,
+    arm,
+    stage,
+    attempt,
+    turn,
+    sessionId,
+    issueBody = '',
+    issueTitle = '',
+    canonicalIssue = '',
+}, ambient = process.env) {
+    const env = {};
+    for (const key of ['PATH', 'LANG', 'LC_ALL', 'SSL_CERT_FILE', 'SSL_CERT_DIR']) {
+        if (ambient[key]) env[key] = ambient[key];
+    }
+    env.PATH = `${FAKE_BIN}:${sanitizedPath(env.PATH)}`;
+    env.HOME = clientHome;
+    env.CODEX_HOME = clientHome;
+    env.TMPDIR = scratch;
+    env.NO_COLOR = '1';
+    env.CYCLE_PIPELINE_CASE = caseId;
+    env.CYCLE_PIPELINE_ARM = arm;
+    env.CYCLE_PIPELINE_STAGE = stage;
+    env.CYCLE_PIPELINE_ATTEMPT = String(attempt);
+    env.CYCLE_PIPELINE_TURN = String(turn);
+    env.CYCLE_PIPELINE_SESSION_ID = sessionId;
+    env.CYCLE_PIPELINE_ISSUE_BODY_BASE64 = Buffer.from(issueBody).toString('base64');
+    env.CYCLE_PIPELINE_ISSUE_TITLE = issueTitle;
+    env.GIT_CONFIG_NOSYSTEM = '1';
+    env.GIT_CONFIG_GLOBAL = '/dev/null';
+    env.GIT_AUTHOR_NAME = 'Pipeline Candidate';
+    env.GIT_AUTHOR_EMAIL = 'candidate@example.invalid';
+    env.GIT_COMMITTER_NAME = 'Pipeline Candidate';
+    env.GIT_COMMITTER_EMAIL = 'candidate@example.invalid';
+    if (canonicalIssue) env.CYCLE_PIPELINE_CANONICAL_ISSUE_BASE64 = Buffer.from(canonicalIssue).toString('base64');
+    return env;
+}
+
+export function parseExecEvents(text) {
+    const events = [];
+    const malformed = [];
+    const invalid = [];
+    for (const [index, line] of text.split('\n').entries()) {
+        if (!line.trim()) continue;
+        try {
+            const event = JSON.parse(line);
+            if (!event || typeof event !== 'object' || Array.isArray(event)) invalid.push(index + 1);
+            else events.push(event);
+        } catch {
+            malformed.push(index + 1);
+        }
+    }
+    const reasons = [];
+    if (malformed.length) reasons.push(`malformed JSONL at line(s) ${malformed.join(', ')}`);
+    if (invalid.length) reasons.push(`invalid JSONL event at line(s) ${invalid.join(', ')}`);
+    const completed = events.findLast((event) => event.type === 'turn.completed');
+    return { events, invalid: reasons.length ? reasons.join('; ') : null, usage: completed?.usage ?? null };
+}
+
+function finalAgentText(events) {
+    return events.findLast((event) => event.type === 'item.completed'
+        && event.item?.type === 'agent_message' && typeof event.item.text === 'string')?.item.text ?? null;
+}
+
+export function validateTurnText(text) {
+    if (!text) return { invalid: 'missing final structured response', value: null };
+    let value;
+    try {
+        value = JSON.parse(text);
+    } catch {
+        return { invalid: 'final response is not JSON', value: null };
+    }
+    if (!value || typeof value !== 'object' || Array.isArray(value)
+        || stableJson(Object.keys(value).sort()) !== stableJson(['question', 'status', 'summary'])
+        || !['needs-input', 'complete'].includes(value.status)
+        || typeof value.question !== 'string' || typeof value.summary !== 'string'
+        || (value.status === 'needs-input' && !value.question.trim())
+        || (value.status === 'complete' && value.question !== '')) {
+        return { invalid: 'final response does not match turn.schema.json', value: null };
+    }
+    return { invalid: null, value };
+}
+
+function usageSum(turns) {
+    const totals = {};
+    let reportedTurns = 0;
+    for (const turn of turns) {
+        if (!turn.usage || typeof turn.usage !== 'object') continue;
+        reportedTurns += 1;
+        for (const [key, value] of Object.entries(turn.usage)) {
+            if (typeof value === 'number' && Number.isFinite(value)) totals[key] = (totals[key] ?? 0) + value;
+        }
+    }
+    return { reported_turns: reportedTurns, totals };
+}
+
+function answerSheet(protocolPath, item) {
+    let sheet;
+    try {
+        sheet = JSON.parse(readFileSync(protocolAsset(protocolPath, item.answer_sheet_path), 'utf8'));
+    } catch (error) {
+        fail(`invalid answer sheet for ${item.id}: ${error.message}`);
+    }
+    if (sheet.case_id !== item.id || !Number.isSafeInteger(sheet.max_followups_per_stage)
+        || sheet.max_followups_per_stage < 0 || !Array.isArray(sheet.rules)
+        || typeof sheet.default_answer !== 'string') {
+        fail(`answer sheet for ${item.id} has an invalid shape`);
+    }
+    return sheet;
+}
+
+export function scriptedAnswer(sheet, question) {
+    for (const rule of sheet.rules) {
+        if (!isNonEmptyString(rule.id) || !isNonEmptyString(rule.question_regex)
+            || typeof rule.answer !== 'string') fail(`invalid answer rule in ${sheet.case_id}`);
+        let expression;
+        try { expression = new RegExp(rule.question_regex, 'i'); }
+        catch { fail(`invalid question regex ${rule.id} in ${sheet.case_id}`); }
+        if (expression.test(question)) return { rule_id: rule.id, answer: rule.answer };
+    }
+    if (sheet.default_answer) return { rule_id: 'default', answer: sheet.default_answer };
+    return null;
+}
+
+function decodeTrackerField(encoded, label) {
+    const decoded = Buffer.from(encoded, 'base64');
+    if (decoded.toString('base64').replace(/=+$/, '') !== encoded.replace(/=+$/, '')) {
+        fail(`fake tracker returned an invalid ${label} marker`);
+    }
+    return decoded.toString('utf8');
+}
+
+export function trackerCreates(turns) {
+    const creates = [];
+    for (const turn of turns) {
+        for (const event of turn.events) {
+            if (event.type !== 'item.completed' || event.item?.type !== 'command_execution') continue;
+            const output = String(event.item.aggregated_output ?? '');
+            let pending = null;
+            for (const line of output.split('\n')) {
+                if (line.startsWith('CYCLE_PIPELINE_TRACKER_CREATE:')) {
+                    if (pending !== null) creates.push(pending);
+                    pending = { body: decodeTrackerField(
+                        line.slice('CYCLE_PIPELINE_TRACKER_CREATE:'.length),
+                        'issue-body',
+                    ), title: null };
+                }
+                if (line.startsWith('CYCLE_PIPELINE_TRACKER_TITLE:')) {
+                    const title = decodeTrackerField(
+                        line.slice('CYCLE_PIPELINE_TRACKER_TITLE:'.length),
+                        'issue-title',
+                    );
+                    if (pending === null || pending.title !== null) creates.push({ body: null, title });
+                    else pending.title = title;
+                }
+            }
+            if (pending !== null) creates.push(pending);
+        }
+    }
+    return creates;
+}
+
+function issueEnvelope(title, body) {
+    return `Issue title:\n${title}\n\nIssue body:\n${body}`;
+}
+
+function issueEnvelopeHash(title, body) {
+    return sha256(Buffer.concat([Buffer.from(title), Buffer.from([0]), Buffer.from(body)]));
+}
+
+function commandEvidence(turns, workspace) {
+    return turns.flatMap((turn) => turn.events
+        .filter((event) => event.type === 'item.completed' && event.item?.type === 'command_execution')
+        .map((event) => ({
+            stage: turn.stage,
+            command: String(event.item.command ?? '').split(workspace).join('<workspace>'),
+            exit_code: event.item.exit_code ?? null,
+        })));
+}
+
+function startLoopbackProbe(root) {
+    const portFile = join(root, 'loopback-port');
+    const server = spawn(process.execPath, [
+        '-e',
+        [
+            "const { writeFileSync } = require('node:fs');",
+            "const { createServer } = require('node:net');",
+            'const server = createServer();',
+            "server.listen(0, '127.0.0.1', () => writeFileSync(process.argv[1], String(server.address().port)));",
+            'setTimeout(() => process.exit(0), 30000);',
+        ].join(' '),
+        portFile,
+    ], { stdio: 'ignore' });
+    const wait = new Int32Array(new SharedArrayBuffer(4));
+    const deadline = Date.now() + 5_000;
+    while (!existsSync(portFile) && Date.now() < deadline && server.exitCode === null) {
+        Atomics.wait(wait, 0, 0, 10);
+    }
+    if (!existsSync(portFile)) {
+        server.kill('SIGTERM');
+        fail('could not start loopback isolation probe');
+    }
+    const port = Number(readFileSync(portFile, 'utf8'));
+    if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
+        server.kill('SIGTERM');
+        fail('loopback isolation probe returned an invalid port');
+    }
+    return { port, stop: () => server.kill('SIGTERM') };
+}
+
+export function runStrictConfigProbe({ codexBin, clientHome, workspace, scratch }) {
+    const result = run(codexBin, ['app-server', '--strict-config', '--listen', 'off'], {
+        cwd: workspace,
+        env: {
+            PATH: sanitizedPath(),
+            LANG: 'C.UTF-8',
+            HOME: clientHome,
+            CODEX_HOME: clientHome,
+            TMPDIR: scratch,
+        },
+        allowFailure: true,
+        timeout: 30_000,
+    });
+    const combined = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+    if (result.status !== 1 || !/no transport configured/i.test(combined)) {
+        fail(`strict pipeline-config probe failed (${result.status})\n${combined}`.trimEnd());
+    }
+    return { strict_config: 'pass', authentication: 'absent', model_calls: 0 };
+}
+
+export function probePipelineConfig(codexBin = 'codex') {
+    const root = privateDirectory('cycle-pipeline-config-probe-');
+    const workspace = join(root, 'workspace');
+    const scratch = join(root, 'scratch');
+    mkdirSync(workspace);
+    mkdirSync(scratch);
+    let clientHome;
+    try {
+        clientHome = createClientHome({
+            includeAuth: false,
+            codexBin,
+            workspace,
+            issueBody: '',
+            issueTitle: 'Probe',
+        });
+        if (existsSync(join(clientHome, 'auth.json'))) fail('config probe unexpectedly contains authentication');
+        return runStrictConfigProbe({ codexBin, clientHome, workspace, scratch });
+    } finally {
+        if (clientHome) rmSync(clientHome, { recursive: true, force: true });
+        rmSync(root, { recursive: true, force: true });
+    }
+}
+
+export function probeIsolation(codexBin = 'codex') {
+    const root = privateDirectory('cycle-pipeline-isolation-');
+    const workspace = join(root, 'workspace');
+    const scratch = privateDirectory('cycle-pipeline-isolation-tmp-');
+    let clientHome;
+    let loopback;
+    try {
+        mkdirSync(workspace);
+        writeFileSync(join(workspace, 'allowed.txt'), 'allowed\n');
+        clientHome = createClientHome({
+            includeAuth: false,
+            codexBin,
+            workspace,
+            issueBody: 'probe body',
+            issueTitle: 'Probe',
+        });
+        const deniedNames = ['source', 'evaluator', 'sibling', 'oracle'];
+        const denied = deniedNames.map((name) => {
+            const path = join(root, `${name}.sentinel`);
+            writeFileSync(path, `${name}\n`);
+            return path;
+        });
+        const homeSentinel = join(clientHome, 'client-home.sentinel');
+        writeFileSync(homeSentinel, 'client-home\n', { mode: 0o600 });
+        denied.push(homeSentinel);
+        loopback = startLoopbackProbe(root);
+        const fakeWrite = join(FAKE_BIN, '.pipeline-write-probe');
+        const script = [
+            'test -r allowed.txt || exit 10',
+            'printf changed > allowed.txt || exit 11',
+            'test "$(cat allowed.txt)" = changed || exit 12',
+            'git --version >/dev/null || exit 13',
+            'gh --version >/dev/null || exit 14',
+            `if printf denied > ${JSON.stringify(fakeWrite)} 2>/dev/null; then exit 15; fi`,
+            `if /bin/bash -c 'exec 3<>/dev/tcp/127.0.0.1/${loopback.port}' 2>/dev/null; then exit 30; fi`,
+            'shift',
+            'for path do test ! -r "$path" || exit 20; done',
+        ].join('; ');
+        const env = {
+            PATH: `${FAKE_BIN}:${sanitizedPath()}`,
+            LANG: 'C.UTF-8',
+            HOME: clientHome,
+            CODEX_HOME: clientHome,
+            TMPDIR: scratch,
+        };
+        const result = run(codexBin, [
+            'sandbox', '--permission-profile', 'pipeline-fixture', '--cd', workspace,
+            '/bin/sh', '-c', script, 'probe', ...denied,
+        ], { cwd: workspace, env, allowFailure: true, timeout: 30_000 });
+        if (existsSync(fakeWrite)) {
+            unlinkSync(fakeWrite);
+            fail('pipeline isolation probe wrote to evaluator assets');
+        }
+        if (result.status !== 0) {
+            fail(`Codex pipeline isolation probe failed (${result.status})\n${result.stderr || result.stdout || ''}`.trimEnd());
+        }
+        return {
+            candidate_workspace_read_write: true,
+            evaluator_assets_read_only: true,
+            denied_host_loopback_listener: true,
+            denied_host_sentinels: [...deniedNames, 'client-home'],
+            command_network: false,
+            filesystem_profile_sha256: sha256(pipelineConfig({
+                workspace: '/fixture',
+                codexBin: resolveExecutable(codexBin),
+                issueBody: '',
+                issueTitle: 'Probe',
+            })
+                .replaceAll(realpathSync(FAKE_BIN), '/evaluator/bin')
+                .replaceAll(workspace, '/fixture')),
+        };
+    } finally {
+        if (loopback) loopback.stop();
+        if (clientHome) rmSync(clientHome, { recursive: true, force: true });
+        rmSync(root, { recursive: true, force: true });
+        rmSync(scratch, { recursive: true, force: true });
+    }
+}
+
+function turnPrompt(protocol, protocolPath, { stage, rawRequest, shapedIssue }) {
+    if (stage === 'intake') {
+        return [
+            `$intake ${rawRequest.trim()}`,
+            '',
+            'This is a frozen evaluation session. Interview one question at a time, draft an actionable',
+            'issue, and file exactly one issue through gh when approved. Return only the requested',
+            'structured status object at the end of each turn.',
+        ].join('\n');
+    }
+    if (stage === 'direct') {
+        const common = readFileSync(protocolAsset(protocolPath, protocol.prompts.direct_path), 'utf8').trim();
+        return `${common}\n\nUser request:\n${shapedIssue ?? rawRequest}`;
+    }
+    const common = readFileSync(protocolAsset(protocolPath, protocol.prompts.stage_path), 'utf8').trim();
+    const invocation = stage === 'implement' ? '$implement #1'
+        : stage === 'done' ? '$done #1'
+            : `$${stage}`;
+    return `${invocation}\n\n${common}\n\nRequested stage: ${stage}`;
+}
+
+function invokeTurn({
+    protocol,
+    output,
+    workspace,
+    runDir,
+    codexBin,
+    model,
+    effort,
+    timeoutMs,
+    clientHome,
+    scratch,
+    authPath,
+    caseId,
+    arm,
+    stage,
+    attempt,
+    turn,
+    sessionId,
+    threadId,
+    prompt,
+    issueBody,
+    issueTitle,
+    canonicalIssue,
+}) {
+    const schema = join(workspace, '.pipeline-eval', 'turn.schema.json');
+    const common = [
+        '--json', '--strict-config', '--ignore-rules',
+        '--model', model,
+        '-c', `model_reasoning_effort=${JSON.stringify(effort)}`,
+        '--output-schema', schema,
+    ];
+    const args = threadId
+        ? ['exec', 'resume', ...common, threadId, prompt]
+        : ['exec', ...common, '--cd', workspace, prompt];
+    const env = clientEnvironment({
+        clientHome,
+        scratch,
+        caseId,
+        arm,
+        stage,
+        attempt,
+        turn,
+        sessionId,
+        issueBody,
+        issueTitle,
+        canonicalIssue,
+    });
+    const startedAt = new Date().toISOString();
+    const processResult = run(codexBin, args, {
+        cwd: workspace,
+        env,
+        timeout: timeoutMs,
+        allowFailure: true,
+    });
+    const finishedAt = new Date().toISOString();
+    const stdout = processResult.stdout ?? '';
+    const stderr = processResult.stderr ?? '';
+    assertNoCredentialMaterial([stdout, stderr], authPath);
+    const turnName = `${stage}-${String(turn).padStart(2, '0')}`;
+    const turnDir = join(runDir, 'turns', arm, turnName);
+    privateWrite(join(turnDir, 'events.jsonl'), stdout);
+    privateWrite(join(turnDir, 'stderr.txt'), stderr);
+    const parsed = parseExecEvents(stdout);
+    const finalText = finalAgentText(parsed.events);
+    if (finalText !== null) privateWrite(join(turnDir, 'final.json'), `${finalText}\n`);
+    const structured = validateTurnText(finalText);
+    const invalid = [];
+    if (processResult.status !== 0) invalid.push(`Codex exited ${processResult.status}`);
+    if (parsed.invalid) invalid.push(parsed.invalid);
+    const started = parsed.events.some((event) => event.type === 'turn.started');
+    const completed = parsed.events.some((event) => event.type === 'turn.completed');
+    if (!started) invalid.push('missing turn.started');
+    if (!completed) invalid.push('missing turn.completed');
+    if (structured.invalid) invalid.push(structured.invalid);
+    const eventThreadIds = parsed.events
+        .filter((event) => event.type === 'thread.started' && isNonEmptyString(event.thread_id))
+        .map((event) => event.thread_id);
+    const actualThreadId = eventThreadIds[0] ?? threadId;
+    if (!actualThreadId) invalid.push('missing thread.started thread id');
+    if (threadId && eventThreadIds.some((value) => value !== threadId)) invalid.push('resumed thread id changed');
+    return {
+        stage,
+        turn,
+        thread_id: actualThreadId ?? null,
+        started_at: startedAt,
+        finished_at: finishedAt,
+        elapsed_ms: processResult.elapsedMs,
+        exit_code: processResult.status,
+        model_turn_started: started,
+        model_turn_completed: completed,
+        usage: parsed.usage,
+        response: structured.value,
+        invalid_reasons: invalid,
+        events: parsed.events,
+        artifacts: {
+            events: relative(output, join(turnDir, 'events.jsonl')),
+            stderr: relative(output, join(turnDir, 'stderr.txt')),
+            final: finalText === null ? null : relative(output, join(turnDir, 'final.json')),
+        },
+    };
+}
+
+function runLifecycle({
+    protocol,
+    protocolPath,
+    output,
+    item,
+    workspace,
+    runDir,
+    codexBin,
+    model,
+    effort,
+    timeoutMs,
+    codexHome,
+    dryRun,
+    arm,
+    stage,
+    attempt,
+    prompt,
+    issueBody = '',
+    issueTitle = '',
+    canonicalIssue = '',
+    threadId = null,
+    sessionId,
+    sessionContext = null,
+}) {
+    const ownsSession = sessionContext === null;
+    const scratch = sessionContext?.scratch ?? privateDirectory('cycle-pipeline-client-tmp-');
+    const authPath = sessionContext?.authPath ?? (dryRun ? null : resolveAuthPath(codexHome));
+    const clientHome = sessionContext?.clientHome ?? createClientHome({
+        codexHome, includeAuth: !dryRun, codexBin, workspace, issueBody, issueTitle,
+    });
+    const sheet = answerSheet(protocolPath, item);
+    const turns = [];
+    let currentPrompt = prompt;
+    let currentThread = threadId;
+    try {
+        for (let turn = 1; turn <= sheet.max_followups_per_stage + 1; turn += 1) {
+            const result = invokeTurn({
+                protocol,
+                output,
+                workspace,
+                runDir,
+                codexBin,
+                model,
+                effort,
+                timeoutMs,
+                clientHome,
+                scratch,
+                authPath,
+                caseId: item.id,
+                arm,
+                stage,
+                attempt,
+                turn,
+                sessionId,
+                threadId: currentThread,
+                prompt: currentPrompt,
+                issueBody,
+                issueTitle,
+                canonicalIssue: dryRun ? canonicalIssue : '',
+            });
+            turns.push(result);
+            if (result.invalid_reasons.length) break;
+            if (!currentThread) currentThread = result.thread_id;
+            if (result.response.status === 'complete') break;
+            if (turn > sheet.max_followups_per_stage) {
+                result.invalid_reasons.push('follow-up limit exceeded');
+                break;
+            }
+            const selected = scriptedAnswer(sheet, result.response.question);
+            if (!selected) {
+                result.invalid_reasons.push('question did not match the frozen answer sheet');
+                break;
+            }
+            result.answer_rule = selected.rule_id;
+            currentPrompt = selected.answer;
+        }
+    } finally {
+        if (ownsSession) {
+            rmSync(clientHome, { recursive: true, force: true });
+            rmSync(scratch, { recursive: true, force: true });
+        }
+    }
+    if (turns.length && !turns.some((turn) => turn.invalid_reasons.length)
+        && turns.at(-1).response?.status !== 'complete') {
+        turns.at(-1).invalid_reasons.push('stage did not complete');
+    }
+    return {
+        stage,
+        thread_id: currentThread,
+        turns,
+        valid: turns.length > 0 && turns.every((turn) => turn.invalid_reasons.length === 0)
+            && turns.at(-1).response?.status === 'complete',
+        usage: usageSum(turns),
+    };
+}
+
+function untrackedPaths(workspace) {
+    return git(workspace, ['ls-files', '--others', '--exclude-standard', '-z']).stdout
+        .split('\0').filter(Boolean).sort();
+}
+
+function combinedDiff(workspace, initialCommit) {
+    const tracked = git(workspace, [
+        'diff', '--binary', '--full-index', '--no-ext-diff', '--no-textconv', '--no-renames', initialCommit,
+    ], { encoding: null }).stdout;
+    const chunks = [tracked];
+    for (const rel of untrackedPaths(workspace)) {
+        const path = resolve(workspace, rel);
+        ensureInside(workspace, path);
+        const stat = lstatSync(path);
+        if (!stat.isFile() || stat.isSymbolicLink()) fail(`candidate created an unsafe untracked path: ${rel}`);
+        if (stat.size > MAX_CAPTURE_FILE) fail(`candidate untracked file is too large to capture: ${rel}`);
+        const result = run('/usr/bin/git', [
+            'diff', '--no-index', '--binary', '--full-index', '--no-ext-diff', '--no-textconv',
+            '--no-renames', '/dev/null', rel,
+        ], {
+            cwd: workspace,
+            encoding: null,
+            allowFailure: true,
+            env: evaluatorGitEnvironment(),
+        });
+        if (result.status !== 1) fail(`cannot capture untracked candidate file: ${rel}`);
+        chunks.push(result.stdout);
+    }
+    return Buffer.concat(chunks);
+}
+
+function changedPaths(workspace, initialCommit) {
+    const tracked = git(workspace, ['diff', '--name-only', '-z', initialCommit]).stdout
+        .split('\0').filter(Boolean);
+    return [...new Set([...tracked, ...untrackedPaths(workspace)])].sort();
+}
+
+function snapshotWorkspace({ output, runDir, workspace, fixture, arm, stage }) {
+    sanitizeCandidateRepository(workspace, fixture.git_directory);
+    const path = join(runDir, 'snapshots', arm, `${stage}.diff`);
+    const diff = combinedDiff(workspace, fixture.initial_commit);
+    privateWrite(path, diff);
+    return {
+        stage,
+        diff: relative(output, path),
+        diff_sha256: sha256(diff),
+        changed_paths: changedPaths(workspace, fixture.initial_commit),
+    };
+}
+
+function applySourceFiles(source, revision, paths, destination) {
+    for (const rel of paths) {
+        const exists = git(source, ['cat-file', '-e', `${revision}:${rel}`], { allowFailure: true }).status === 0;
+        const path = resolve(destination, rel);
+        ensureInside(destination, path);
+        if (!exists) {
+            rmSync(path, { recursive: true, force: true });
+            continue;
+        }
+        const mode = git(source, ['ls-tree', revision, '--', rel]).stdout.trim().split(/\s+/)[0];
+        if (!['100644', '100755'].includes(mode)) fail(`unsupported verifier source mode for ${rel}`);
+        mkdirSync(dirname(path), { recursive: true });
+        writeFileSync(path, git(source, ['show', `${revision}:${rel}`], { encoding: null }).stdout);
+        chmodSync(path, mode === '100755' ? 0o755 : 0o644);
+    }
+}
+
+function candidateFiles(workspace) {
+    return git(workspace, ['ls-files', '--cached', '--others', '--exclude-standard', '-z']).stdout
+        .split('\0').filter(Boolean).sort();
+}
+
+const VERIFIER_EXCLUDES = [
+    '.agents', '.claude', '.codex', '.cycle', '.git', '.pipeline-eval',
+    'AGENTS.md', 'CLAUDE.md', 'node_modules',
+];
+
+const VERIFIER_CONTROL_PATHS = [
+    'package.json',
+    'package-lock.json',
+    'tsconfig.json',
+    'vitest.config.ts',
+];
+
+function copyCandidateSource(workspace, destination) {
+    mkdirSync(destination, { recursive: true });
+    for (const rel of candidateFiles(workspace)) {
+        if (isExcluded(rel, VERIFIER_EXCLUDES)) continue;
+        const sourcePath = resolve(workspace, rel);
+        ensureInside(workspace, sourcePath);
+        const stat = lstatSync(sourcePath);
+        if (!stat.isFile() || stat.isSymbolicLink()) fail(`candidate source contains an unsafe path: ${rel}`);
+        if (stat.size > MAX_CAPTURE_FILE) fail(`candidate source file is too large for verifier: ${rel}`);
+        const target = resolve(destination, rel);
+        ensureInside(destination, target);
+        mkdirSync(dirname(target), { recursive: true });
+        writeFileSync(target, readFileSync(sourcePath));
+        chmodSync(target, stat.mode & 0o111 ? 0o755 : 0o644);
+    }
+}
+
+function restoreVerifierControls(source, base, destination) {
+    for (const entry of readdirSync(destination)) {
+        if (/^(?:vite|vitest)\.config\.(?:js|cjs|mjs|ts|cts|mts)$/.test(entry)) {
+            rmSync(join(destination, entry), { recursive: true, force: true });
+        }
+    }
+    applySourceFiles(source, base, VERIFIER_CONTROL_PATHS, destination);
+}
+
+function sandboxedCommand({ codexBin, workspace, command, timeoutMs }) {
+    const scratch = privateDirectory('cycle-pipeline-verifier-tmp-');
+    const clientHome = createClientHome({
+        includeAuth: false,
+        codexBin,
+        workspace,
+        issueBody: '',
+        issueTitle: 'Hidden verifier',
+    });
+    try {
+        const env = {
+            PATH: `${FAKE_BIN}:${sanitizedPath()}`,
+            LANG: 'C.UTF-8',
+            LC_ALL: 'C.UTF-8',
+            HOME: clientHome,
+            CODEX_HOME: clientHome,
+            TMPDIR: scratch,
+            NO_COLOR: '1',
+        };
+        return run(codexBin, [
+            'sandbox', '--permission-profile', 'pipeline-fixture', '--cd', workspace,
+            '/bin/sh', '-c', command,
+        ], { cwd: workspace, env, allowFailure: true, timeout: timeoutMs });
+    } finally {
+        rmSync(clientHome, { recursive: true, force: true });
+        rmSync(scratch, { recursive: true, force: true });
+    }
+}
+
+function runOracleCommands({ codexBin, workspace, commands, timeoutMs }) {
+    const records = [];
+    let status = 0;
+    for (const command of commands) {
+        const result = sandboxedCommand({ codexBin, workspace, command, timeoutMs });
+        records.push({
+            command,
+            status: result.status,
+            elapsed_ms: result.elapsedMs,
+            stdout: result.stdout ?? '',
+            stderr: result.stderr ?? '',
+        });
+        if (result.status !== 0) {
+            status = result.status ?? 2;
+            break;
+        }
+    }
+    return { status, records };
+}
+
+function oracleFailure(result) {
+    const failed = result.records.find((record) => record.status !== 0) ?? result.records.at(-1);
+    if (!failed) return 'no oracle command ran';
+    return `${failed.command} (${failed.status})\n${failed.stderr || failed.stdout || ''}`.trimEnd();
+}
+
+function verifyFrozenOracle({ protocol, protocolPath, source, item, codexBin }) {
+    const root = privateDirectory(`cycle-pipeline-oracle-${item.id}-`);
+    const workspace = join(root, 'workspace');
+    try {
+        materializeFixture({
+            protocol,
+            protocolPath,
+            source,
+            caseId: item.id,
+            mode: 'neutral',
+            destination: workspace,
+            dependencies: true,
+        });
+        applySourceFiles(source, item.repair, item.oracle_paths, workspace);
+        const base = runOracleCommands({
+            codexBin,
+            workspace,
+            commands: item.oracle_commands,
+            timeoutMs: protocol.execution.timeout_ms_per_turn,
+        });
+        if (base.status === 0) fail(`case ${item.id} hidden oracle unexpectedly passed on the base`);
+        applySourceFiles(source, item.repair, item.repair_paths, workspace);
+        const repaired = runOracleCommands({
+            codexBin,
+            workspace,
+            commands: item.oracle_commands,
+            timeoutMs: protocol.execution.timeout_ms_per_turn,
+        });
+        if (repaired.status !== 0) {
+            fail(`case ${item.id} hidden oracle stayed red after repair\n${oracleFailure(repaired)}`);
+        }
+        applySourceFiles(source, item.base, item.repair_paths, workspace);
+        const mutation = runOracleCommands({
+            codexBin,
+            workspace,
+            commands: item.oracle_commands,
+            timeoutMs: protocol.execution.timeout_ms_per_turn,
+        });
+        if (mutation.status === 0) fail(`case ${item.id} mutation proof did not turn the hidden oracle red`);
+        return {
+            case_id: item.id,
+            hidden_oracle_on_base: 'fail',
+            hidden_oracle_after_repair: 'pass',
+            accepted_repair_removed_mutation: 'fail',
+        };
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+}
+
+function verifyCandidate({ protocol, source, item, workspace, codexBin }) {
+    const root = privateDirectory(`cycle-pipeline-candidate-verifier-${item.id}-`);
+    const verifier = join(root, 'workspace');
+    try {
+        copyCandidateSource(workspace, verifier);
+        restoreVerifierControls(source, item.base, verifier);
+        cloneDependencies(source, verifier);
+        applySourceFiles(source, item.repair, item.oracle_paths, verifier);
+        const result = runOracleCommands({
+            codexBin,
+            workspace: verifier,
+            commands: item.oracle_commands,
+            timeoutMs: protocol.execution.timeout_ms_per_turn,
+        });
+        return {
+            status: result.status === 0 ? 'pass' : 'fail',
+            commands: result.records.map((record) => ({
+                command: record.command,
+                status: record.status,
+                elapsed_ms: record.elapsed_ms,
+            })),
+            private_output: result.records.map((record) => ({
+                command: record.command,
+                stdout: record.stdout,
+                stderr: record.stderr,
+            })),
+        };
+    } finally {
+        rmSync(root, { recursive: true, force: true });
+    }
+}
+
+function scanChangedFilesForCredentials(workspace, initialCommit, authPath) {
+    if (!authPath) return;
+    const values = [];
+    for (const rel of changedPaths(workspace, initialCommit)) {
+        const path = resolve(workspace, rel);
+        ensureInside(workspace, path);
+        if (!existsSync(path)) continue;
+        const stat = lstatSync(path);
+        if (!stat.isFile() || stat.isSymbolicLink()) fail(`candidate changed an unsafe path: ${rel}`);
+        if (stat.size <= MAX_CAPTURE_FILE) values.push(readFileSync(path));
+    }
+    const newObjects = git(workspace, [
+        'rev-list', '--objects', '--all', '--not', initialCommit,
+    ]).stdout.trim().split('\n').filter(Boolean).map((line) => line.split(' ')[0]);
+    for (const object of new Set(newObjects)) {
+        if (git(workspace, ['cat-file', '-t', object]).stdout.trim() !== 'blob') continue;
+        const size = Number(git(workspace, ['cat-file', '-s', object]).stdout.trim());
+        if (Number.isSafeInteger(size) && size <= MAX_CAPTURE_FILE) {
+            values.push(git(workspace, ['cat-file', 'blob', object], { encoding: null }).stdout);
+        }
+    }
+    assertNoCredentialMaterial(values, authPath);
+}
+
+function verifyCandidateBoundary({ workspace, source, item, protocol, initialCommit, authPath }) {
+    const history = assertHistoryTruncated(
+        workspace,
+        [item.repair, protocol.source.pipeline_guidance_commit],
+        { expectedRoot: initialCommit },
+    );
+    const dependencyRoot = join(workspace, 'node_modules');
+    const sourceDependencyRoot = join(source, 'node_modules');
+    if (!existsSync(dependencyRoot) || !lstatSync(dependencyRoot).isDirectory()
+        || lstatSync(dependencyRoot).isSymbolicLink()) fail('candidate dependency root is not a physical directory');
+    const candidateStat = lstatSync(dependencyRoot);
+    const sourceStat = lstatSync(sourceDependencyRoot);
+    if (candidateStat.dev === sourceStat.dev && candidateStat.ino === sourceStat.ino) {
+        fail('candidate dependency root aliases the evaluator source tree');
+    }
+    for (const rel of changedPaths(workspace, initialCommit)) {
+        const path = resolve(workspace, rel);
+        if (existsSync(path) && lstatSync(path).isSymbolicLink()) fail(`candidate changed a symlink path: ${rel}`);
+        if (/^(?:\.env(?:\.|$)|auth\.json$|.*credentials)/i.test(rel)) {
+            fail(`candidate created a credential-shaped path: ${rel}`);
+        }
+    }
+    scanChangedFilesForCredentials(workspace, initialCommit, authPath);
+    return { ...history, dependency_root_inode_distinct: true, credential_scan: 'pass' };
+}
+
+function codexVersion(codexBin) {
+    return run(codexBin, ['--version'], {
+        env: { PATH: sanitizedPath(), LANG: 'C.UTF-8', HOME: '/nonexistent' },
+    }).stdout.trim();
+}
+
+function preflight({ protocol, protocolPath, source, output, codexBin, skipOracles = false }) {
+    assertArtifactLock(protocol, protocolPath, source);
+    const version = codexVersion(codexBin);
+    if (version !== protocol.execution.codex_version) {
+        fail(`Codex version mismatch: expected ${protocol.execution.codex_version}, got ${version}`);
+    }
+    const config = probePipelineConfig(codexBin);
+    const fixtures = [];
+    for (const item of protocol.cases) {
+        const root = privateDirectory(`cycle-pipeline-preflight-${item.id}-`);
+        try {
+            const fixture = materializeFixture({
+                protocol,
+                protocolPath,
+                source,
+                caseId: item.id,
+                mode: 'neutral',
+                destination: join(root, 'workspace'),
+                dependencies: false,
+            });
+            fixtures.push({
+                case_id: item.id,
+                base_tree_sha256: fixture.base_tree_sha256,
+                history: fixture.history,
+            });
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    }
+    const isolation = probeIsolation(codexBin);
+    const oracles = skipOracles ? null : protocol.cases.map((item) => verifyFrozenOracle({
+        protocol, protocolPath, source, item, codexBin,
+    }));
+    const result = {
+        study_id: protocol.study_id,
+        protocol_sha256: sha256(readFileSync(protocolPath)),
+        artifact_lock: 'pass',
+        codex_version: version,
+        config,
+        fixtures,
+        isolation,
+        oracles,
+        scored_model_calls: 0,
+    };
+    privateWrite(join(output, 'preflight.json'), `${JSON.stringify(result, null, 2)}\n`);
+    return result;
+}
+
+function persistentSession({ codexHome, dryRun, codexBin, workspace, issueBody, issueTitle }) {
+    const scratch = privateDirectory('cycle-pipeline-client-tmp-');
+    const clientHome = createClientHome({
+        codexHome,
+        includeAuth: !dryRun,
+        codexBin,
+        workspace,
+        issueBody,
+        issueTitle,
+    });
+    return {
+        clientHome,
+        scratch,
+        authPath: dryRun ? null : resolveAuthPath(codexHome),
+        cleanup() {
+            rmSync(clientHome, { recursive: true, force: true });
+            rmSync(scratch, { recursive: true, force: true });
+        },
+    };
+}
+
+function lifecycleSummary(lifecycle) {
+    return {
+        stage: lifecycle.stage,
+        thread_id: lifecycle.thread_id,
+        valid: lifecycle.valid,
+        usage: lifecycle.usage,
+        turns: lifecycle.turns.map((turn) => ({
+            stage: turn.stage,
+            turn: turn.turn,
+            thread_id: turn.thread_id,
+            started_at: turn.started_at,
+            finished_at: turn.finished_at,
+            elapsed_ms: turn.elapsed_ms,
+            exit_code: turn.exit_code,
+            model_turn_started: turn.model_turn_started,
+            model_turn_completed: turn.model_turn_completed,
+            usage: turn.usage,
+            response: turn.response,
+            invalid_reasons: turn.invalid_reasons,
+            answer_rule: turn.answer_rule ?? null,
+            artifacts: turn.artifacts,
+        })),
+    };
+}
+
+function lifecycleInvalid(lifecycle) {
+    return lifecycle.turns.flatMap((turn) => turn.invalid_reasons
+        .map((reason) => `${lifecycle.stage} turn ${turn.turn}: ${reason}`));
+}
+
+function recursiveFiles(root) {
+    const files = [];
+    const queue = [root];
+    while (queue.length) {
+        const directory = queue.pop();
+        for (const entry of readdirSync(directory, { withFileTypes: true })) {
+            const path = join(directory, entry.name);
+            if (entry.isDirectory()) queue.push(path);
+            else if (entry.isFile()) files.push(path);
+            else fail(`private artifact tree contains a special file: ${path}`);
+        }
+    }
+    return files.sort();
+}
+
+function artifactManifest(output, runDir) {
+    return Object.fromEntries(recursiveFiles(runDir)
+        .filter((path) => !path.endsWith(`${sep}result.json`))
+        .map((path) => [relative(output, path), sha256(readFileSync(path))]));
+}
+
+function createFixture({
+    protocol, protocolPath, source, item, mode, destination, dryRun, dependencies = true,
+}) {
+    return dryRun
+        ? materializeDryFixture({ protocol, protocolPath, caseId: item.id, mode, destination })
+        : materializeFixture({
+            protocol,
+            protocolPath,
+            source,
+            caseId: item.id,
+            mode,
+            destination,
+            dependencies,
+        });
+}
+
+function finalizeArm({
+    protocol,
+    output,
+    runDir,
+    source,
+    item,
+    workspace,
+    fixture,
+    codexBin,
+    dryRun,
+    codexHome,
+    arm,
+    snapshots,
+    lifecycles,
+}) {
+    const authPath = dryRun ? null : resolveAuthPath(codexHome);
+    const boundary = dryRun
+        ? assertHistoryTruncated(workspace, [], { expectedRoot: fixture.initial_commit })
+        : verifyCandidateBoundary({
+            workspace,
+            source,
+            item,
+            protocol,
+            initialCommit: fixture.initial_commit,
+            authPath,
+        });
+    const oracle = dryRun
+        ? { status: 'not-run', commands: [], private_output: [] }
+        : verifyCandidate({ protocol, source, item, workspace, codexBin });
+    if (!dryRun) {
+        assertNoCredentialMaterial(
+            oracle.private_output.flatMap((record) => [record.stdout, record.stderr]),
+            authPath,
+        );
+    }
+    const oraclePath = join(runDir, 'oracles', `${arm}.json`);
+    privateWrite(oraclePath, `${JSON.stringify(oracle.private_output, null, 2)}\n`);
+    const allTurns = lifecycles.flatMap((lifecycle) => lifecycle.turns);
+    const final = snapshots.at(-1);
+    return {
+        arm,
+        input_sha256: null,
+        valid: lifecycles.every((lifecycle) => lifecycle.valid),
+        lifecycle: lifecycles.map(lifecycleSummary),
+        usage: usageSum(allTurns),
+        model_turns_started: allTurns.filter((turn) => turn.model_turn_started).length,
+        model_turns_completed: allTurns.filter((turn) => turn.model_turn_completed).length,
+        command_evidence: commandEvidence(allTurns, workspace),
+        snapshots,
+        final_diff: final.diff,
+        final_diff_sha256: final.diff_sha256,
+        changed_paths: final.changed_paths,
+        boundary,
+        hidden_oracle: {
+            status: oracle.status,
+            commands: oracle.commands,
+            private_output: relative(output, oraclePath),
+        },
+    };
+}
+
+function executeCaseAttempt({
+    protocol,
+    protocolPath,
+    source,
+    output,
+    item,
+    caseIndex,
+    attempt,
+    codexBin,
+    model,
+    effort,
+    timeoutMs,
+    dryRun,
+    codexHome,
+    codexVersionValue,
+}) {
+    const privateRoot = privateDirectory(`cycle-pipeline-case-${item.id}-`);
+    const runName = `${String(caseIndex).padStart(2, '0')}-${item.id}-a${attempt}`;
+    const runDir = join(output, 'private', 'runs', runName);
+    privateMkdir(runDir);
+    const rawRequest = readFileSync(protocolAsset(protocolPath, item.raw_prompt_path), 'utf8');
+    const canonicalIssue = readFileSync(protocolAsset(protocolPath, item.canonical_issue_path), 'utf8');
+    const invalid = [];
+    const arms = [];
+    const attemptedLifecycles = [];
+    let shapedIssue = null;
+    let shapedTitle = null;
+    let intakeIssueCount = 0;
+    try {
+        const intakeWorkspace = join(privateRoot, 'intake');
+        createFixture({
+            protocol,
+            protocolPath,
+            source,
+            item,
+            mode: 'pipeline',
+            destination: intakeWorkspace,
+            dryRun,
+            dependencies: false,
+        });
+        const intake = runLifecycle({
+            protocol,
+            protocolPath,
+            output,
+            item,
+            workspace: intakeWorkspace,
+            runDir,
+            codexBin,
+            model,
+            effort,
+            timeoutMs,
+            codexHome,
+            dryRun,
+            arm: 'intake',
+            stage: 'intake',
+            attempt,
+            prompt: turnPrompt(protocol, protocolPath, { stage: 'intake', rawRequest }),
+            canonicalIssue,
+            sessionId: `${item.id}-intake-a${attempt}`,
+        });
+        attemptedLifecycles.push(intake);
+        invalid.push(...lifecycleInvalid(intake));
+        const created = trackerCreates(intake.turns);
+        intakeIssueCount = created.length;
+        if (created.length !== 1) invalid.push(`intake created ${created.length} issues instead of exactly one`);
+        else if (!isNonEmptyString(created[0].title) || !isNonEmptyString(created[0].body)) {
+            invalid.push('intake created an issue without a non-empty title and body');
+        } else {
+            shapedIssue = created[0].body;
+            shapedTitle = created[0].title;
+        }
+        privateWrite(join(runDir, 'intake', 'lifecycle.json'), `${JSON.stringify(lifecycleSummary(intake), null, 2)}\n`);
+        if (shapedIssue !== null) privateWrite(join(runDir, 'intake', 'created-issue.md'), shapedIssue);
+        if (shapedTitle !== null) privateWrite(join(runDir, 'intake', 'created-title.txt'), `${shapedTitle}\n`);
+        rmSync(intakeWorkspace, { recursive: true, force: true });
+
+        if (!invalid.length) {
+            for (const arm of ['raw-direct', 'shaped-direct']) {
+                const workspace = join(privateRoot, arm);
+                try {
+                    const fixture = createFixture({
+                        protocol, protocolPath, source, item, mode: 'neutral', destination: workspace, dryRun,
+                    });
+                    const input = arm === 'raw-direct'
+                        ? rawRequest
+                        : issueEnvelope(shapedTitle, shapedIssue);
+                    const lifecycle = runLifecycle({
+                        protocol,
+                        protocolPath,
+                        output,
+                        item,
+                        workspace,
+                        runDir,
+                        codexBin,
+                        model,
+                        effort,
+                        timeoutMs,
+                        codexHome,
+                        dryRun,
+                        arm,
+                        stage: 'direct',
+                        attempt,
+                        prompt: turnPrompt(protocol, protocolPath, {
+                            stage: 'direct',
+                            rawRequest,
+                            shapedIssue: arm === 'shaped-direct'
+                                ? issueEnvelope(shapedTitle, shapedIssue)
+                                : null,
+                        }),
+                        sessionId: `${item.id}-${arm}-a${attempt}`,
+                    });
+                    attemptedLifecycles.push(lifecycle);
+                    invalid.push(...lifecycleInvalid(lifecycle).map((reason) => `${arm}: ${reason}`));
+                    if (!lifecycle.valid) break;
+                    const snapshot = snapshotWorkspace({
+                        output, runDir, workspace, fixture, arm, stage: 'final',
+                    });
+                    const result = finalizeArm({
+                        protocol,
+                        output,
+                        runDir,
+                        source,
+                        item,
+                        workspace,
+                        fixture,
+                        codexBin,
+                        dryRun,
+                        codexHome,
+                        arm,
+                        snapshots: [snapshot],
+                        lifecycles: [lifecycle],
+                    });
+                    result.input_sha256 = arm === 'raw-direct'
+                        ? sha256(input)
+                        : issueEnvelopeHash(shapedTitle, shapedIssue);
+                    arms.push(result);
+                } finally {
+                    rmSync(workspace, { recursive: true, force: true });
+                }
+            }
+        }
+
+        if (!invalid.length) {
+            const arm = 'full-cycle';
+            const workspace = join(privateRoot, arm);
+            const fixture = createFixture({
+                protocol, protocolPath, source, item, mode: 'pipeline', destination: workspace, dryRun,
+            });
+            const session = persistentSession({
+                codexHome,
+                dryRun,
+                codexBin,
+                workspace,
+                issueBody: shapedIssue,
+                issueTitle: shapedTitle,
+            });
+            const lifecycles = [];
+            const snapshots = [];
+            let threadId = null;
+            try {
+                for (const stage of protocol.execution.full_cycle.resumed_stages) {
+                    const lifecycle = runLifecycle({
+                        protocol,
+                        protocolPath,
+                        output,
+                        item,
+                        workspace,
+                        runDir,
+                        codexBin,
+                        model,
+                        effort,
+                        timeoutMs,
+                        codexHome,
+                        dryRun,
+                        arm,
+                        stage,
+                        attempt,
+                        prompt: turnPrompt(protocol, protocolPath, { stage }),
+                        issueBody: shapedIssue,
+                        issueTitle: shapedTitle,
+                        threadId,
+                        sessionId: `${item.id}-${arm}-a${attempt}`,
+                        sessionContext: session,
+                    });
+                    lifecycles.push(lifecycle);
+                    attemptedLifecycles.push(lifecycle);
+                    invalid.push(...lifecycleInvalid(lifecycle).map((reason) => `${arm}: ${reason}`));
+                    if (!lifecycle.valid) break;
+                    if (threadId && lifecycle.thread_id !== threadId) {
+                        invalid.push('full-cycle changed Codex thread between stages');
+                        break;
+                    }
+                    threadId = lifecycle.thread_id;
+                    snapshots.push(snapshotWorkspace({
+                        output,
+                        runDir,
+                        workspace,
+                        fixture,
+                        arm,
+                        stage,
+                    }));
+                }
+            } finally {
+                session.cleanup();
+            }
+            if (!invalid.length && snapshots.length === 4) {
+                const result = finalizeArm({
+                    protocol,
+                    output,
+                    runDir,
+                    source,
+                    item,
+                    workspace,
+                    fixture,
+                    codexBin,
+                    dryRun,
+                    codexHome,
+                    arm,
+                    snapshots,
+                    lifecycles,
+                });
+                result.input_sha256 = issueEnvelopeHash(shapedTitle, shapedIssue);
+                arms.push(result);
+            } else if (!invalid.length) {
+                invalid.push(`full-cycle captured ${snapshots.length} stage snapshots instead of four`);
+            }
+        }
+
+        if (!invalid.length) {
+            const shapedHash = issueEnvelopeHash(shapedTitle, shapedIssue);
+            const shapedDirect = arms.find((arm) => arm.arm === 'shaped-direct');
+            const fullCycle = arms.find((arm) => arm.arm === 'full-cycle');
+            if (!shapedDirect || !fullCycle || shapedDirect.input_sha256 !== shapedHash
+                || fullCycle.input_sha256 !== shapedHash) {
+                invalid.push('shaped-direct and full-cycle did not receive byte-identical issue title and body text');
+            }
+            if (arms.length !== 3) invalid.push(`captured ${arms.length} arms instead of three`);
+        }
+
+        const result = {
+            study_id: protocol.study_id,
+            case_id: item.id,
+            case_index: caseIndex,
+            attempt,
+            valid: invalid.length === 0,
+            invalid_reasons: invalid,
+            model,
+            reasoning_effort: effort,
+            codex_version: codexVersionValue,
+            raw_request_sha256: sha256(rawRequest),
+            shaped_issue_sha256: shapedIssue === null ? null : sha256(shapedIssue),
+            shaped_issue_title_sha256: shapedTitle === null ? null : sha256(shapedTitle),
+            shaped_issue_envelope_sha256: shapedIssue === null || shapedTitle === null
+                ? null
+                : issueEnvelopeHash(shapedTitle, shapedIssue),
+            canonical_issue_sha256: sha256(canonicalIssue),
+            intake_issue_count: intakeIssueCount,
+            lifecycle: attemptedLifecycles.map(lifecycleSummary),
+            usage: usageSum(attemptedLifecycles.flatMap((lifecycle) => lifecycle.turns)),
+            model_turns_started: attemptedLifecycles.flatMap((lifecycle) => lifecycle.turns)
+                .filter((turn) => turn.model_turn_started).length,
+            model_turns_completed: attemptedLifecycles.flatMap((lifecycle) => lifecycle.turns)
+                .filter((turn) => turn.model_turn_completed).length,
+            arms,
+        };
+        result.artifacts = artifactManifest(output, runDir);
+        privateWrite(join(runDir, 'result.json'), `${JSON.stringify(result, null, 2)}\n`);
+        return result;
+    } finally {
+        rmSync(privateRoot, { recursive: true, force: true });
+    }
+}
+
+function ensureNewOutput(path) {
+    const output = resolve(path);
+    if (existsSync(output)) fail(`output already exists: ${output}`);
+    privateMkdir(output);
+    privateMkdir(join(output, 'private'));
+    return realpathSync(output);
+}
+
+function prepareBatchOutput(path) {
+    let output = resolve(path);
+    if (!existsSync(output)) return { output: ensureNewOutput(output), resume: false };
+    if (!statSync(output).isDirectory() || lstatSync(output).isSymbolicLink()) {
+        fail(`batch output is not a safe directory: ${output}`);
+    }
+    output = realpathSync(output);
+    recursiveFiles(output);
+    chmodSync(output, 0o700);
+    privateMkdir(join(output, 'private'));
+    return { output, resume: true };
+}
+
+function resultIndexPath(output) {
+    return join(output, 'private', 'results.jsonl');
+}
+
+function readResults(output) {
+    const path = resultIndexPath(output);
+    if (!existsSync(path)) return [];
+    const text = readFileSync(path, 'utf8').trim();
+    if (!text) return [];
+    return text.split('\n').map((line, index) => {
+        try { return JSON.parse(line); }
+        catch (error) { fail(`invalid resumable result at line ${index + 1}: ${error.message}`); }
+    });
+}
+
+function appendResult(output, result) {
+    const path = resultIndexPath(output);
+    privateMkdir(dirname(path));
+    writeFileSync(path, `${JSON.stringify(result)}\n`, { flag: 'a', mode: 0o600 });
+    chmodSync(path, 0o600);
+}
+
+function experimentPath(output) {
+    return join(output, 'private', 'experiment.json');
+}
+
+function experimentRecord({ protocol, protocolPath, model, effort, codexVersionValue, dryRun }) {
+    return {
+        study_id: protocol.study_id,
+        protocol_sha256: sha256(readFileSync(protocolPath)),
+        model,
+        reasoning_effort: effort,
+        codex_version: codexVersionValue,
+        dry_run: dryRun,
+        case_order: protocol.schedule.case_order,
+        arms: protocol.arms.map((arm) => arm.id),
+        cases_per_batch: protocol.schedule.cases_per_batch,
+    };
+}
+
+function loadOrCreateExperiment({ protocol, protocolPath, output, model, effort, codexVersionValue, dryRun }) {
+    const expected = experimentRecord({ protocol, protocolPath, model, effort, codexVersionValue, dryRun });
+    const path = experimentPath(output);
+    if (!existsSync(path)) {
+        privateWrite(path, `${JSON.stringify(expected, null, 2)}\n`);
+        return expected;
+    }
+    let actual;
+    try { actual = JSON.parse(readFileSync(path, 'utf8')); }
+    catch (error) { fail(`invalid resumable experiment record: ${error.message}`); }
+    if (stableJson(actual) !== stableJson(expected)) fail('resumable experiment identity changed');
+    return actual;
+}
+
+function validateArtifactFile(output, rel, expectedHash) {
+    const path = resolve(output, rel);
+    ensureInside(output, path);
+    if (!existsSync(path) || !lstatSync(path).isFile() || lstatSync(path).isSymbolicLink()) {
+        fail(`missing or unsafe resumable artifact: ${rel}`);
+    }
+    if ((lstatSync(path).mode & 0o077) !== 0) fail(`resumable artifact is not private: ${rel}`);
+    if (sha256(readFileSync(path)) !== expectedHash) fail(`resumable artifact content changed: ${rel}`);
+}
+
+function validatePersistedResult({ protocol, output, experiment, result, expectedItem, expectedIndex, expectedAttempt }) {
+    if (!result || typeof result !== 'object' || Array.isArray(result)) fail('resumable result is not an object');
+    const identity = {
+        study_id: protocol.study_id,
+        case_id: expectedItem.id,
+        case_index: expectedIndex,
+        attempt: expectedAttempt,
+        model: experiment.model,
+        reasoning_effort: experiment.reasoning_effort,
+        codex_version: experiment.codex_version,
+    };
+    for (const [key, value] of Object.entries(identity)) {
+        if (result[key] !== value) fail(`resumable result identity mismatch: ${key}`);
+    }
+    if (typeof result.valid !== 'boolean' || !Array.isArray(result.invalid_reasons)
+        || !result.artifacts || typeof result.artifacts !== 'object') {
+        fail(`resumable result for ${expectedItem.id} has invalid status fields`);
+    }
+    const runName = `${String(expectedIndex).padStart(2, '0')}-${expectedItem.id}-a${expectedAttempt}`;
+    const expectedPrefix = `private/runs/${runName}/`;
+    for (const [rel, digest] of Object.entries(result.artifacts)) {
+        if (!rel.startsWith(expectedPrefix) || rel.endsWith('/result.json')) {
+            fail(`resumable result has an unexpected artifact path: ${rel}`);
+        }
+        validateArtifactFile(output, rel, digest);
+    }
+    const resultPath = join(output, 'private', 'runs', runName, 'result.json');
+    if (!existsSync(resultPath) || (lstatSync(resultPath).mode & 0o077) !== 0) {
+        fail(`missing private result artifact for ${expectedItem.id} attempt ${expectedAttempt}`);
+    }
+    let persisted;
+    try { persisted = JSON.parse(readFileSync(resultPath, 'utf8')); }
+    catch (error) { fail(`invalid private result artifact for ${expectedItem.id}: ${error.message}`); }
+    if (stableJson(persisted) !== stableJson(result)) {
+        fail(`resumable result index disagrees with ${relative(output, resultPath)}`);
+    }
+}
+
+export function validateProgress({ protocol, output, experiment, results }) {
+    let cursor = 0;
+    let completedCases = 0;
+    let terminalInvalidCase = null;
+    for (let index = 0; index < protocol.cases.length; index += 1) {
+        const item = protocol.cases[index];
+        const caseIndex = index + 1;
+        if (cursor === results.length) break;
+        const first = results[cursor];
+        validatePersistedResult({
+            protocol,
+            output,
+            experiment,
+            result: first,
+            expectedItem: item,
+            expectedIndex: caseIndex,
+            expectedAttempt: 1,
+        });
+        cursor += 1;
+        if (first.valid) {
+            completedCases += 1;
+            continue;
+        }
+        if (cursor === results.length) break;
+        const retry = results[cursor];
+        validatePersistedResult({
+            protocol,
+            output,
+            experiment,
+            result: retry,
+            expectedItem: item,
+            expectedIndex: caseIndex,
+            expectedAttempt: 2,
+        });
+        cursor += 1;
+        if (retry.valid) completedCases += 1;
+        else terminalInvalidCase = item.id;
+        if (terminalInvalidCase) break;
+    }
+    if (cursor !== results.length) fail('resumable results are not an exact prefix of the frozen schedule');
+    return {
+        completedCases,
+        terminalInvalidCase,
+        complete: completedCases === protocol.cases.length,
+        nextCase: terminalInvalidCase ? null : protocol.cases[completedCases] ?? null,
+    };
+}
+
+function acceptedResults(protocol, results) {
+    const accepted = new Map();
+    for (const item of protocol.cases) {
+        const attempts = results.filter((result) => result.case_id === item.id);
+        const latest = attempts.at(-1);
+        if (latest?.valid) accepted.set(item.id, latest);
+    }
+    return accepted;
+}
+
+function seededRank(seed, value) {
+    return sha256(`${seed}\0${value}`);
+}
+
+function resultCreatedIssuePath(result) {
+    return Object.keys(result.artifacts).find((path) => path.endsWith('/intake/created-issue.md')) ?? null;
+}
+
+function resultCreatedTitlePath(result) {
+    return Object.keys(result.artifacts).find((path) => path.endsWith('/intake/created-title.txt')) ?? null;
+}
+
+function normalizedGateEvidence(arm) {
+    return arm.command_evidence
+        .filter((record) => /(?:^|\s)(?:npm|npx|node) (?:test|run|--test|vitest|tsc|lint|build|check)/.test(record.command))
+        .map((record) => ({ command: normalizePublicText(record.command), exit_code: record.exit_code }));
+}
+
+function normalizePublicText(value) {
+    return String(value)
+        .replace(/file:\/\/\/(?:home|tmp)\/[^\s"'`<>]+/g, '<host-path>')
+        .replace(/(?:\/home\/[^/\s]+|\/tmp)\/[^\s"'`<>]+/g, '<host-path>');
+}
+
+function writeScoringArtifacts({ protocol, protocolPath, output, results }) {
+    const accepted = acceptedResults(protocol, results);
+    if (accepted.size !== protocol.cases.length) fail('cannot normalize an incomplete pipeline experiment');
+    const scoringRoot = join(output, 'scoring');
+    const fixtureRoot = join(scoringRoot, 'fixtures');
+    privateMkdir(fixtureRoot);
+    const packets = [];
+    const map = [];
+    for (const item of protocol.cases) {
+        const result = accepted.get(item.id);
+        const packetId = sha256(`${protocol.schedule.seed}\0packet\0${item.id}`).slice(0, 16);
+        const issuePath = resultCreatedIssuePath(result);
+        const titlePath = resultCreatedTitlePath(result);
+        if (!issuePath || !titlePath) fail(`missing intake issue artifact for ${item.id}`);
+        const shapedIssue = normalizePublicText(readFileSync(join(output, issuePath), 'utf8'));
+        const shapedTitle = normalizePublicText(readFileSync(join(output, titlePath), 'utf8').trimEnd());
+        const ordered = [...result.arms].sort((a, b) => seededRank(
+            protocol.schedule.seed,
+            `${item.id}:${a.arm}`,
+        ).localeCompare(seededRank(protocol.schedule.seed, `${item.id}:${b.arm}`)));
+        const outputs = ordered.map((arm, index) => {
+            const label = String.fromCharCode(65 + index);
+            const destination = join('fixtures', `${packetId}-${label}.diff`);
+            const rawDiff = readFileSync(join(output, arm.final_diff));
+            if (rawDiff.includes(Buffer.from('GIT binary patch'))) {
+                fail(`cannot publish a binary scoring diff for ${item.id}`);
+            }
+            const bytes = Buffer.from(normalizePublicText(rawDiff.toString('utf8')));
+            privateWrite(join(scoringRoot, destination), bytes);
+            map.push({ packet_id: packetId, output_label: label, case_id: item.id, arm: arm.arm });
+            return {
+                output_label: label,
+                final_diff: destination,
+                final_diff_sha256: sha256(bytes),
+                changed_paths: arm.changed_paths,
+                hidden_oracle: arm.hidden_oracle.status,
+                gate_evidence: normalizedGateEvidence(arm),
+            };
+        });
+        packets.push({
+            packet_id: packetId,
+            raw_request: normalizePublicText(
+                readFileSync(protocolAsset(protocolPath, item.raw_prompt_path), 'utf8'),
+            ),
+            historical_reference_title: item.title,
+            historical_reference_issue: normalizePublicText(readFileSync(
+                protocolAsset(protocolPath, item.canonical_issue_path), 'utf8',
+            )),
+            intake_produced_title: shapedTitle,
+            intake_produced_issue: shapedIssue,
+            outputs,
+        });
+    }
+    const scoringInput = {
+        version: 1,
+        study_id: protocol.study_id,
+        instructions: {
+            primary: protocol.scoring.primary,
+            process_quality: protocol.scoring.process_quality,
+            analysis: protocol.scoring.analysis,
+            independence: 'Two scorers lock separate schema-valid files before the arm map is revealed.',
+        },
+        packets,
+    };
+    const scoringBytes = Buffer.from(`${JSON.stringify(scoringInput, null, 2)}\n`);
+    const scoreSchema = readFileSync(protocolAsset(protocolPath, protocol.scoring.schema_path));
+    privateWrite(join(scoringRoot, 'scoring-input.json'), scoringBytes);
+    privateWrite(join(scoringRoot, 'score.schema.json'), scoreSchema);
+    const blindingBytes = Buffer.from(`${JSON.stringify(map, null, 2)}\n`);
+    privateWrite(join(output, 'private', 'blinding-map.json'), blindingBytes);
+    privateWrite(join(scoringRoot, 'manifest.json'), `${JSON.stringify({
+        scoring_input_sha256: sha256(scoringBytes),
+        score_schema_sha256: sha256(scoreSchema),
+        blinding_map_sha256: sha256(blindingBytes),
+        packet_count: packets.length,
+        output_count: packets.length * 3,
+        fixture_diffs: packets.flatMap((packet) => packet.outputs.map((arm) => ({
+            packet_id: packet.packet_id,
+            output_label: arm.output_label,
+            sha256: arm.final_diff_sha256,
+        }))),
+    }, null, 2)}\n`);
+}
+
+function validateScoringArtifacts(output) {
+    const manifestPath = join(output, 'scoring', 'manifest.json');
+    let manifest;
+    try { manifest = JSON.parse(readFileSync(manifestPath, 'utf8')); }
+    catch (error) { fail(`invalid resumable scoring manifest: ${error.message}`); }
+    const fixed = [
+        ['scoring/scoring-input.json', manifest.scoring_input_sha256],
+        ['scoring/score.schema.json', manifest.score_schema_sha256],
+        ['private/blinding-map.json', manifest.blinding_map_sha256],
+    ];
+    for (const [rel, digest] of fixed) validateArtifactFile(output, rel, digest);
+    if (!Array.isArray(manifest.fixture_diffs) || manifest.fixture_diffs.length !== 12) {
+        fail('resumable scoring manifest has an invalid fixture list');
+    }
+    for (const fixture of manifest.fixture_diffs) {
+        if (!isNonEmptyString(fixture.packet_id) || !/^[ABC]$/.test(fixture.output_label ?? '')
+            || !/^[0-9a-f]{64}$/.test(fixture.sha256 ?? '')) {
+            fail('resumable scoring manifest has an invalid fixture record');
+        }
+        validateArtifactFile(
+            output,
+            `scoring/fixtures/${fixture.packet_id}-${fixture.output_label}.diff`,
+            fixture.sha256,
+        );
+    }
+    return manifest;
+}
+
+function summarize(protocol, results) {
+    const valid = acceptedResults(protocol, results);
+    const allTurns = results.flatMap((result) => result.lifecycle.flatMap((stage) => stage.turns));
+    return {
+        complete: valid.size === protocol.cases.length,
+        completed_cases: valid.size,
+        total_cases: protocol.cases.length,
+        remaining_cases: protocol.cases.length - valid.size,
+        attempts: results.length,
+        invalid_attempts: results.filter((result) => !result.valid).length,
+        model_turns_started: allTurns.filter((turn) => turn.model_turn_started).length,
+        model_turns_completed: allTurns.filter((turn) => turn.model_turn_completed).length,
+        usage: usageSum(allTurns),
+    };
+}
+
+function withBatchLock(output, callback) {
+    const lock = join(output, '.batch.lock');
+    let descriptor;
+    try {
+        descriptor = openSync(lock, 'wx', 0o600);
+    } catch (error) {
+        fail(`cannot acquire batch lock ${lock}: ${error.message}`);
+    }
+    closeSync(descriptor);
+    try { return callback(); }
+    finally { rmSync(lock, { force: true }); }
+}
+
+function runExperiment({
+    protocol,
+    protocolPath,
+    source,
+    output,
+    codexBin,
+    model,
+    effort,
+    timeoutMs,
+    dryRun,
+    codexHome,
+    maxCases = Number.POSITIVE_INFINITY,
+}) {
+    const version = codexVersion(codexBin);
+    const experiment = loadOrCreateExperiment({
+        protocol,
+        protocolPath,
+        output,
+        model,
+        effort,
+        codexVersionValue: version,
+        dryRun,
+    });
+    let results = readResults(output);
+    let progress = validateProgress({ protocol, output, experiment, results });
+    const active = join(output, 'private', 'active-case.json');
+    if (existsSync(active)) fail(`stale active-case marker requires inspection: ${active}`);
+    const scoringExists = existsSync(join(output, 'scoring'));
+    if (!progress.complete && scoringExists) fail('scoring artifacts exist before the experiment is complete');
+    if (progress.complete && scoringExists) validateScoringArtifacts(output);
+    if (progress.terminalInvalidCase) fail(`experiment stopped at invalid case ${progress.terminalInvalidCase}`);
+    let processed = 0;
+    while (!progress.complete && processed < maxCases) {
+        const item = progress.nextCase;
+        const caseIndex = protocol.cases.findIndex((entry) => entry.id === item.id) + 1;
+        privateWrite(active, `${JSON.stringify({ case_id: item.id, case_index: caseIndex, attempt: 1 }, null, 2)}\n`);
+        let accepted = false;
+        let caseCheckpointed = false;
+        try {
+            for (let attempt = 1; attempt <= protocol.schedule.invalid_case_retry_limit + 1; attempt += 1) {
+                privateWrite(active, `${JSON.stringify({ case_id: item.id, case_index: caseIndex, attempt }, null, 2)}\n`);
+                const result = executeCaseAttempt({
+                    protocol,
+                    protocolPath,
+                    source,
+                    output,
+                    item,
+                    caseIndex,
+                    attempt,
+                    codexBin,
+                    model,
+                    effort,
+                    timeoutMs,
+                    dryRun,
+                    codexHome,
+                    codexVersionValue: version,
+                });
+                appendResult(output, result);
+                results.push(result);
+                if (result.valid) {
+                    accepted = true;
+                    break;
+                }
+            }
+            caseCheckpointed = true;
+        } finally {
+            if (caseCheckpointed) rmSync(active, { force: true });
+        }
+        processed += 1;
+        progress = validateProgress({ protocol, output, experiment, results });
+        if (!accepted || progress.terminalInvalidCase) break;
+    }
+    const summary = summarize(protocol, results);
+    privateWrite(join(output, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`);
+    if (summary.complete) {
+        if (!existsSync(join(output, 'scoring', 'scoring-input.json'))) {
+            writeScoringArtifacts({ protocol, protocolPath, output, results });
+        } else {
+            validateScoringArtifacts(output);
+        }
+    }
+    const receipt = {
+        completed_cases: summary.completed_cases,
+        total_cases: summary.total_cases,
+        remaining_cases: summary.remaining_cases,
+        attempts: summary.attempts,
+        invalid_attempts: summary.invalid_attempts,
+        model_turns_started: summary.model_turns_started,
+        model_turns_completed: summary.model_turns_completed,
+        reported_token_usage: summary.usage,
+        complete: summary.complete,
+    };
+    return { summary, receipt, terminalInvalidCase: progress.terminalInvalidCase };
+}
+
+export function buildPlan(protocol) {
+    return {
+        study_id: protocol.study_id,
+        model: protocol.execution.model,
+        reasoning_effort: protocol.execution.reasoning_effort,
+        cases_per_batch: protocol.schedule.cases_per_batch,
+        case_order: protocol.schedule.case_order,
+        arm_order_within_case: protocol.arms.map((arm) => arm.id),
+        lifecycle_per_case: {
+            common_intake: ['intake'],
+            raw_direct: ['direct'],
+            shaped_direct: ['direct'],
+            full_cycle: protocol.execution.full_cycle.resumed_stages,
+        },
+        minimum_model_turns_per_valid_case: 7,
+        maximum_model_turns_per_attempt: 28,
+        whole_case_retry_limit: protocol.schedule.invalid_case_retry_limit,
+        scored_model_calls_in_setup_issue: 0,
+    };
+}
+
+function usage() {
+    return `Usage:
+  node eval/pipeline/run.mjs lock --source <songsiknow-checkout>
+  node eval/pipeline/run.mjs plan
+  node eval/pipeline/run.mjs dry-run --output <new-directory>
+  node eval/pipeline/run.mjs dry-run-batch --output <new-or-resumable-directory>
+  node eval/pipeline/run.mjs preflight --source <songsiknow-checkout> --output <new-directory>
+       [--skip-oracles]
+  node eval/pipeline/run.mjs run --source <songsiknow-checkout> --output <new-directory>
+       --confirm-protocol-sha256 <sha256> [--codex-home <path>]
+  node eval/pipeline/run.mjs run-batch --source <songsiknow-checkout>
+       --output <new-or-resumable-directory> --confirm-protocol-sha256 <sha256>
+       [--codex-home <path>]
+
+Options:
+  --protocol <path>       Protocol file, default: eval/pipeline/protocol.json
+  --codex-bin <path>      Codex executable; dry runs default to the bundled fake
+  --timeout-ms <number>   Dry-run override; scored runs use the frozen timeout
+`;
+}
+
+export function main(argv = process.argv.slice(2)) {
+    const { values, positionals } = parseArgs({
+        args: argv,
+        allowPositionals: true,
+        strict: true,
+        options: {
+            protocol: { type: 'string', default: DEFAULT_PROTOCOL },
+            source: { type: 'string' },
+            output: { type: 'string' },
+            'codex-bin': { type: 'string' },
+            'codex-home': { type: 'string' },
+            'confirm-protocol-sha256': { type: 'string' },
+            'timeout-ms': { type: 'string' },
+            'skip-oracles': { type: 'boolean', default: false },
+            help: { type: 'boolean', short: 'h', default: false },
+        },
+    });
+    if (values.help || positionals.length !== 1) {
+        console.log(usage());
+        return values.help ? 0 : 2;
+    }
+    const command = positionals[0];
+    const { protocol, protocolPath } = loadProtocol(values.protocol, { requireLock: command !== 'lock' });
+    if (command === 'lock') {
+        if (!values.source) fail('lock requires --source');
+        console.log(JSON.stringify(computeArtifactLock(protocol, protocolPath, values.source), null, 2));
+        return 0;
+    }
+    if (command === 'plan') {
+        assertLocalArtifactLock(protocol, protocolPath);
+        console.log(JSON.stringify({
+            ...buildPlan(protocol),
+            protocol_sha256: sha256(readFileSync(protocolPath)),
+        }, null, 2));
+        return 0;
+    }
+    const commands = ['dry-run', 'dry-run-batch', 'preflight', 'run', 'run-batch'];
+    if (!commands.includes(command)) fail(`unknown command: ${command}`);
+    if (!values.output) fail(`${command} requires --output`);
+    const timeoutMs = Number(values['timeout-ms'] ?? protocol.execution.timeout_ms_per_turn);
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1) fail('--timeout-ms must be a positive integer');
+    const batch = command === 'dry-run-batch' || command === 'run-batch';
+    const prepared = batch
+        ? prepareBatchOutput(values.output)
+        : { output: ensureNewOutput(values.output), resume: false };
+    const { output } = prepared;
+
+    if (command === 'dry-run' || command === 'dry-run-batch') {
+        assertLocalArtifactLock(protocol, protocolPath);
+        const codexBin = resolve(values['codex-bin'] ?? DEFAULT_FAKE_CODEX);
+        const config = probePipelineConfig(codexBin);
+        privateWrite(join(output, 'dry-preflight.json'), `${JSON.stringify({
+            study_id: protocol.study_id,
+            strict_config: config,
+            scored_model_calls: 0,
+        }, null, 2)}\n`);
+        const execute = () => runExperiment({
+            protocol,
+            protocolPath,
+            output,
+            codexBin,
+            model: 'fake-pipeline-model',
+            effort: protocol.execution.reasoning_effort,
+            timeoutMs,
+            dryRun: true,
+            maxCases: command === 'dry-run-batch' ? protocol.schedule.cases_per_batch : Number.POSITIVE_INFINITY,
+        });
+        const result = batch ? withBatchLock(output, execute) : execute();
+        console.log(JSON.stringify(result.receipt, null, 2));
+        if (result.terminalInvalidCase) fail(`experiment stopped at invalid case ${result.terminalInvalidCase}`);
+        return 0;
+    }
+
+    if (!values.source) fail(`${command} requires --source`);
+    const source = verifySource(values.source, protocol);
+    const codexBin = resolveExecutable(values['codex-bin'] ?? 'codex');
+    if (command === 'preflight') {
+        preflight({
+            protocol,
+            protocolPath,
+            source,
+            output,
+            codexBin,
+            skipOracles: values['skip-oracles'],
+        });
+        return 0;
+    }
+    const expected = sha256(readFileSync(protocolPath));
+    if (values['confirm-protocol-sha256'] !== expected) {
+        fail(`${command} requires --confirm-protocol-sha256 ${expected}`);
+    }
+    if (timeoutMs !== protocol.execution.timeout_ms_per_turn) {
+        fail(`${command} timeout is frozen at ${protocol.execution.timeout_ms_per_turn}ms`);
+    }
+    if (values['skip-oracles']) fail(`${command} cannot skip hidden-oracle preflight`);
+    const execute = () => {
+        preflight({ protocol, protocolPath, source, output, codexBin, skipOracles: false });
+        const result = runExperiment({
+            protocol,
+            protocolPath,
+            source,
+            output,
+            codexBin,
+            model: protocol.execution.model,
+            effort: protocol.execution.reasoning_effort,
+            timeoutMs,
+            dryRun: false,
+            codexHome: values['codex-home'],
+            maxCases: command === 'run-batch'
+                ? protocol.schedule.cases_per_batch
+                : Number.POSITIVE_INFINITY,
+        });
+        if (command === 'run-batch') console.log(JSON.stringify(result.receipt, null, 2));
+        if (result.terminalInvalidCase) fail(`experiment stopped at invalid case ${result.terminalInvalidCase}`);
+        return 0;
+    };
+    return batch ? withBatchLock(output, execute) : execute();
+}
+
+function invokedDirectly() {
+    return process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+}
+
+if (invokedDirectly()) {
+    try {
+        process.exitCode = main();
+    } catch (error) {
+        if (error instanceof PipelineEvalError) {
+            console.error(error.message);
+            process.exitCode = 2;
+        } else {
+            throw error;
+        }
+    }
+}

--- a/eval/pipeline/score.schema.json
+++ b/eval/pipeline/score.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "scorer", "cases"],
+  "properties": {
+    "version": { "const": 1 },
+    "scorer": { "type": "string", "minLength": 1 },
+    "cases": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["packet_id", "outcomes", "process_quality", "notes"],
+        "properties": {
+          "packet_id": { "type": "string", "minLength": 8 },
+          "outcomes": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["A", "B", "C"],
+            "properties": {
+              "A": { "$ref": "#/$defs/outcome" },
+              "B": { "$ref": "#/$defs/outcome" },
+              "C": { "$ref": "#/$defs/outcome" }
+            }
+          },
+          "process_quality": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["A", "B", "C"],
+            "properties": {
+              "A": { "$ref": "#/$defs/quality" },
+              "B": { "$ref": "#/$defs/quality" },
+              "C": { "$ref": "#/$defs/quality" }
+            }
+          },
+          "notes": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["A", "B", "C"],
+            "properties": {
+              "A": { "type": "string", "minLength": 1 },
+              "B": { "type": "string", "minLength": 1 },
+              "C": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "outcome": { "type": "string", "enum": ["pass", "fail", "invalid"] },
+    "ordinal": { "type": "string", "enum": ["weak", "adequate", "strong"] },
+    "quality": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scope_control", "decision_handling", "test_quality", "evidence_quality"],
+      "properties": {
+        "scope_control": { "$ref": "#/$defs/ordinal" },
+        "decision_handling": { "$ref": "#/$defs/ordinal" },
+        "test_quality": { "$ref": "#/$defs/ordinal" },
+        "evidence_quality": { "$ref": "#/$defs/ordinal" }
+      }
+    }
+  }
+}

--- a/eval/pipeline/stage-prompt.md
+++ b/eval/pipeline/stage-prompt.md
@@ -1,0 +1,5 @@
+Continue the frozen full-pipeline evaluation in this same session. Run exactly the requested
+workflow stage named below, following the repository skill for that stage. Do not use the network or
+inspect paths outside the repository. When a material decision is required, return `needs-input`
+with one concise question. Otherwise complete the stage and return `complete`. Always obey the
+requested structured-output schema; set `question` to an empty string when complete.

--- a/eval/pipeline/turn.schema.json
+++ b/eval/pipeline/turn.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["status", "question", "summary"],
+  "properties": {
+    "status": { "type": "string", "enum": ["needs-input", "complete"] },
+    "question": { "type": "string" },
+    "summary": { "type": "string" }
+  }
+}

--- a/test/pipeline-eval.test.mjs
+++ b/test/pipeline-eval.test.mjs
@@ -1,0 +1,379 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+    chmodSync,
+    lstatSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    readdirSync,
+    rmSync,
+    statSync,
+    symlinkSync,
+    writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+    assertNoCredentialMaterial,
+    buildPlan,
+    clientEnvironment,
+    loadProtocol,
+    parseExecEvents,
+    pipelineConfig,
+    probePipelineConfig,
+    sanitizeCandidateRepository,
+    scriptedAnswer,
+    sha256,
+    trackerCreates,
+    validateTurnText,
+} from '../eval/pipeline/run.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PIPELINE_ROOT = join(ROOT, 'eval', 'pipeline');
+const RUNNER = join(PIPELINE_ROOT, 'run.mjs');
+const PROTOCOL_PATH = join(PIPELINE_ROOT, 'protocol.json');
+
+function json(path) {
+    return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function hashFiles(paths) {
+    const hash = createHash('sha256');
+    for (const rel of paths) {
+        hash.update(rel);
+        hash.update('\0');
+        hash.update(readFileSync(join(PIPELINE_ROOT, rel)));
+        hash.update('\0');
+    }
+    return hash.digest('hex');
+}
+
+function permissionBits(path) {
+    return statSync(path).mode & 0o777;
+}
+
+function assertPrivateTree(path) {
+    assert.equal(permissionBits(path), 0o700, `${path} must be mode 0700`);
+    for (const entry of readdirSync(path, { withFileTypes: true })) {
+        const child = join(path, entry.name);
+        if (entry.isDirectory()) assertPrivateTree(child);
+        else assert.equal(permissionBits(child), 0o600, `${child} must be mode 0600`);
+    }
+}
+
+test('pipeline protocol freezes the census, three arms, four cases, and local artifacts', () => {
+    const { protocol } = loadProtocol(PROTOCOL_PATH);
+    assert.deepEqual(protocol.schedule.case_order, ['sik-133', 'sik-131', 'sik-139', 'sik-123']);
+    assert.deepEqual(protocol.arms.map((arm) => arm.id), ['raw-direct', 'shaped-direct', 'full-cycle']);
+    assert.equal(protocol.schedule.cases_per_batch, 1);
+    assert.equal(protocol.schedule.invalid_case_retry_limit, 1);
+    assert.equal(protocol.execution.model, 'gpt-5.6-sol');
+    assert.equal(protocol.execution.reasoning_effort, 'high');
+    assert.equal(protocol.execution.codex_version, 'codex-cli 0.150.1');
+    assert.equal(protocol.execution.command_network, false);
+    assert.equal(protocol.execution.subagents, false);
+    assert.deepEqual(protocol.execution.full_cycle.resumed_stages, ['implement', 'review', 'patch', 'done']);
+    assert.equal(buildPlan(protocol).minimum_model_turns_per_valid_case, 7);
+    const scoreSchema = json(join(PIPELINE_ROOT, protocol.scoring.schema_path));
+    const scoreCase = scoreSchema.properties.cases.items.properties;
+    assert.deepEqual(scoreCase.outcomes.required, ['A', 'B', 'C']);
+    assert.deepEqual(scoreCase.process_quality.required, ['A', 'B', 'C']);
+    assert.deepEqual(scoreCase.notes.required, ['A', 'B', 'C']);
+    assert.deepEqual([123, 130, 131, 133, 139]
+        .map((issue) => ({ issue, rank: sha256(`full-pipeline-pilot-v1-2026-08-30:${issue}`) }))
+        .sort((a, b) => a.rank.localeCompare(b.rank))
+        .map(({ issue }) => issue), [133, 131, 139, 123, 130]);
+
+    assert.equal(sha256(readFileSync(RUNNER)), protocol.artifact_lock.runner_sha256);
+    assert.equal(
+        sha256(readFileSync(join(PIPELINE_ROOT, 'fake-codex.cjs'))),
+        protocol.artifact_lock.fake_codex_sha256,
+    );
+    assert.equal(
+        hashFiles(['bin/gh', 'bin/fake-gh.cjs']),
+        protocol.artifact_lock.fake_tracker_sha256,
+    );
+    assert.equal(
+        sha256(readFileSync(join(PIPELINE_ROOT, 'bin', 'git'))),
+        protocol.artifact_lock.fake_git_sha256,
+    );
+    assert.equal(
+        sha256(readFileSync(join(PIPELINE_ROOT, protocol.census_path))),
+        protocol.artifact_lock.census_sha256,
+    );
+    for (const item of protocol.cases) {
+        const lock = protocol.artifact_lock.cases[item.id];
+        assert.equal(
+            sha256(readFileSync(join(PIPELINE_ROOT, item.raw_prompt_path))),
+            lock.raw_prompt_sha256,
+        );
+        assert.equal(
+            sha256(readFileSync(join(PIPELINE_ROOT, item.canonical_issue_path))),
+            lock.canonical_issue_sha256,
+        );
+        assert.equal(
+            sha256(readFileSync(join(PIPELINE_ROOT, item.answer_sheet_path))),
+            lock.answer_sheet_sha256,
+        );
+    }
+});
+
+test('pipeline config grants one writable workspace and drops ambient credentials', () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-pipeline-config-test-'));
+    try {
+        const workspace = join(scratch, 'workspace');
+        mkdirSync(workspace);
+        const config = pipelineConfig({
+            workspace,
+            codexBin: join(PIPELINE_ROOT, 'fake-codex.cjs'),
+            issueBody: 'body',
+            issueTitle: 'title',
+        });
+        assert.match(config, /":root" = "deny"/);
+        assert.match(config, /":minimal" = "read"/);
+        assert.match(config, new RegExp(`${workspace.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}" = "write"`));
+        assert.match(config, /\[permissions\.pipeline-fixture\.network\]\nenabled = false/);
+        assert.match(config, /\[shell_environment_policy\]\ninherit = "none"/);
+        assert.match(config, /multi_agent = false/);
+        assert.doesNotMatch(config, /OPENAI_API_KEY|GH_TOKEN|NPM_TOKEN/);
+        const neutralConfig = pipelineConfig({
+            workspace,
+            codexBin: join(PIPELINE_ROOT, 'fake-codex.cjs'),
+        });
+        assert.doesNotMatch(neutralConfig, /CYCLE_PIPELINE_ISSUE_(?:BODY|TITLE|LABEL)/);
+
+        const env = clientEnvironment({
+            clientHome: '/private/client',
+            scratch: '/private/tmp',
+            caseId: 'sik-123',
+            arm: 'raw-direct',
+            stage: 'direct',
+            attempt: 1,
+            turn: 1,
+            sessionId: 'session',
+        }, {
+            PATH: '/usr/bin:/bin',
+            OPENAI_API_KEY: 'secret',
+            GH_TOKEN: 'secret',
+            NPM_TOKEN: 'secret',
+        });
+        assert.equal(env.OPENAI_API_KEY, undefined);
+        assert.equal(env.GH_TOKEN, undefined);
+        assert.equal(env.NPM_TOKEN, undefined);
+        assert.equal(env.HOME, '/private/client');
+        assert.match(env.PATH, /eval\/pipeline\/bin/);
+
+        const auth = join(scratch, 'auth.json');
+        const token = 'pipeline-auth-fingerprint-1234567890';
+        writeFileSync(auth, `${JSON.stringify({ token })}\n`);
+        assert.doesNotThrow(() => assertNoCredentialMaterial(['ordinary output'], auth));
+        assert.throws(
+            () => assertNoCredentialMaterial([`accidental ${token} disclosure`], auth),
+            /authentication material/,
+        );
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
+test('turn parsing and frozen answer selection reject malformed lifecycle output', () => {
+    const parsed = parseExecEvents([
+        JSON.stringify({ type: 'thread.started', thread_id: 'thread' }),
+        JSON.stringify({ type: 'turn.started' }),
+        JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 7, output_tokens: 3 } }),
+        '',
+    ].join('\n'));
+    assert.equal(parsed.invalid, null);
+    assert.deepEqual(parsed.usage, { input_tokens: 7, output_tokens: 3 });
+    assert.equal(parseExecEvents('null\nnot json\n').invalid,
+        'malformed JSONL at line(s) 2; invalid JSONL event at line(s) 1');
+
+    assert.deepEqual(validateTurnText(JSON.stringify({
+        status: 'complete', question: '', summary: 'done',
+    })), {
+        invalid: null,
+        value: { status: 'complete', question: '', summary: 'done' },
+    });
+    assert.equal(validateTurnText('not json').invalid, 'final response is not JSON');
+    assert.equal(validateTurnText(JSON.stringify({
+        status: 'needs-input', question: '', summary: 'missing question',
+    })).invalid, 'final response does not match turn.schema.json');
+
+    const sheet = json(join(PIPELINE_ROOT, 'answers', 'sik-133.json'));
+    assert.equal(scriptedAnswer(sheet, 'Do you approve this draft for filing?').rule_id, 'approve-filing');
+    assert.equal(scriptedAnswer(sheet, 'Which byte limit should I use?').rule_id, 'default');
+
+    const marker = (name, value) => `CYCLE_PIPELINE_TRACKER_${name}:${Buffer.from(value).toString('base64')}`;
+    assert.deepEqual(trackerCreates([{ events: [{
+        type: 'item.completed',
+        item: {
+            type: 'command_execution',
+            aggregated_output: [
+                marker('CREATE', 'first body'), marker('TITLE', 'first title'),
+                marker('CREATE', 'second body'), marker('TITLE', 'second title'),
+            ].join('\n'),
+        },
+    }] }]), [
+        { body: 'first body', title: 'first title' },
+        { body: 'second body', title: 'second title' },
+    ]);
+});
+
+test('fake Codex passes the strict model-free profile probe without authentication', () => {
+    assert.deepEqual(probePipelineConfig(join(PIPELINE_ROOT, 'fake-codex.cjs')), {
+        strict_config: 'pass',
+        authentication: 'absent',
+        model_calls: 0,
+    });
+});
+
+test('candidate Git controls are pinned and sanitized before evaluator-side inspection', () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-pipeline-git-control-test-'));
+    try {
+        const workspace = join(scratch, 'workspace');
+        mkdirSync(workspace);
+        execFileSync('/usr/bin/git', ['init', '-q', '-b', 'main'], { cwd: workspace });
+        const original = lstatSync(join(workspace, '.git'));
+        const identity = { dev: original.dev, ino: original.ino };
+        execFileSync('/usr/bin/git', ['config', 'core.fsmonitor', '/bin/false'], { cwd: workspace });
+        sanitizeCandidateRepository(workspace, identity);
+        assert.doesNotMatch(readFileSync(join(workspace, '.git', 'config'), 'utf8'), /fsmonitor/i);
+
+        const replacement = join(scratch, 'replacement.git');
+        mkdirSync(replacement);
+        rmSync(join(workspace, '.git'), { recursive: true, force: true });
+        symlinkSync(replacement, join(workspace, '.git'));
+        assert.throws(
+            () => sanitizeCandidateRepository(workspace, identity),
+            /replaced its \.git control directory/,
+        );
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
+test('model-free full pilot exercises follow-ups, retry, three arms, four resumed stages, and blinding', {
+    timeout: 120_000,
+}, () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-pipeline-dry-test-'));
+    try {
+        const output = join(scratch, 'output');
+        execFileSync(process.execPath, [RUNNER, 'dry-run', '--output', output], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            stdio: 'pipe',
+        });
+        assert.deepEqual(json(join(output, 'summary.json')), {
+            complete: true,
+            completed_cases: 4,
+            total_cases: 4,
+            remaining_cases: 0,
+            attempts: 5,
+            invalid_attempts: 1,
+            model_turns_started: 41,
+            model_turns_completed: 41,
+            usage: {
+                reported_turns: 41,
+                totals: {
+                    input_tokens: 4010,
+                    cached_input_tokens: 1100,
+                    output_tokens: 1003,
+                    reasoning_output_tokens: 200,
+                },
+            },
+        });
+        const results = readFileSync(join(output, 'private', 'results.jsonl'), 'utf8')
+            .trim().split('\n').map(JSON.parse);
+        assert.equal(results.length, 5);
+        assert.equal(results.filter((result) => !result.valid).length, 1);
+        assert.deepEqual(results[0].invalid_reasons, [
+            'shaped-direct: direct turn 1: final response is not JSON',
+        ]);
+        assert.equal(results[1].attempt, 2);
+        assert.ok(results.slice(1).every((result) => result.valid));
+        for (const result of results.slice(1)) {
+            assert.deepEqual(result.arms.map((arm) => arm.arm), [
+                'raw-direct', 'shaped-direct', 'full-cycle',
+            ]);
+            const shaped = result.arms.find((arm) => arm.arm === 'shaped-direct');
+            const cycle = result.arms.find((arm) => arm.arm === 'full-cycle');
+            assert.equal(shaped.input_sha256, result.shaped_issue_envelope_sha256);
+            assert.equal(cycle.input_sha256, result.shaped_issue_envelope_sha256);
+            assert.ok(result.shaped_issue_title_sha256);
+            assert.deepEqual(cycle.snapshots.map((snapshot) => snapshot.stage), [
+                'implement', 'review', 'patch', 'done',
+            ]);
+            const stages = cycle.lifecycle;
+            assert.deepEqual(stages.map((stage) => stage.stage), ['implement', 'review', 'patch', 'done']);
+            assert.equal(new Set(stages.map((stage) => stage.thread_id)).size, 1);
+            assert.equal(result.intake_issue_count, 1);
+        }
+        const scoring = readFileSync(join(output, 'scoring', 'scoring-input.json'), 'utf8');
+        assert.doesNotMatch(scoring, /raw-direct|shaped-direct|full-cycle/);
+        assert.doesNotMatch(scoring, /\/tmp\//);
+        assert.doesNotMatch(scoring, /\/home\//);
+        assert.equal(JSON.parse(scoring).packets.length, 4);
+        assert.equal(JSON.parse(scoring).packets.flatMap((packet) => packet.outputs).length, 12);
+        assert.match(readFileSync(join(output, 'private', 'blinding-map.json'), 'utf8'), /full-cycle/);
+        assertPrivateTree(output);
+
+        const completedResume = JSON.parse(execFileSync(process.execPath, [
+            RUNNER, 'dry-run-batch', '--output', output,
+        ], { cwd: ROOT, encoding: 'utf8', stdio: 'pipe' }));
+        assert.equal(completedResume.complete, true);
+        writeFileSync(join(output, 'scoring', 'scoring-input.json'), 'tampered\n');
+        chmodSync(join(output, 'scoring', 'scoring-input.json'), 0o600);
+        const tamperedScoring = spawnSync(process.execPath, [
+            RUNNER, 'dry-run-batch', '--output', output,
+        ], { cwd: ROOT, encoding: 'utf8', stdio: 'pipe' });
+        assert.equal(tamperedScoring.status, 2);
+        assert.match(tamperedScoring.stderr, /resumable artifact content changed/);
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});
+
+test('one-case batches resume an exact prefix and reject artifact tampering', { timeout: 120_000 }, () => {
+    const scratch = mkdtempSync(join(tmpdir(), 'cycle-pipeline-batch-test-'));
+    try {
+        const output = join(scratch, 'output');
+        const first = JSON.parse(execFileSync(process.execPath, [
+            RUNNER, 'dry-run-batch', '--output', output,
+        ], { cwd: ROOT, encoding: 'utf8', stdio: 'pipe' }));
+        assert.equal(first.completed_cases, 1);
+        assert.equal(first.remaining_cases, 3);
+        assert.equal(first.attempts, 2);
+
+        const escape = join(scratch, 'escape-target');
+        mkdirSync(escape);
+        symlinkSync(escape, join(output, 'private', 'escape'));
+        const symlinked = spawnSync(process.execPath, [RUNNER, 'dry-run-batch', '--output', output], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            stdio: 'pipe',
+        });
+        assert.equal(symlinked.status, 2);
+        assert.match(symlinked.stderr, /private artifact tree contains a special file/);
+        rmSync(join(output, 'private', 'escape'), { force: true });
+
+        const result = readFileSync(join(output, 'private', 'results.jsonl'), 'utf8')
+            .trim().split('\n').map(JSON.parse).at(-1);
+        const [artifact] = Object.keys(result.artifacts);
+        writeFileSync(join(output, artifact), 'tampered\n');
+        chmodSync(join(output, artifact), 0o600);
+        const resumed = spawnSync(process.execPath, [RUNNER, 'dry-run-batch', '--output', output], {
+            cwd: ROOT,
+            encoding: 'utf8',
+            stdio: 'pipe',
+        });
+        assert.equal(resumed.status, 2);
+        assert.match(resumed.stderr, /resumable artifact content changed/);
+        assert.equal(lstatSync(join(output, '.batch.lock'), { throwIfNoEntry: false }), undefined);
+    } finally {
+        rmSync(scratch, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
This freezes a four-case Songs I Know pilot that compares raw direct implementation, intake-shaped direct implementation, and the full intake-to-cycle workflow from identical shaped issue bytes.

What shipped:
- deterministic two-day census, seeded selection, reconstructed raw requests, canonical references, and scripted answers
- one-case quota-visible batching with exact resume, retry, lifecycle, usage, and private-artifact accounting
- isolated candidate repositories, stateless tracker and push doubles, separate hidden-oracle verifiers, and blinded per-output scoring artifacts
- model-free synthetic coverage plus the real base-fail, repair-pass, repair-removal-fail preflight

Review findings actioned:
- restored frozen package and Vitest controls before hidden verification
- made both shaped arms consume the exact intake title and body while removing shaped metadata from raw-direct
- rejected candidate Git control poisoning and symlinked resume trees before evaluator-side writes or Git inspection
- counted every tracker create marker, retained interrupted-case markers, validated completed scoring artifacts, and tightened repository-history checks
- changed the scoring contract so A, B, and C each receive their own outcome, process-quality ratings, and evidence note

Verification:
- node bin/cycle.mjs lint
- npm test: 329 passing
- node bin/cycle.mjs check
- real zero-model-call preflight: artifact lock, strict config, filesystem and network isolation, and all four mutation-proven hidden oracles passing

This change handles the Codex authentication boundary, so the PR intentionally retains the manual merge brake.

Closes #135

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)