### PR TITLE
fix(eval): separate pilot retry classes

### DIFF
--- a/eval/pipeline/fake-codex.cjs
+++ b/eval/pipeline/fake-codex.cjs
@@ -91,6 +91,11 @@ function finish(payload) {
 event({ type: 'thread.started', thread_id: threadId });
 event({ type: 'turn.started' });
 
+if (caseId === 'sik-133' && arm === 'intake' && attempt === 2 && turn === 1) {
+    console.error('synthetic infrastructure interruption');
+    process.exit(86);
+}
+
 if (caseId === 'sik-133' && arm === 'shaped-direct' && attempt === 1 && turn === 1) {
     event({ type: 'item.completed', item: { id: `item-${++item}`, type: 'agent_message', text: 'invalid fake response' } });
     event({ type: 'turn.completed', usage: { input_tokens: 10, output_tokens: 3 } });

--- a/eval/pipeline/protocol.json
+++ b/eval/pipeline/protocol.json
@@ -1,12 +1,13 @@
 {
   "version": 1,
-  "revision": 2,
+  "revision": 3,
   "study_id": "songsiknow-full-pipeline-pilot-v1",
-  "amends_protocol_sha256": "02ccaf466a7c6a51eca54843c3ecd873d4a47dc51ecf867bc276c75a20f1130d",
+  "amends_protocol_sha256": "cc25080c15a3207d744fec461c6fd2e996aaf2b48b5aa2847bdfdbc591019d25",
   "amendment": {
-    "reason": "Revision 1 produced zero valid cases because the evaluator made disposable Git metadata read-only and could not run the repository's required build without local tsx and Next.js subprocess IPC, Google Fonts network access, or synthetic deployment inputs. Revision 2 corrects only the hermetic execution and capture boundary plus its model-free preflight; prompts, cases, answers, arms, order, model, effort, scoring, and retry rules remain frozen.",
-    "completed_cases_before_amendment": 0,
-    "invalid_attempts_preserved": 2
+    "reason": "Revision 2 produced one valid case, then stopped after one behavioral invalid attempt and one infrastructure-interrupted retry exhausted a shared retry allowance. Revision 3 restarts all four cases from scratch, raises the predeclared per-turn ceiling from 15 to 30 minutes, gives behavioral invalidation and infrastructure interruption separate bounded retry allowances, and records the installed Codex CLI advancing from 0.150.1 to 0.151.0 before the revision-3 freeze. Revision 1 and 2 artifacts remain preserved and excluded; prompts, cases, answers, arms, order, model, effort, and scoring remain frozen.",
+    "completed_cases_before_amendment": 1,
+    "invalid_attempts_preserved": 4,
+    "restart_scope": "all four cases from scratch in a new revision-3 output directory"
   },
   "claim": "For short, underspecified coding requests, a frozen intake-to-cycle workflow can improve verified task completion, decision handling, regression coverage, scope control, and evidence quality relative to direct implementation prompts.",
   "census_path": "CENSUS.md",
@@ -65,15 +66,19 @@
     "case_order": ["sik-133", "sik-131", "sik-139", "sik-123"],
     "arms_per_case": 3,
     "cases_per_batch": 1,
-    "invalid_case_retry_limit": 1,
+    "retry_limits": {
+      "behavioral": 1,
+      "infrastructure": 1,
+      "max_attempts_per_case": 3
+    },
     "resume_rule": "Each invocation completes exactly one case across intake and all three arms. Resume only from an exact validated prefix. An active-case marker stops before any repeated model turn.",
-    "retry_rule": "Preserve every invalid attempt and retry the entire case once. If the retry is invalid, stop incomplete and do not score either attempt."
+    "retry_rule": "Preserve every invalid attempt. A behavioral invalidation and an infrastructure interruption each have one independent whole-case retry allowance, with three total attempts as a hard ceiling. Two invalid attempts of the same class or any invalid third attempt stop the experiment incomplete; no invalid attempt is scored."
   },
   "execution": {
     "model": "gpt-5.6-sol",
     "reasoning_effort": "high",
-    "codex_version": "codex-cli 0.150.1",
-    "timeout_ms_per_turn": 900000,
+    "codex_version": "codex-cli 0.151.0",
+    "timeout_ms_per_turn": 1800000,
     "fixture_commit_time": "2026-08-30T12:00:00Z",
     "subagents": false,
     "command_network": false,
@@ -161,12 +166,16 @@
     "credential_rule": "Codex authentication remains an outer-client symlink in a mode-0700 disposable home. It is never copied into a candidate, inherited by model-generated commands, or persisted before credential-fingerprint scanning."
   },
   "invalidation": {
-    "turn": [
-      "nonzero exit or timeout",
-      "malformed JSONL or missing turn.started or turn.completed",
-      "missing or schema-invalid final response",
-      "unmatched question or follow-up limit exceeded"
-    ],
+    "turn": {
+      "infrastructure": [
+        "Codex process failed to start, exited nonzero, received a signal, or exceeded the frozen timeout"
+      ],
+      "behavioral": [
+        "malformed JSONL or missing turn.started or turn.completed after a zero exit",
+        "missing or schema-invalid final response",
+        "unmatched question or follow-up limit exceeded"
+      ]
+    },
     "case": [
       "intake did not create exactly one issue",
       "shaped-direct and full-cycle did not receive byte-identical issue title and body text",
@@ -249,8 +258,8 @@
     }
   ],
   "artifact_lock": {
-    "runner_sha256": "7653cea4d431d90adea8b4af54c3271ca12ed34c775cfd38a93884c5ed8351fe",
-    "fake_codex_sha256": "e65f1997e33c6f4a7736a7f2181d87c7279712027d85276ddf1c0f3964723204",
+    "runner_sha256": "9c84e7764745c33e01540250319299f513177588181034854552ad17918cdf7e",
+    "fake_codex_sha256": "8a482b40588d8e83ccc9ca396433703d0b723a4fe705b46d3282ac960efd91c4",
     "fake_tracker_sha256": "348839290d85bff664edef0474cb148d5b1c46410cb7c3830c45c16c3bb97f97",
     "fake_git_sha256": "47ec70403d0bf70dd6624d28d2ec9809eac2353a3fbac91b126cd3f0f7929c4f",
     "tsx_no_ipc_sha256": "4e07da3ba22f976ff458a565ba89a9214fdb15a0c7894503c1334ffbfb668c9e",

--- a/eval/pipeline/run.mjs
+++ b/eval/pipeline/run.mjs
@@ -150,12 +150,13 @@ export function validateProtocol(protocol, { requireLock = true } = {}) {
     if (!protocol || typeof protocol !== 'object' || Array.isArray(protocol)) {
         fail('pipeline protocol must be an object');
     }
-    if (protocol.version !== 1 || protocol.revision !== 2
+    if (protocol.version !== 1 || protocol.revision !== 3
         || protocol.study_id !== 'songsiknow-full-pipeline-pilot-v1'
-        || protocol.amends_protocol_sha256 !== '02ccaf466a7c6a51eca54843c3ecd873d4a47dc51ecf867bc276c75a20f1130d'
+        || protocol.amends_protocol_sha256 !== 'cc25080c15a3207d744fec461c6fd2e996aaf2b48b5aa2847bdfdbc591019d25'
         || !isNonEmptyString(protocol.amendment?.reason)
-        || protocol.amendment?.completed_cases_before_amendment !== 0
-        || protocol.amendment?.invalid_attempts_preserved !== 2
+        || protocol.amendment?.completed_cases_before_amendment !== 1
+        || protocol.amendment?.invalid_attempts_preserved !== 4
+        || !isNonEmptyString(protocol.amendment?.restart_scope)
         || !isNonEmptyString(protocol.claim) || protocol.census_path !== 'CENSUS.md') {
         fail('pipeline protocol has an invalid identity');
     }
@@ -167,15 +168,18 @@ export function validateProtocol(protocol, { requireLock = true } = {}) {
     if (!schedule || schedule.seed !== 'songsiknow-full-pipeline-pilot-v1-2026-08-30'
         || stableJson(schedule.case_order) !== stableJson(['sik-133', 'sik-131', 'sik-139', 'sik-123'])
         || schedule.arms_per_case !== 3 || schedule.cases_per_batch !== 1
-        || schedule.invalid_case_retry_limit !== 1) {
+        || stableJson(schedule.retry_limits) !== stableJson({
+            behavioral: 1,
+            infrastructure: 1,
+            max_attempts_per_case: 3,
+        })) {
         fail('pipeline protocol has an invalid frozen schedule');
     }
     const execution = protocol.execution;
     if (!execution || execution.model !== 'gpt-5.6-sol'
         || execution.reasoning_effort !== 'high'
-        || execution.codex_version !== 'codex-cli 0.150.1'
-        || !Number.isSafeInteger(execution.timeout_ms_per_turn)
-        || execution.timeout_ms_per_turn < 1
+        || execution.codex_version !== 'codex-cli 0.151.0'
+        || execution.timeout_ms_per_turn !== 1_800_000
         || execution.subagents !== false || execution.command_network !== false
         || execution.preflight?.case_id !== 'sik-133'
         || execution.preflight?.required_gate !== 'npm run build'
@@ -1466,7 +1470,13 @@ function invokeTurn({
     if (finalText !== null) privateWrite(join(turnDir, 'final.json'), `${finalText}\n`);
     const structured = validateTurnText(finalText);
     const invalid = [];
-    if (processResult.status !== 0) invalid.push(`Codex exited ${processResult.status}`);
+    const timedOut = processResult.error?.code === 'ETIMEDOUT';
+    const infrastructureFailure = Boolean(processResult.error)
+        || (processResult.signal !== null && processResult.signal !== undefined)
+        || processResult.status !== 0;
+    if (timedOut) invalid.push(`Codex timed out after ${timeoutMs}ms`);
+    else if (processResult.error) invalid.push(`Codex process failed: ${processResult.error.code ?? 'unknown error'}`);
+    else if (processResult.status !== 0) invalid.push(`Codex exited ${processResult.status}`);
     if (parsed.invalid) invalid.push(parsed.invalid);
     const started = parsed.events.some((event) => event.type === 'turn.started');
     const completed = parsed.events.some((event) => event.type === 'turn.completed');
@@ -1487,6 +1497,12 @@ function invokeTurn({
         finished_at: finishedAt,
         elapsed_ms: processResult.elapsedMs,
         exit_code: processResult.status,
+        infrastructure_failure: infrastructureFailure,
+        termination: {
+            timed_out: timedOut,
+            signal: processResult.signal ?? null,
+            error_code: processResult.error?.code ?? null,
+        },
         model_turn_started: started,
         model_turn_completed: completed,
         usage: parsed.usage,
@@ -2006,6 +2022,8 @@ function lifecycleSummary(lifecycle) {
             finished_at: turn.finished_at,
             elapsed_ms: turn.elapsed_ms,
             exit_code: turn.exit_code,
+            infrastructure_failure: turn.infrastructure_failure,
+            termination: turn.termination,
             model_turn_started: turn.model_turn_started,
             model_turn_completed: turn.model_turn_completed,
             usage: turn.usage,
@@ -2020,6 +2038,29 @@ function lifecycleSummary(lifecycle) {
 function lifecycleInvalid(lifecycle) {
     return lifecycle.turns.flatMap((turn) => turn.invalid_reasons
         .map((reason) => `${lifecycle.stage} turn ${turn.turn}: ${reason}`));
+}
+
+export function classifyAttemptInvalidation({ valid, lifecycles }) {
+    if (valid) return null;
+    const turns = lifecycles.flatMap((lifecycle) => lifecycle.turns ?? []);
+    return turns.some((turn) => turn.infrastructure_failure) ? 'infrastructure' : 'behavioral';
+}
+
+export function retryDisposition(retryLimits, attempts) {
+    if (!Array.isArray(attempts) || attempts.length === 0) fail('retry disposition requires an attempt');
+    const latest = attempts.at(-1);
+    if (latest.valid) return 'accepted';
+    if (!['behavioral', 'infrastructure'].includes(latest.invalidation_class)) {
+        fail('invalid attempt is missing its invalidation class');
+    }
+    const failuresOfClass = attempts.filter(
+        (attempt) => !attempt.valid && attempt.invalidation_class === latest.invalidation_class,
+    ).length;
+    if (attempts.length >= retryLimits.max_attempts_per_case
+        || failuresOfClass > retryLimits[latest.invalidation_class]) {
+        return 'terminal';
+    }
+    return 'retry';
 }
 
 function recursiveFiles(root) {
@@ -2360,12 +2401,18 @@ function executeCaseAttempt({
             if (arms.length !== 3) invalid.push(`captured ${arms.length} arms instead of three`);
         }
 
+        const valid = invalid.length === 0;
+        const invalidationClass = classifyAttemptInvalidation({
+            valid,
+            lifecycles: attemptedLifecycles,
+        });
         const result = {
             study_id: protocol.study_id,
             case_id: item.id,
             case_index: caseIndex,
             attempt,
-            valid: invalid.length === 0,
+            valid,
+            invalidation_class: invalidationClass,
             invalid_reasons: invalid,
             model,
             reasoning_effort: effort,
@@ -2494,8 +2541,16 @@ function validatePersistedResult({ protocol, output, experiment, result, expecte
         if (result[key] !== value) fail(`resumable result identity mismatch: ${key}`);
     }
     if (typeof result.valid !== 'boolean' || !Array.isArray(result.invalid_reasons)
+        || !Array.isArray(result.lifecycle)
         || !result.artifacts || typeof result.artifacts !== 'object') {
         fail(`resumable result for ${expectedItem.id} has invalid status fields`);
+    }
+    if (result.valid !== (result.invalid_reasons.length === 0)
+        || result.invalidation_class !== classifyAttemptInvalidation({
+            valid: result.valid,
+            lifecycles: result.lifecycle ?? [],
+        })) {
+        fail(`resumable result for ${expectedItem.id} has inconsistent invalidation fields`);
     }
     const runName = `${String(expectedIndex).padStart(2, '0')}-${expectedItem.id}-a${expectedAttempt}`;
     const expectedPrefix = `private/runs/${runName}/`;
@@ -2521,47 +2576,51 @@ export function validateProgress({ protocol, output, experiment, results }) {
     let cursor = 0;
     let completedCases = 0;
     let terminalInvalidCase = null;
+    let pendingCase = null;
+    cases:
     for (let index = 0; index < protocol.cases.length; index += 1) {
         const item = protocol.cases[index];
         const caseIndex = index + 1;
         if (cursor === results.length) break;
-        const first = results[cursor];
-        validatePersistedResult({
-            protocol,
-            output,
-            experiment,
-            result: first,
-            expectedItem: item,
-            expectedIndex: caseIndex,
-            expectedAttempt: 1,
-        });
-        cursor += 1;
-        if (first.valid) {
-            completedCases += 1;
-            continue;
+        const attempts = [];
+        for (let attempt = 1; attempt <= protocol.schedule.retry_limits.max_attempts_per_case; attempt += 1) {
+            if (cursor === results.length) {
+                pendingCase = item;
+                break cases;
+            }
+            const result = results[cursor];
+            validatePersistedResult({
+                protocol,
+                output,
+                experiment,
+                result,
+                expectedItem: item,
+                expectedIndex: caseIndex,
+                expectedAttempt: attempt,
+            });
+            cursor += 1;
+            attempts.push(result);
+            const disposition = retryDisposition(protocol.schedule.retry_limits, attempts);
+            if (disposition === 'accepted') {
+                completedCases += 1;
+                continue cases;
+            }
+            if (disposition === 'terminal') {
+                terminalInvalidCase = item.id;
+                break cases;
+            }
+            if (cursor === results.length) {
+                pendingCase = item;
+                break cases;
+            }
         }
-        if (cursor === results.length) break;
-        const retry = results[cursor];
-        validatePersistedResult({
-            protocol,
-            output,
-            experiment,
-            result: retry,
-            expectedItem: item,
-            expectedIndex: caseIndex,
-            expectedAttempt: 2,
-        });
-        cursor += 1;
-        if (retry.valid) completedCases += 1;
-        else terminalInvalidCase = item.id;
-        if (terminalInvalidCase) break;
     }
     if (cursor !== results.length) fail('resumable results are not an exact prefix of the frozen schedule');
     return {
         completedCases,
         terminalInvalidCase,
         complete: completedCases === protocol.cases.length,
-        nextCase: terminalInvalidCase ? null : protocol.cases[completedCases] ?? null,
+        nextCase: terminalInvalidCase ? null : pendingCase ?? protocol.cases[completedCases] ?? null,
     };
 }
 
@@ -2714,13 +2773,20 @@ function validateScoringArtifacts(output) {
 function summarize(protocol, results) {
     const valid = acceptedResults(protocol, results);
     const allTurns = results.flatMap((result) => result.lifecycle.flatMap((stage) => stage.turns));
+    const invalidAttempts = results.filter((result) => !result.valid);
     return {
         complete: valid.size === protocol.cases.length,
         completed_cases: valid.size,
         total_cases: protocol.cases.length,
         remaining_cases: protocol.cases.length - valid.size,
         attempts: results.length,
-        invalid_attempts: results.filter((result) => !result.valid).length,
+        invalid_attempts: invalidAttempts.length,
+        invalid_attempts_by_class: {
+            behavioral: invalidAttempts.filter((result) => result.invalidation_class === 'behavioral').length,
+            infrastructure: invalidAttempts.filter(
+                (result) => result.invalidation_class === 'infrastructure',
+            ).length,
+        },
         model_turns_started: allTurns.filter((turn) => turn.model_turn_started).length,
         model_turns_completed: allTurns.filter((turn) => turn.model_turn_completed).length,
         usage: usageSum(allTurns),
@@ -2776,10 +2842,12 @@ function runExperiment({
         const item = progress.nextCase;
         const caseIndex = protocol.cases.findIndex((entry) => entry.id === item.id) + 1;
         privateWrite(active, `${JSON.stringify({ case_id: item.id, case_index: caseIndex, attempt: 1 }, null, 2)}\n`);
-        let accepted = false;
         let caseCheckpointed = false;
         try {
-            for (let attempt = 1; attempt <= protocol.schedule.invalid_case_retry_limit + 1; attempt += 1) {
+            const attempts = [];
+            for (let attempt = 1;
+                attempt <= protocol.schedule.retry_limits.max_attempts_per_case;
+                attempt += 1) {
                 privateWrite(active, `${JSON.stringify({ case_id: item.id, case_index: caseIndex, attempt }, null, 2)}\n`);
                 const result = executeCaseAttempt({
                     protocol,
@@ -2799,10 +2867,8 @@ function runExperiment({
                 });
                 appendResult(output, result);
                 results.push(result);
-                if (result.valid) {
-                    accepted = true;
-                    break;
-                }
+                attempts.push(result);
+                if (retryDisposition(protocol.schedule.retry_limits, attempts) !== 'retry') break;
             }
             caseCheckpointed = true;
         } finally {
@@ -2810,7 +2876,7 @@ function runExperiment({
         }
         processed += 1;
         progress = validateProgress({ protocol, output, experiment, results });
-        if (!accepted || progress.terminalInvalidCase) break;
+        if (progress.terminalInvalidCase) break;
     }
     const summary = summarize(protocol, results);
     privateWrite(join(output, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`);
@@ -2827,6 +2893,7 @@ function runExperiment({
         remaining_cases: summary.remaining_cases,
         attempts: summary.attempts,
         invalid_attempts: summary.invalid_attempts,
+        invalid_attempts_by_class: summary.invalid_attempts_by_class,
         model_turns_started: summary.model_turns_started,
         model_turns_completed: summary.model_turns_completed,
         reported_token_usage: summary.usage,
@@ -2851,7 +2918,7 @@ export function buildPlan(protocol) {
         },
         minimum_model_turns_per_valid_case: 7,
         maximum_model_turns_per_attempt: 28,
-        whole_case_retry_limit: protocol.schedule.invalid_case_retry_limit,
+        whole_case_retry_limits: protocol.schedule.retry_limits,
         scored_model_calls_in_setup_issue: 0,
     };
 }

--- a/test/pipeline-eval.test.mjs
+++ b/test/pipeline-eval.test.mjs
@@ -22,11 +22,13 @@ import {
     assertNoCredentialMaterial,
     buildPlan,
     candidateUntrackedPaths,
+    classifyAttemptInvalidation,
     clientEnvironment,
     loadProtocol,
     parseExecEvents,
     pipelineConfig,
     probePipelineConfig,
+    retryDisposition,
     sanitizeCandidateRepository,
     scriptedAnswer,
     sha256,
@@ -70,19 +72,24 @@ function assertPrivateTree(path) {
 test('pipeline protocol freezes the census, three arms, four cases, and local artifacts', () => {
     const { protocol } = loadProtocol(PROTOCOL_PATH);
     assert.deepEqual(protocol.schedule.case_order, ['sik-133', 'sik-131', 'sik-139', 'sik-123']);
-    assert.equal(protocol.revision, 2);
+    assert.equal(protocol.revision, 3);
     assert.equal(
         protocol.amends_protocol_sha256,
-        '02ccaf466a7c6a51eca54843c3ecd873d4a47dc51ecf867bc276c75a20f1130d',
+        'cc25080c15a3207d744fec461c6fd2e996aaf2b48b5aa2847bdfdbc591019d25',
     );
-    assert.equal(protocol.amendment.completed_cases_before_amendment, 0);
-    assert.equal(protocol.amendment.invalid_attempts_preserved, 2);
+    assert.equal(protocol.amendment.completed_cases_before_amendment, 1);
+    assert.equal(protocol.amendment.invalid_attempts_preserved, 4);
     assert.deepEqual(protocol.arms.map((arm) => arm.id), ['raw-direct', 'shaped-direct', 'full-cycle']);
     assert.equal(protocol.schedule.cases_per_batch, 1);
-    assert.equal(protocol.schedule.invalid_case_retry_limit, 1);
+    assert.deepEqual(protocol.schedule.retry_limits, {
+        behavioral: 1,
+        infrastructure: 1,
+        max_attempts_per_case: 3,
+    });
     assert.equal(protocol.execution.model, 'gpt-5.6-sol');
     assert.equal(protocol.execution.reasoning_effort, 'high');
-    assert.equal(protocol.execution.codex_version, 'codex-cli 0.150.1');
+    assert.equal(protocol.execution.codex_version, 'codex-cli 0.151.0');
+    assert.equal(protocol.execution.timeout_ms_per_turn, 1_800_000);
     assert.equal(protocol.execution.command_network, false);
     assert.equal(protocol.execution.subagents, false);
     assert.deepEqual(protocol.execution.preflight, {
@@ -92,6 +99,7 @@ test('pipeline protocol freezes the census, three arms, four cases, and local ar
     });
     assert.deepEqual(protocol.execution.full_cycle.resumed_stages, ['implement', 'review', 'patch', 'done']);
     assert.equal(buildPlan(protocol).minimum_model_turns_per_valid_case, 7);
+    assert.deepEqual(buildPlan(protocol).whole_case_retry_limits, protocol.schedule.retry_limits);
     const scoreSchema = json(join(PIPELINE_ROOT, protocol.scoring.schema_path));
     const scoreCase = scoreSchema.properties.cases.items.properties;
     assert.deepEqual(scoreCase.outcomes.required, ['A', 'B', 'C']);
@@ -297,6 +305,29 @@ test('turn parsing and frozen answer selection reject malformed lifecycle output
     ]);
 });
 
+test('attempt invalidation and retry accounting keep behavioral and infrastructure budgets separate', () => {
+    const limits = { behavioral: 1, infrastructure: 1, max_attempts_per_case: 3 };
+    const behavioral = { valid: false, invalidation_class: 'behavioral' };
+    const infrastructure = { valid: false, invalidation_class: 'infrastructure' };
+    const accepted = { valid: true, invalidation_class: null };
+
+    assert.equal(classifyAttemptInvalidation({
+        valid: false,
+        lifecycles: [{ turns: [{ infrastructure_failure: false }] }],
+    }), 'behavioral');
+    assert.equal(classifyAttemptInvalidation({
+        valid: false,
+        lifecycles: [{ turns: [{ infrastructure_failure: true }] }],
+    }), 'infrastructure');
+    assert.equal(classifyAttemptInvalidation({ valid: true, lifecycles: [] }), null);
+
+    assert.equal(retryDisposition(limits, [behavioral]), 'retry');
+    assert.equal(retryDisposition(limits, [behavioral, infrastructure]), 'retry');
+    assert.equal(retryDisposition(limits, [behavioral, infrastructure, accepted]), 'accepted');
+    assert.equal(retryDisposition(limits, [behavioral, behavioral]), 'terminal');
+    assert.equal(retryDisposition(limits, [infrastructure, infrastructure]), 'terminal');
+});
+
 test('fake Codex passes the strict model-free profile probe without authentication', () => {
     assert.deepEqual(probePipelineConfig(join(PIPELINE_ROOT, 'fake-codex.cjs')), {
         strict_config: 'pass',
@@ -358,7 +389,7 @@ test('candidate ignore edits cannot conceal new source files from evaluator capt
     }
 });
 
-test('model-free full pilot exercises follow-ups, retry, three arms, four resumed stages, and blinding', {
+test('model-free full pilot exercises class-separated retries, three arms, four resumed stages, and blinding', {
     timeout: 120_000,
 }, () => {
     const scratch = mkdtempSync(join(tmpdir(), 'cycle-pipeline-dry-test-'));
@@ -374,9 +405,13 @@ test('model-free full pilot exercises follow-ups, retry, three arms, four resume
             completed_cases: 4,
             total_cases: 4,
             remaining_cases: 0,
-            attempts: 5,
-            invalid_attempts: 1,
-            model_turns_started: 41,
+            attempts: 6,
+            invalid_attempts: 2,
+            invalid_attempts_by_class: {
+                behavioral: 1,
+                infrastructure: 1,
+            },
+            model_turns_started: 42,
             model_turns_completed: 41,
             usage: {
                 reported_turns: 41,
@@ -390,14 +425,25 @@ test('model-free full pilot exercises follow-ups, retry, three arms, four resume
         });
         const results = readFileSync(join(output, 'private', 'results.jsonl'), 'utf8')
             .trim().split('\n').map(JSON.parse);
-        assert.equal(results.length, 5);
-        assert.equal(results.filter((result) => !result.valid).length, 1);
+        assert.equal(results.length, 6);
+        assert.equal(results.filter((result) => !result.valid).length, 2);
         assert.deepEqual(results[0].invalid_reasons, [
             'shaped-direct: direct turn 1: final response is not JSON',
         ]);
+        assert.equal(results[0].invalidation_class, 'behavioral');
         assert.equal(results[1].attempt, 2);
-        assert.ok(results.slice(1).every((result) => result.valid));
-        for (const result of results.slice(1)) {
+        assert.equal(results[1].invalidation_class, 'infrastructure');
+        assert.deepEqual(results[1].invalid_reasons, [
+            'intake turn 1: Codex exited 86',
+            'intake turn 1: missing turn.completed',
+            'intake turn 1: missing final structured response',
+            'intake created 0 issues instead of exactly one',
+        ]);
+        assert.equal(results[2].attempt, 3);
+        assert.ok(results.slice(2).every(
+            (result) => result.valid && result.invalidation_class === null,
+        ));
+        for (const result of results.slice(2)) {
             assert.deepEqual(result.arms.map((arm) => arm.arm), [
                 'raw-direct', 'shaped-direct', 'full-cycle',
             ]);
@@ -448,7 +494,7 @@ test('one-case batches resume an exact prefix and reject artifact tampering', { 
         ], { cwd: ROOT, encoding: 'utf8', stdio: 'pipe' }));
         assert.equal(first.completed_cases, 1);
         assert.equal(first.remaining_cases, 3);
-        assert.equal(first.attempts, 2);
+        assert.equal(first.attempts, 3);
 
         const escape = join(scratch, 'escape-target');
         mkdirSync(escape);


### PR DESCRIPTION
## Summary

- amend the full-pipeline pilot to revision 3 while preserving and excluding revision 1 and 2 artifacts
- restart all four cases with separate one-retry budgets for behavioral invalidation and infrastructure interruption, plus a hard three-attempt ceiling
- raise the frozen per-turn ceiling to 30 minutes and record Codex CLI 0.151.0 before any revision-3 model call
- persist invalidation classes and transport termination evidence in resumable results
- exercise behavioral failure, infrastructure interruption, and third-attempt recovery through the full model-free pilot

## Review

Inline correctness, test-quality, and measurement-integrity review found no P0, P1, or P2 findings.

## Verification

- npm test — 332 passed
- node bin/cycle.mjs lint — pass
- node bin/cycle.mjs check — pass
- git diff --check — pass
- revision-3 model-free preflight — pass with zero model calls
- protocol SHA-256: 4b6292686119ddb26c7e078b88062045095e80b1710a08ed6841f8e4a1ce7eb3
- preflight SHA-256: 87536b3a2fa7f34d71a56353ed4f13ac92b23c267b2be0d8e3f83649ba6cb918

Closes #136

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)