### PR TITLE
fix(eval): initialize candidate verifier repository

### DIFF
--- a/docs/EVALUATION.md
+++ b/docs/EVALUATION.md
@@ -368,6 +368,8 @@ mounts no user home or `/etc`, mounts only the disposable fixture writable, and 
 the Node/pnpm runtime read-only. Candidate changes to package-manager, compiler, formatter, or test
 configuration are rejected before verification. This preserves the real Release Relay gate while
 avoiding both a false sandbox failure and an unsandboxed execution of model-authored source.
+The verifier commits the frozen base and control files as a one-root, no-remote repository before
+applying the candidate delta uncommitted; preflight runs its gate matrix through that same path.
 
 Preflight additionally proves the hidden oracle is red on the base, green on the historical and
 independent repairs, and red after repair removal; checks exact history, dependency, artifact, and

--- a/eval/model-lift/protocol.json
+++ b/eval/model-lift/protocol.json
@@ -186,7 +186,7 @@
   },
   "artifact_lock": {
     "shared_runner_sha256": "10fe07d84ee9373426a618687f4667de50686555ecab39eceb18af8a33aa2bfd",
-    "runner_sha256": "a02cb1172b7d3b2ebe0d636bee2d54398adb87b354e5692ea7f4f1f8793f9f34",
+    "runner_sha256": "55aba9e61ba6d5038b9386e874653cb1f4284708ce93d422c84f103171a9eebf",
     "fake_codex_sha256": "8a482b40588d8e83ccc9ca396433703d0b723a4fe705b46d3282ac960efd91c4",
     "fake_tracker_sha256": "aecb340a653b8176d74b5549523f00efede0a7ebf72512db6f5072018092d25a",
     "fake_git_sha256": "47ec70403d0bf70dd6624d28d2ec9809eac2353a3fbac91b126cd3f0f7929c4f",

--- a/eval/model-lift/run.mjs
+++ b/eval/model-lift/run.mjs
@@ -1014,12 +1014,13 @@ export function prepareVerifier({
     ));
     applyOfflinePackageManagerOverlay(destination, PNPM_RUNTIME_STORE);
     writeGuidance(destination, source, protocol);
+    writeControlAssets(destination, protocol, protocolPath);
+    initializeRepository(destination, protocol.execution.fixture_commit_time);
     if (candidate && fixture) copyCandidateDelta(candidate, fixture.initial_commit, destination);
     const oracleTarget = resolve(destination, protocol.task.oracle_destination);
     ensureInside(destination, oracleTarget);
     mkdirSync(dirname(oracleTarget), { recursive: true });
     writeFileSync(oracleTarget, readFileSync(protocolAsset(protocolPath, protocol.task.oracle_path)));
-    writeControlAssets(destination, protocol, protocolPath);
     cloneDependencies(dependencySource, destination);
     preparePnpmRuntime(destination, dependencyStore);
     return destination;
@@ -1592,7 +1593,7 @@ function preflight({
     let fixture;
     let gateMatrix;
     try {
-        const workspace = join(fixtureRoot, 'workspace');
+        const fixtureWorkspace = join(fixtureRoot, 'fixture');
         fixture = materializeFixture({
             protocol,
             protocolPath,
@@ -1600,8 +1601,17 @@ function preflight({
             dependencySource,
             dependencyStore,
             mode: 'pipeline',
-            destination: workspace,
+            destination: fixtureWorkspace,
             dryRun: false,
+        });
+        const workspace = join(fixtureRoot, 'verifier');
+        prepareVerifier({
+            protocol,
+            protocolPath,
+            source,
+            dependencySource,
+            dependencyStore,
+            destination: workspace,
         });
         const packageManager = verifierCommand({
             protocol,

--- a/test/model-lift-eval.test.mjs
+++ b/test/model-lift-eval.test.mjs
@@ -132,6 +132,24 @@ test('verifier sandbox unshares the network and mounts no user home', () => {
     }
 });
 
+test('candidate verifier initializes Git before applying an uncommitted candidate delta', () => {
+    const runner = readFileSync(RUNNER, 'utf8');
+    const body = runner.match(/export function prepareVerifier\([\s\S]+?\n}\n\nfunction executablePath/)?.[0];
+    assert.ok(body, 'prepareVerifier body must remain discoverable');
+    const control = body.indexOf('writeControlAssets(destination, protocol, protocolPath)');
+    const initialize = body.indexOf('initializeRepository(destination, protocol.execution.fixture_commit_time)');
+    const candidate = body.indexOf('copyCandidateDelta(candidate, fixture.initial_commit, destination)');
+    const oracle = body.indexOf('writeFileSync(oracleTarget');
+    assert.ok(control >= 0 && control < initialize, 'control assets must be frozen into the verifier root');
+    assert.ok(initialize < candidate, 'candidate delta must remain uncommitted');
+    assert.ok(candidate < oracle, 'the evaluator-owned oracle must overwrite any candidate path');
+
+    const preflight = runner.match(/function preflight\([\s\S]+?\n}\n\nfunction resultIndexPath/)?.[0];
+    assert.ok(preflight, 'preflight body must remain discoverable');
+    assert.match(preflight, /prepareVerifier\([\s\S]+?candidate_matrix/,
+        'preflight gates must exercise the final verifier constructor');
+});
+
 test('model-free batches resume an exact model prefix and produce a private blinded packet', {
     timeout: 120_000,
 }, () => {


### PR DESCRIPTION
## Summary

- initialize every final candidate verifier as a frozen one-root, no-remote Git repository before applying the candidate delta uncommitted
- keep evaluator control files in the frozen commit and write the hidden oracle after the candidate delta
- run preflight's required gate matrix through the exact final-verifier constructor instead of a different fixture path
- add regression coverage and document the invariant

## Why

The first blinded reveal showed all six candidates passing the behavior-only oracle but failing pnpm check identically. The failure was evaluator-owned: Release Relay's coverage-oracle test correctly rejected the final verifier because it had no .git repository. The original model outputs and locked scores remain preserved as superseded evidence.

## Verification

- node bin/cycle.mjs lint
- npm test (341/341)
- node bin/cycle.mjs check
- focused evaluator tests (14/14)
- repaired zero-model-call preflight: all four oracle controls correct, pnpm check green, pnpm build green

Closes #143

🤖 Generated with [Codex CLI](https://developers.openai.com/codex/cli)
